### PR TITLE
Explicitly list supported browsers in .browserslistrc instead of…

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+# Browsers that we support
+last 1 Android versions
+last 1 iOS versions
+last 1 Chrome versions
+last 1 Edge versions
+last 1 Firefox versions
+last 1 Safari versions

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "nps",
     "format": "nps format",
+    "build": "nps build",
     "test": "nps test",
     "precommit": "ban",
     "prepush": "nps lint",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -79,7 +79,8 @@ const nodeConfig = input => ({
             modules: false,
             targets: {
               node: 'current'
-            }
+            },
+            ignoreBrowserslistConfig: true
           }
         ]
       ],
@@ -109,10 +110,7 @@ const browserifyConfig = input => ({
         [
           'env',
           {
-            modules: false,
-            targets: {
-              browsers: 'last 1 version'
-            }
+            modules: false
           }
         ]
       ],
@@ -146,7 +144,8 @@ const serviceworkerConfig = input => ({
             modules: false,
             targets: {
               browsers: 'Chrome 62'
-            }
+            },
+            ignoreBrowserslistConfig: true
           }
         ]
       ],


### PR DESCRIPTION
…relying on 'last 1 version' in rollup.config.js