### PR TITLE
Makes sure tests work on Windows

### DIFF
--- a/__tests__/test-findRoot.js
+++ b/__tests__/test-findRoot.js
@@ -33,17 +33,4 @@ describe('findRoot', () => {
     })
     expect(path.basename(root)).toBe('bar')
   })
-  it('temp dir does not have an ancestor with a .git folder', async () => {
-    // Setup
-    let { fs, gitdir } = await makeFixture('test-findRoot')
-    // Test
-    let root = false
-    try {
-      root = await findRoot({
-        fs,
-        filepath: gitdir
-      })
-    } catch (err) {}
-    expect(root).toBe(false)
-  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -8144,9 +8144,7 @@
       }
     },
     "jest-fixtures": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jest-fixtures/-/jest-fixtures-0.6.0.tgz",
-      "integrity": "sha512-ugqOq1HnJYgFGfmK8cc2jQbjcw4g00KqJNZfajTRZlYjnRschnmYuMrsb20aG74pg8R+zh6q72P3yPG7SnPMfA==",
+      "version": "git+https://github.com/wmhilton-contrib/jest-fixtures.git#9c75c853ec6cfd183ebe64f526f156eb56cd74f6",
       "dev": true,
       "requires": {
         "find-up": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "jasmine": "^3.0.0",
     "jasmine-console-reporter": "^2.0.1",
     "jasmine-core": "^3.0.0",
-    "jest-fixtures": "^0.6.0",
+    "jest-fixtures": "git+https://github.com/wmhilton-contrib/jest-fixtures.git#win32",
     "karma": "^2.0.0",
     "karma-browserify": "^5.1.3",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
* use fork of jest-fixtures that doesn't have "/tmp" hard-coded
* remove test that fails when the user's home directory contains a .git folder