### PR TITLE
is-buffer working in node 10.0.0 fixes #155

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
   email: false
 node_js:
   - '9'
+  - '10'
 before_script:
   - chmod ugo+x __tests__/__fixtures__/test-push-server.git/hooks/update
   - chmod ugo+x __tests__/__fixtures__/test-push-server.git/hooks/post-receive

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "git-apply-delta": "0.0.7",
     "git-list-pack": "0.0.10",
     "ignore": "^3.3.7",
+    "is-buffer": "^2.0.2",
     "lodash.sortby": "^4.7.0",
     "marky": "^1.2.0",
     "minimisted": "^2.0.0",

--- a/src/models/GitCommit.js
+++ b/src/models/GitCommit.js
@@ -1,5 +1,6 @@
 // @flow
 import { Buffer } from 'buffer'
+import isBuffer from 'is-buffer'
 
 function formatTimezoneOffset (minutes /*: number */) {
   let sign = Math.sign(minutes) || 1
@@ -68,7 +69,7 @@ export class GitCommit {
   constructor (commit /*: string|Buffer|Object */) {
     if (typeof commit === 'string') {
       this._commit = commit
-    } else if (Buffer.isBuffer(commit)) {
+    } else if (isBuffer(commit)) {
       this._commit = commit.toString('utf8')
     } else if (typeof commit === 'object') {
       this._commit = GitCommit.render(commit)

--- a/src/models/GitIndex.js
+++ b/src/models/GitIndex.js
@@ -118,7 +118,7 @@ export class GitIndex {
   constructor (index /*: any */) {
     this._dirty = false
     if (isBuffer(index)) {
-      this._entries = parseBuffer(buffer.Buffer(index))
+      this._entries = parseBuffer(Buffer(index))
     } else if (index === null) {
       this._entries = new Map()
     } else {

--- a/src/models/GitIndex.js
+++ b/src/models/GitIndex.js
@@ -3,6 +3,7 @@ import { Buffer } from 'buffer'
 import BufferCursor from 'buffercursor'
 import sortby from 'lodash.sortby'
 import shasum from 'shasum'
+import isBuffer from 'is-buffer'
 
 const MAX_UINT32 = 2 ** 32
 /*::
@@ -116,8 +117,8 @@ export class GitIndex {
    */
   constructor (index /*: any */) {
     this._dirty = false
-    if (Buffer.isBuffer(index)) {
-      this._entries = parseBuffer(index)
+    if (isBuffer(index)) {
+      this._entries = parseBuffer(buffer.Buffer(index))
     } else if (index === null) {
       this._entries = new Map()
     } else {

--- a/src/models/GitTree.js
+++ b/src/models/GitTree.js
@@ -1,5 +1,6 @@
 // @flow
 import { Buffer } from 'buffer'
+import isBuffer from 'is-buffer'
 
 /*::
 type TreeEntry = {
@@ -67,8 +68,8 @@ export class GitTree {
   _entries: Array<TreeEntry>
   */
   constructor (entries /*: any */) {
-    if (Buffer.isBuffer(entries)) {
-      this._entries = parseBuffer(entries)
+    if (isBuffer(entries)) {
+      this._entries = parseBuffer(buffer.Buffer(entries))
     } else if (Array.isArray(entries)) {
       this._entries = entries.map(nudgeIntoShape)
     } else {

--- a/src/models/GitTree.js
+++ b/src/models/GitTree.js
@@ -69,7 +69,7 @@ export class GitTree {
   */
   constructor (entries /*: any */) {
     if (isBuffer(entries)) {
-      this._entries = parseBuffer(buffer.Buffer(entries))
+      this._entries = parseBuffer(Buffer(entries))
     } else if (Array.isArray(entries)) {
       this._entries = entries.map(nudgeIntoShape)
     } else {


### PR DESCRIPTION
There appears to be a superficial difference between two types of buffers being used which caused `isBuffer()` to give false negatives, and also for `parseBuffer` to fail the checksum test.

Honestly I don't fully understand the problem, but it used to fail in node v10.0.0 as per #155 but this patch makes it work.