### PR TITLE
fix: Attach API function name to error.caller (fix #212)

### DIFF
--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -18,4 +18,17 @@ describe('add', () => {
     await add({ fs, dir, filepath: 'b.txt' })
     expect((await listFiles({ fs, dir })).length === 3).toBe(true)
   })
+  it('non-existant file', async () => {
+    // Setup
+    let { fs, dir } = await makeFixture('test-add')
+    // Test
+    await init({ fs, dir })
+    let err = null
+    try {
+      await add({ fs, dir, filepath: 'asdf.txt' })
+    } catch (e) {
+      err = e
+    }
+    expect(err.caller).toEqual('git.add')
+  })
 })

--- a/__tests__/test-branch.js
+++ b/__tests__/test-branch.js
@@ -29,11 +29,12 @@ describe('branch', () => {
     try {
       await branch({ fs, dir, gitdir, ref: 'inv@{id..branch.lock' })
     } catch (err) {
-      error = err.message
+      error = err
     }
-    expect(error).toEqual(
+    expect(error.message).toEqual(
       `Failed to create branch 'inv@{id..branch.lock' because that name would not be a valid git reference. A valid alternative would be 'inv-id.branch'.`
     )
+    expect(error.caller).toEqual('git.branch')
   })
 
   it('missing ref argument', async () => {
@@ -44,9 +45,10 @@ describe('branch', () => {
     try {
       await branch({ fs, dir, gitdir })
     } catch (err) {
-      error = err.message
+      error = err
     }
-    expect(error).toEqual('Cannot create branch "undefined"')
+    expect(error.message).toEqual('Cannot create branch "undefined"')
+    expect(error.caller).toEqual('git.branch')
   })
 
   it('empty repo', async () => {
@@ -58,10 +60,11 @@ describe('branch', () => {
     try {
       await branch({ fs, dir, gitdir, ref: 'test-branch' })
     } catch (err) {
-      error = err.message
+      error = err
     }
-    expect(error).toEqual(
+    expect(error.message).toEqual(
       `Failed to create branch 'test-branch' because there are no commits in this project.`
     )
+    expect(error.caller).toEqual('git.branch')
   })
 })

--- a/__tests__/test-checkout.js
+++ b/__tests__/test-checkout.js
@@ -39,11 +39,14 @@ describe('checkout', () => {
   it('checkout unfetched branch', async () => {
     // Setup
     let { fs, dir, gitdir } = await makeFixture('test-checkout')
+    let error = null
     try {
       await checkout({ fs, dir, gitdir, ref: 'missing-branch' })
       throw new Error('Checkout should have failed.')
     } catch (err) {
-      expect(err.message).toMatchSnapshot()
+      error = err
     }
+    expect(error.message).toMatchSnapshot()
+    expect(error.caller).toEqual('git.checkout')
   })
 })

--- a/__tests__/test-clone.js
+++ b/__tests__/test-clone.js
@@ -84,11 +84,12 @@ describe('clone', () => {
         url
       })
     } catch (err) {
-      error = err.message
+      error = err
     }
-    expect(error).toEqual(
+    expect(error.message).toEqual(
       `Git remote "${url}" uses an unrecognized transport protocol: "foobar"`
     )
+    expect(error.caller).toEqual('git.clone')
   })
   // For now we are only running this in the browser, because the karma middleware solution only
   // works when running in Karma, and these tests also need to pass Jest and node-jasmine.

--- a/__tests__/test-commit.js
+++ b/__tests__/test-commit.js
@@ -25,7 +25,7 @@ describe('commit', () => {
     // Setup
     let { fs, gitdir } = await makeFixture('test-commit')
     // Test
-    let error = null
+    let error = {}
     try {
       await commit({
         fs,
@@ -38,13 +38,14 @@ describe('commit', () => {
         message: 'Initial commit'
       })
     } catch (err) {
-      error = err.message
+      error = err
     }
-    expect(error).toBe(
+    expect(error.message).toBe(
       'Author name and email must be specified as an argument or in the .git/config file'
     )
+    expect(error.caller).toEqual('git.commit')
     // reset for test 2
-    error = null
+    error = {}
     try {
       await commit({
         fs,
@@ -57,11 +58,12 @@ describe('commit', () => {
         message: 'Initial commit'
       })
     } catch (err) {
-      error = err.message
+      error = err
     }
-    expect(error).toBe(
+    expect(error.message).toBe(
       'Author name and email must be specified as an argument or in the .git/config file'
     )
+    expect(error.caller).toEqual('git.commit')
   })
 
   it('GPG signing', async () => {

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -151,5 +151,6 @@ describe('fetch', () => {
     }
     expect(err).toBeDefined()
     expect(err.message).toMatchSnapshot()
+    expect(err.caller).toEqual('git.fetch')
   })
 })

--- a/__tests__/test-resolveRef.js
+++ b/__tests__/test-resolveRef.js
@@ -75,4 +75,21 @@ describe('resolveRef', () => {
     })
     expect(ref).toMatchSnapshot()
   })
+  it('non-existant refs', async () => {
+    // Setup
+    let { fs, gitdir } = await makeFixture('test-resolveRef')
+    // Test
+    let error = {}
+    try {
+      await resolveRef({
+        fs,
+        gitdir,
+        ref: 'this-is-not-a-ref'
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error.message).toBeDefined()
+    expect(error.caller).toEqual('git.resolveRef')
+  })
 })

--- a/src/commands/branch.js
+++ b/src/commands/branch.js
@@ -15,34 +15,39 @@ export async function branch ({
   fs: _fs,
   ref
 }) {
-  const fs = new FileSystem(_fs)
-  if (ref === undefined) {
-    throw new Error('Cannot create branch "undefined"')
-  }
-
-  if (ref !== clean(ref)) {
-    throw new Error(
-      `Failed to create branch '${ref}' because that name would not be a valid git reference. A valid alternative would be '${clean(
-        ref
-      )}'.`
-    )
-  }
-
-  const exist = await fs.exists(`${gitdir}/refs/heads/${ref}`)
-  if (exist) {
-    throw new Error(
-      `Failed to create branch '${ref}' because branch '${ref}' already exists.`
-    )
-  }
-  // Get tree oid
-  let oid
   try {
-    oid = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
-  } catch (e) {
-    throw new Error(
-      `Failed to create branch '${ref}' because there are no commits in this project.`
-    )
+    const fs = new FileSystem(_fs)
+    if (ref === undefined) {
+      throw new Error('Cannot create branch "undefined"')
+    }
+
+    if (ref !== clean(ref)) {
+      throw new Error(
+        `Failed to create branch '${ref}' because that name would not be a valid git reference. A valid alternative would be '${clean(
+          ref
+        )}'.`
+      )
+    }
+
+    const exist = await fs.exists(`${gitdir}/refs/heads/${ref}`)
+    if (exist) {
+      throw new Error(
+        `Failed to create branch '${ref}' because branch '${ref}' already exists.`
+      )
+    }
+    // Get tree oid
+    let oid
+    try {
+      oid = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
+    } catch (e) {
+      throw new Error(
+        `Failed to create branch '${ref}' because there are no commits in this project.`
+      )
+    }
+    // Create a new branch that points at that same commit
+    await fs.write(`${gitdir}/refs/heads/${ref}`, oid + '\n')
+  } catch (err) {
+    err.caller = 'git.branch'
+    throw err
   }
-  // Create a new branch that points at that same commit
-  await fs.write(`${gitdir}/refs/heads/${ref}`, oid + '\n')
 }

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -17,78 +17,83 @@ export async function checkout ({
   remote = 'origin',
   ref
 }) {
-  const fs = new FileSystem(_fs)
-  if (ref === undefined) {
-    throw new Error('Cannot checkout ref "undefined"')
-  }
-  // Get tree oid
-  let oid
   try {
-    oid = await GitRefManager.resolve({ fs, gitdir, ref })
-    // TODO: Figure out what to do if both 'ref' and 'remote' are specified, ref already exists,
-    // and is configured to track a different remote.
-  } catch (err) {
-    // If `ref` doesn't exist, create a new remote tracking branch
-    // Figure out the commit to checkout
-    let remoteRef = `${remote}/${ref}`
-    oid = await GitRefManager.resolve({
-      fs,
-      gitdir,
-      ref: remoteRef
-    })
-    // Set up remote tracking branch
-    await config({
-      gitdir,
-      fs,
-      path: `branch.${ref}.remote`,
-      value: `${remote}`
-    })
-    await config({
-      gitdir,
-      fs,
-      path: `branch.${ref}.merge`,
-      value: `refs/heads/${ref}`
-    })
-    // Create a new branch that points at that same commit
-    await fs.write(`${gitdir}/refs/heads/${ref}`, oid + '\n')
-  }
-  let commit = {}
-  try {
-    commit = await GitObjectManager.read({ fs, gitdir, oid })
-  } catch (err) {
-    throw new Error(
-      `Failed to checkout ref '${ref}' because commit ${oid} is not available locally. Do a git fetch to make the branch available locally.`
-    )
-  }
-  if (commit.type !== 'commit') {
-    throw new Error(`Unexpected type: ${commit.type}`)
-  }
-  let comm = GitCommit.from(commit.object.toString('utf8'))
-  let sha = comm.headers().tree
-  // Get top-level tree
-  let { type, object } = await GitObjectManager.read({ fs, gitdir, oid: sha })
-  if (type !== 'tree') throw new Error(`Unexpected type: ${type}`)
-  let tree = GitTree.from(object)
-  // Acquire a lock on the index
-  await GitIndexManager.acquire(
-    { fs, filepath: `${gitdir}/index` },
-    async function (index) {
-      // TODO: Big optimization possible here.
-      // Instead of deleting and rewriting everything, only delete files
-      // that are not present in the new branch, and only write files that
-      // are not in the index or are in the index but have the wrong SHA.
-      for (let entry of index) {
-        try {
-          await fs.rm(path.join(dir, entry.path))
-        } catch (err) {}
-      }
-      index.clear()
-      // Write files. TODO: Write them atomically
-      await writeTreeToDisk({ fs, gitdir, dir, index, prefix: '', tree })
-      // Update HEAD TODO: Handle non-branch cases
-      await fs.write(`${gitdir}/HEAD`, `ref: refs/heads/${ref}`)
+    const fs = new FileSystem(_fs)
+    if (ref === undefined) {
+      throw new Error('Cannot checkout ref "undefined"')
     }
-  )
+    // Get tree oid
+    let oid
+    try {
+      oid = await GitRefManager.resolve({ fs, gitdir, ref })
+      // TODO: Figure out what to do if both 'ref' and 'remote' are specified, ref already exists,
+      // and is configured to track a different remote.
+    } catch (err) {
+      // If `ref` doesn't exist, create a new remote tracking branch
+      // Figure out the commit to checkout
+      let remoteRef = `${remote}/${ref}`
+      oid = await GitRefManager.resolve({
+        fs,
+        gitdir,
+        ref: remoteRef
+      })
+      // Set up remote tracking branch
+      await config({
+        gitdir,
+        fs,
+        path: `branch.${ref}.remote`,
+        value: `${remote}`
+      })
+      await config({
+        gitdir,
+        fs,
+        path: `branch.${ref}.merge`,
+        value: `refs/heads/${ref}`
+      })
+      // Create a new branch that points at that same commit
+      await fs.write(`${gitdir}/refs/heads/${ref}`, oid + '\n')
+    }
+    let commit = {}
+    try {
+      commit = await GitObjectManager.read({ fs, gitdir, oid })
+    } catch (err) {
+      throw new Error(
+        `Failed to checkout ref '${ref}' because commit ${oid} is not available locally. Do a git fetch to make the branch available locally.`
+      )
+    }
+    if (commit.type !== 'commit') {
+      throw new Error(`Unexpected type: ${commit.type}`)
+    }
+    let comm = GitCommit.from(commit.object.toString('utf8'))
+    let sha = comm.headers().tree
+    // Get top-level tree
+    let { type, object } = await GitObjectManager.read({ fs, gitdir, oid: sha })
+    if (type !== 'tree') throw new Error(`Unexpected type: ${type}`)
+    let tree = GitTree.from(object)
+    // Acquire a lock on the index
+    await GitIndexManager.acquire(
+      { fs, filepath: `${gitdir}/index` },
+      async function (index) {
+        // TODO: Big optimization possible here.
+        // Instead of deleting and rewriting everything, only delete files
+        // that are not present in the new branch, and only write files that
+        // are not in the index or are in the index but have the wrong SHA.
+        for (let entry of index) {
+          try {
+            await fs.rm(path.join(dir, entry.path))
+          } catch (err) {}
+        }
+        index.clear()
+        // Write files. TODO: Write them atomically
+        await writeTreeToDisk({ fs, gitdir, dir, index, prefix: '', tree })
+        // Update HEAD TODO: Handle non-branch cases
+        await fs.write(`${gitdir}/HEAD`, `ref: refs/heads/${ref}`)
+      }
+    )
+  } catch (err) {
+    err.caller = 'git.checkout'
+    throw err
+  }
 }
 
 async function writeTreeToDisk ({ fs: _fs, dir, gitdir, index, prefix, tree }) {

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -30,53 +30,58 @@ export async function clone ({
   noCheckout = false,
   onprogress
 }) {
-  if (onprogress !== undefined) {
-    console.warn(
-      'The `onprogress` callback has been deprecated. Please use the more generic `emitter` EventEmitter argument instead.'
-    )
-  }
-  const fs = new FileSystem(_fs)
-  remote = remote || 'origin'
-  await init({ gitdir, fs })
-  // Add remote
-  await config({
-    gitdir,
-    fs,
-    path: `remote.${remote}.url`,
-    value: url
-  })
-  await config({
-    gitdir,
-    fs,
-    path: `remote.${remote}.fetch`,
-    value: `+refs/heads/*:refs/remotes/${remote}/*`
-  })
-  // Fetch commits
-  let { defaultBranch } = await fetch({
-    gitdir,
-    fs,
-    emitter,
-    ref,
-    remote,
-    authUsername,
-    authPassword,
-    depth,
-    since,
-    exclude,
-    relative,
-    singleBranch,
-    tags: true
-  })
-  ref = ref || defaultBranch
-  ref = ref.replace('refs/heads/', '')
-  // Checkout that branch
-  if (!noCheckout) {
-    await checkout({
-      dir,
+  try {
+    if (onprogress !== undefined) {
+      console.warn(
+        'The `onprogress` callback has been deprecated. Please use the more generic `emitter` EventEmitter argument instead.'
+      )
+    }
+    const fs = new FileSystem(_fs)
+    remote = remote || 'origin'
+    await init({ gitdir, fs })
+    // Add remote
+    await config({
       gitdir,
       fs,
-      ref,
-      remote
+      path: `remote.${remote}.url`,
+      value: url
     })
+    await config({
+      gitdir,
+      fs,
+      path: `remote.${remote}.fetch`,
+      value: `+refs/heads/*:refs/remotes/${remote}/*`
+    })
+    // Fetch commits
+    let { defaultBranch } = await fetch({
+      gitdir,
+      fs,
+      emitter,
+      ref,
+      remote,
+      authUsername,
+      authPassword,
+      depth,
+      since,
+      exclude,
+      relative,
+      singleBranch,
+      tags: true
+    })
+    ref = ref || defaultBranch
+    ref = ref.replace('refs/heads/', '')
+    // Checkout that branch
+    if (!noCheckout) {
+      await checkout({
+        dir,
+        gitdir,
+        fs,
+        ref,
+        remote
+      })
+    }
+  } catch (err) {
+    err.caller = 'git.clone'
+    throw err
   }
 }

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -19,85 +19,90 @@ export async function commit ({
   author,
   committer
 }) {
-  const fs = new FileSystem(_fs)
-  // Fill in missing arguments with default values
-  if (author === undefined) author = {}
-  if (author.name === undefined) {
-    author.name = await config({ fs, gitdir, path: 'user.name' })
-  }
-  if (author.email === undefined) {
-    author.email = await config({ fs, gitdir, path: 'user.email' })
-  }
-  if (author.name === undefined || author.email === undefined) {
-    throw new Error(
-      'Author name and email must be specified as an argument or in the .git/config file'
-    )
-  }
-  committer = committer || author
-  let authorDateTime = author.date || new Date()
-  let committerDateTime = committer.date || authorDateTime
-  let oid
-  await GitIndexManager.acquire(
-    { fs, filepath: `${gitdir}/index` },
-    async function (index) {
-      const inode = flatFileListToDirectoryStructure(index.entries)
-      const treeRef = await constructTree({ fs, gitdir, inode })
-      let parents
-      try {
-        let parent = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
-        parents = [parent]
-      } catch (err) {
-        // Probably an initial commit
-        parents = []
-      }
-      let comm = GitCommit.from({
-        tree: treeRef,
-        parent: parents,
-        author: {
-          name: author.name,
-          email: author.email,
-          timestamp:
-            author.timestamp !== undefined && author.timestamp !== null
-              ? author.timestamp
-              : Math.floor(authorDateTime.valueOf() / 1000),
-          timezoneOffset:
-            author.timezoneOffset !== undefined &&
-            author.timezoneOffset !== null
-              ? author.timezoneOffset
-              : new Date().getTimezoneOffset()
-        },
-        committer: {
-          name: committer.name,
-          email: committer.email,
-          timestamp:
-            committer.timestamp !== undefined && committer.timestamp !== null
-              ? committer.timestamp
-              : Math.floor(committerDateTime.valueOf() / 1000),
-          timezoneOffset:
-            committer.timezoneOffset !== undefined &&
-            committer.timezoneOffset !== null
-              ? committer.timezoneOffset
-              : new Date().getTimezoneOffset()
-        },
-        message
-      })
-      oid = await GitObjectManager.write({
-        fs,
-        gitdir,
-        type: 'commit',
-        object: comm.toObject()
-      })
-      // Update branch pointer
-      const branch = await GitRefManager.resolve({
-        fs,
-        gitdir,
-        ref: 'HEAD',
-        depth: 2
-      })
-      await fs.write(path.join(gitdir, branch), oid + '\n')
+  try {
+    const fs = new FileSystem(_fs)
+    // Fill in missing arguments with default values
+    if (author === undefined) author = {}
+    if (author.name === undefined) {
+      author.name = await config({ fs, gitdir, path: 'user.name' })
     }
-  )
-  return oid
+    if (author.email === undefined) {
+      author.email = await config({ fs, gitdir, path: 'user.email' })
+    }
+    if (author.name === undefined || author.email === undefined) {
+      throw new Error(
+        'Author name and email must be specified as an argument or in the .git/config file'
+      )
+    }
+    committer = committer || author
+    let authorDateTime = author.date || new Date()
+    let committerDateTime = committer.date || authorDateTime
+    let oid
+    await GitIndexManager.acquire(
+      { fs, filepath: `${gitdir}/index` },
+      async function (index) {
+        const inode = flatFileListToDirectoryStructure(index.entries)
+        const treeRef = await constructTree({ fs, gitdir, inode })
+        let parents
+        try {
+          let parent = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
+          parents = [parent]
+        } catch (err) {
+          // Probably an initial commit
+          parents = []
+        }
+        let comm = GitCommit.from({
+          tree: treeRef,
+          parent: parents,
+          author: {
+            name: author.name,
+            email: author.email,
+            timestamp:
+              author.timestamp !== undefined && author.timestamp !== null
+                ? author.timestamp
+                : Math.floor(authorDateTime.valueOf() / 1000),
+            timezoneOffset:
+              author.timezoneOffset !== undefined &&
+              author.timezoneOffset !== null
+                ? author.timezoneOffset
+                : new Date().getTimezoneOffset()
+          },
+          committer: {
+            name: committer.name,
+            email: committer.email,
+            timestamp:
+              committer.timestamp !== undefined && committer.timestamp !== null
+                ? committer.timestamp
+                : Math.floor(committerDateTime.valueOf() / 1000),
+            timezoneOffset:
+              committer.timezoneOffset !== undefined &&
+              committer.timezoneOffset !== null
+                ? committer.timezoneOffset
+                : new Date().getTimezoneOffset()
+          },
+          message
+        })
+        oid = await GitObjectManager.write({
+          fs,
+          gitdir,
+          type: 'commit',
+          object: comm.toObject()
+        })
+        // Update branch pointer
+        const branch = await GitRefManager.resolve({
+          fs,
+          gitdir,
+          ref: 'HEAD',
+          depth: 2
+        })
+        await fs.write(path.join(gitdir, branch), oid + '\n')
+      }
+    )
+    return oid
+  } catch (err) {
+    err.caller = 'git.commit'
+    throw err
+  }
 }
 
 async function constructTree ({ fs, gitdir, inode }) {

--- a/src/commands/currentBranch.js
+++ b/src/commands/currentBranch.js
@@ -33,13 +33,18 @@ export async function currentBranch ({
   fs: _fs,
   fullname = false
 }) {
-  const fs = new FileSystem(_fs)
-  let ref = await GitRefManager.resolve({
-    fs,
-    gitdir,
-    ref: 'HEAD',
-    depth: 2
-  })
-  if (fullname) return ref
-  return abbreviate(ref)
+  try {
+    const fs = new FileSystem(_fs)
+    let ref = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: 'HEAD',
+      depth: 2
+    })
+    if (fullname) return ref
+    return abbreviate(ref)
+  } catch (err) {
+    err.caller = 'git.currentBranch'
+    throw err
+  }
 }

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -35,55 +35,60 @@ export async function fetch ({
   singleBranch,
   onprogress // deprecated
 }) {
-  if (onprogress !== undefined) {
-    console.warn(
-      'The `onprogress` callback has been deprecated. Please use the more generic `emitter` EventEmitter argument instead.'
+  try {
+    if (onprogress !== undefined) {
+      console.warn(
+        'The `onprogress` callback has been deprecated. Please use the more generic `emitter` EventEmitter argument instead.'
+      )
+    }
+    const fs = new FileSystem(_fs)
+    let response = await fetchPackfile({
+      gitdir,
+      fs,
+      ref,
+      refs,
+      remote,
+      url,
+      authUsername,
+      authPassword,
+      depth,
+      since,
+      exclude,
+      relative,
+      tags,
+      singleBranch
+    })
+    // Note: progress messages are designed to be written directly to the terminal,
+    // so they are often sent with just a carriage return to overwrite the last line of output.
+    // But there are also messages delimited with newlines.
+    // I also include CRLF just in case.
+    response.progress.pipe(split2(/(\r\n)|\r|\n/)).on('data', line => {
+      if (emitter) {
+        emitter.emit('message', line.trim())
+      }
+      let matches = line.match(/\((\d+?)\/(\d+?)\)/)
+      if (matches && emitter) {
+        emitter.emit('progress', {
+          loaded: parseInt(matches[1], 10),
+          total: parseInt(matches[2], 10),
+          lengthComputable: true
+        })
+      }
+    })
+    let packfile = await pify(concat)(response.packfile)
+    let packfileSha = packfile.slice(-20).toString('hex')
+    await fs.write(
+      path.join(gitdir, `objects/pack/pack-${packfileSha}.pack`),
+      packfile
     )
-  }
-  const fs = new FileSystem(_fs)
-  let response = await fetchPackfile({
-    gitdir,
-    fs,
-    ref,
-    refs,
-    remote,
-    url,
-    authUsername,
-    authPassword,
-    depth,
-    since,
-    exclude,
-    relative,
-    tags,
-    singleBranch
-  })
-  // Note: progress messages are designed to be written directly to the terminal,
-  // so they are often sent with just a carriage return to overwrite the last line of output.
-  // But there are also messages delimited with newlines.
-  // I also include CRLF just in case.
-  response.progress.pipe(split2(/(\r\n)|\r|\n/)).on('data', line => {
-    if (emitter) {
-      emitter.emit('message', line.trim())
+    // TODO: Return more metadata?
+    return {
+      defaultBranch: response.HEAD,
+      fetchHead: response.FETCH_HEAD
     }
-    let matches = line.match(/\((\d+?)\/(\d+?)\)/)
-    if (matches && emitter) {
-      emitter.emit('progress', {
-        loaded: parseInt(matches[1], 10),
-        total: parseInt(matches[2], 10),
-        lengthComputable: true
-      })
-    }
-  })
-  let packfile = await pify(concat)(response.packfile)
-  let packfileSha = packfile.slice(-20).toString('hex')
-  await fs.write(
-    path.join(gitdir, `objects/pack/pack-${packfileSha}.pack`),
-    packfile
-  )
-  // TODO: Return more metadata?
-  return {
-    defaultBranch: response.HEAD,
-    fetchHead: response.FETCH_HEAD
+  } catch (err) {
+    err.caller = 'git.fetch'
+    throw err
   }
 }
 

--- a/src/commands/findRoot.js
+++ b/src/commands/findRoot.js
@@ -8,8 +8,13 @@ import { FileSystem } from '../models'
  * @link https://isomorphic-git.github.io/docs/findRoot.html
  */
 export async function findRoot ({ fs: _fs, filepath }) {
-  const fs = new FileSystem(_fs)
-  return _findRoot(fs, filepath)
+  try {
+    const fs = new FileSystem(_fs)
+    return _findRoot(fs, filepath)
+  } catch (err) {
+    err.caller = 'git.findRoot'
+    throw err
+  }
 }
 
 async function _findRoot (fs, filepath) {

--- a/src/commands/getRemoteInfo.js
+++ b/src/commands/getRemoteInfo.js
@@ -6,46 +6,51 @@ import { GitRemoteHTTP } from '../managers'
  * @link https://isomorphic-git.github.io/docs/getRemoteInfo.html
  */
 export async function getRemoteInfo ({ url, authUsername, authPassword }) {
-  let auth
-  if (authUsername !== undefined && authPassword !== undefined) {
-    auth = {
-      username: authUsername,
-      password: authPassword
+  try {
+    let auth
+    if (authUsername !== undefined && authPassword !== undefined) {
+      auth = {
+        username: authUsername,
+        password: authPassword
+      }
     }
-  }
 
-  const remote = await GitRemoteHTTP.discover({
-    service: 'git-upload-pack',
-    url,
-    auth
-  })
-  const result = {}
-  // Note: remote.capabilities, remote.refs, and remote.symrefs are Set and Map objects,
-  // but one of the objectives of the public API is to always return JSON-compatible objects
-  // so we must JSONify them.
-  result.capabilities = [...remote.capabilities]
-  // Convert the flat list into an object tree, because I figure 99% of the time
-  // that will be easier to use.
-  for (const [ref, oid] of remote.refs) {
-    let parts = ref.split('/')
-    let last = parts.pop()
-    let o = result
-    for (let part of parts) {
-      o[part] = o[part] || {}
-      o = o[part]
+    const remote = await GitRemoteHTTP.discover({
+      service: 'git-upload-pack',
+      url,
+      auth
+    })
+    const result = {}
+    // Note: remote.capabilities, remote.refs, and remote.symrefs are Set and Map objects,
+    // but one of the objectives of the public API is to always return JSON-compatible objects
+    // so we must JSONify them.
+    result.capabilities = [...remote.capabilities]
+    // Convert the flat list into an object tree, because I figure 99% of the time
+    // that will be easier to use.
+    for (const [ref, oid] of remote.refs) {
+      let parts = ref.split('/')
+      let last = parts.pop()
+      let o = result
+      for (let part of parts) {
+        o[part] = o[part] || {}
+        o = o[part]
+      }
+      o[last] = oid
     }
-    o[last] = oid
-  }
-  // Merge symrefs on top of refs to more closely match actual git repo layouts
-  for (const [symref, ref] of remote.symrefs) {
-    let parts = symref.split('/')
-    let last = parts.pop()
-    let o = result
-    for (let part of parts) {
-      o[part] = o[part] || {}
-      o = o[part]
+    // Merge symrefs on top of refs to more closely match actual git repo layouts
+    for (const [symref, ref] of remote.symrefs) {
+      let parts = symref.split('/')
+      let last = parts.pop()
+      let o = result
+      for (let part of parts) {
+        o[part] = o[part] || {}
+        o = o[part]
+      }
+      o[last] = ref
     }
-    o[last] = ref
+    return result
+  } catch (err) {
+    err.caller = 'git.getRemoteInfo'
+    throw err
   }
-  return result
 }

--- a/src/commands/indexPack.js
+++ b/src/commands/indexPack.js
@@ -13,8 +13,13 @@ export async function indexPack ({
   fs: _fs,
   filepath
 }) {
-  const fs = new FileSystem(_fs)
-  const pack = await fs.read(path.join(dir, filepath))
-  const idx = await GitPackIndex.fromPack({ pack })
-  await fs.write(filepath.replace(/\.pack$/, '.idx'), idx.toBuffer())
+  try {
+    const fs = new FileSystem(_fs)
+    const pack = await fs.read(path.join(dir, filepath))
+    const idx = await GitPackIndex.fromPack({ pack })
+    await fs.write(filepath.replace(/\.pack$/, '.idx'), idx.toBuffer())
+  } catch (err) {
+    err.caller = 'git.indexPack'
+    throw err
+  }
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -8,28 +8,33 @@ import { FileSystem } from '../models'
  * @link https://isomorphic-git.github.io/docs/init.html
  */
 export async function init ({ dir, gitdir = path.join(dir, '.git'), fs: _fs }) {
-  const fs = new FileSystem(_fs)
-  let folders = [
-    'hooks',
-    'info',
-    'objects/info',
-    'objects/pack',
-    'refs/heads',
-    'refs/tags'
-  ]
-  folders = folders.map(dir => gitdir + '/' + dir)
-  for (let folder of folders) {
-    await fs.mkdir(folder)
+  try {
+    const fs = new FileSystem(_fs)
+    let folders = [
+      'hooks',
+      'info',
+      'objects/info',
+      'objects/pack',
+      'refs/heads',
+      'refs/tags'
+    ]
+    folders = folders.map(dir => gitdir + '/' + dir)
+    for (let folder of folders) {
+      await fs.mkdir(folder)
+    }
+    await fs.write(
+      gitdir + '/config',
+      '[core]\n' +
+        '\trepositoryformatversion = 0\n' +
+        '\tfilemode = false\n' +
+        '\tbare = false\n' +
+        '\tlogallrefupdates = true\n' +
+        '\tsymlinks = false\n' +
+        '\tignorecase = true\n'
+    )
+    await fs.write(gitdir + '/HEAD', 'ref: refs/heads/master\n')
+  } catch (err) {
+    err.caller = 'git.init'
+    throw err
   }
-  await fs.write(
-    gitdir + '/config',
-    '[core]\n' +
-      '\trepositoryformatversion = 0\n' +
-      '\tfilemode = false\n' +
-      '\tbare = false\n' +
-      '\tlogallrefupdates = true\n' +
-      '\tsymlinks = false\n' +
-      '\tignorecase = true\n'
-  )
-  await fs.write(gitdir + '/HEAD', 'ref: refs/heads/master\n')
 }

--- a/src/commands/listBranches.js
+++ b/src/commands/listBranches.js
@@ -14,6 +14,11 @@ export async function listBranches ({
   fs: _fs,
   remote = undefined
 }) {
-  const fs = new FileSystem(_fs)
-  return GitRefManager.listBranches({ fs, gitdir, remote })
+  try {
+    const fs = new FileSystem(_fs)
+    return GitRefManager.listBranches({ fs, gitdir, remote })
+  } catch (err) {
+    err.caller = 'git.listBranches'
+    throw err
+  }
 }

--- a/src/commands/listTags.js
+++ b/src/commands/listTags.js
@@ -13,6 +13,11 @@ export async function listTags ({
   gitdir = path.join(dir, '.git'),
   fs: _fs
 }) {
-  const fs = new FileSystem(_fs)
-  return GitRefManager.listTags({ fs, gitdir })
+  try {
+    const fs = new FileSystem(_fs)
+    return GitRefManager.listTags({ fs, gitdir })
+  } catch (err) {
+    err.caller = 'git.listTags'
+    throw err
+  }
 }

--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -19,40 +19,45 @@ export async function merge ({
   theirs,
   fastForwardOnly
 }) {
-  const fs = new FileSystem(_fs)
-  let ourOid = await GitRefManager.resolve({
-    fs,
-    gitdir,
-    ref: ours
-  })
-  let theirOid = await GitRefManager.resolve({
-    fs,
-    gitdir,
-    ref: theirs
-  })
-  // find most recent common ancestor of ref a and ref b
-  let baseOid = await findMergeBase({ gitdir, fs, refs: [ourOid, theirOid] })
-  // handle fast-forward case
-  if (baseOid === theirOid) {
-    console.log(`'${theirs}' is already merged into '${ours}'`)
-    return {
-      oid: ourOid,
-      alreadyMerged: true
+  try {
+    const fs = new FileSystem(_fs)
+    let ourOid = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: ours
+    })
+    let theirOid = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: theirs
+    })
+    // find most recent common ancestor of ref a and ref b
+    let baseOid = await findMergeBase({ gitdir, fs, refs: [ourOid, theirOid] })
+    // handle fast-forward case
+    if (baseOid === theirOid) {
+      console.log(`'${theirs}' is already merged into '${ours}'`)
+      return {
+        oid: ourOid,
+        alreadyMerged: true
+      }
     }
-  }
-  if (baseOid === ourOid) {
-    console.log(`Performing a fast-forward merge...`)
-    await GitRefManager.writeRef({ fs, gitdir, ref: ours, value: theirOid })
-    return {
-      oid: theirOid,
-      fastForward: true
+    if (baseOid === ourOid) {
+      console.log(`Performing a fast-forward merge...`)
+      await GitRefManager.writeRef({ fs, gitdir, ref: ours, value: theirOid })
+      return {
+        oid: theirOid,
+        fastForward: true
+      }
+    } else {
+      // not a simple fast-forward
+      if (fastForwardOnly) {
+        throw new Error('A simple fast-forward merge was not possible.')
+      }
+      throw new Error('Non-fast-forward merges are not supported yet.')
     }
-  } else {
-    // not a simple fast-forward
-    if (fastForwardOnly) {
-      throw new Error('A simple fast-forward merge was not possible.')
-    }
-    throw new Error('Non-fast-forward merges are not supported yet.')
+  } catch (err) {
+    err.caller = 'git.merge'
+    throw err
   }
 }
 

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -35,103 +35,108 @@ export async function push ({
   authUsername,
   authPassword
 }) {
-  const fs = new FileSystem(_fs)
-  // TODO: Figure out how pushing tags works. (This only works for branches.)
-  if (url === undefined) {
-    url = await config({ fs, gitdir, path: `remote.${remote}.url` })
-  }
-  let fullRef
-  if (!ref) {
-    ref = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD', depth: 1 })
-    fullRef = ref.replace(/^ref: /, '')
-  } else {
-    fullRef = ref.startsWith('refs/') ? ref : `refs/heads/${ref}`
-  }
-  let oid = await GitRefManager.resolve({ fs, gitdir, ref })
-  let auth
-  if (authUsername !== undefined && authPassword !== undefined) {
-    auth = {
-      username: authUsername,
-      password: authPassword
+  try {
+    const fs = new FileSystem(_fs)
+    // TODO: Figure out how pushing tags works. (This only works for branches.)
+    if (url === undefined) {
+      url = await config({ fs, gitdir, path: `remote.${remote}.url` })
     }
-  }
-  let GitRemoteHTTP = GitRemoteManager.getRemoteHelperFor({ url })
-  let httpRemote = await GitRemoteHTTP.discover({
-    service: 'git-receive-pack',
-    url,
-    auth
-  })
-  let commits = await listCommits({
-    fs,
-    gitdir,
-    start: [oid],
-    finish: httpRemote.refs.values()
-  })
-  let objects = await listObjects({ fs, gitdir, oids: commits })
-  let packstream = new PassThrough()
-  let oldoid =
-    httpRemote.refs.get(fullRef) || '0000000000000000000000000000000000000000'
-  const capabilities = `report-status side-band-64k agent=git/${pkg.name}@${
-    pkg.version
-  }`
-  packstream.write(
-    GitPktLine.encode(`${oldoid} ${oid} ${fullRef}\0 ${capabilities}\n`)
-  )
-  packstream.write(GitPktLine.flush())
-  pack({
-    fs,
-    gitdir,
-    oids: [...objects],
-    outputStream: packstream
-  })
-  let { packfile, progress } = await GitRemoteHTTP.connect({
-    service: 'git-receive-pack',
-    url,
-    auth,
-    stream: packstream
-  })
-  if (emitter) {
-    progress.on('data', chunk => {
-      let msg = chunk.toString('utf8')
-      emitter.emit('message', msg)
+    let fullRef
+    if (!ref) {
+      ref = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD', depth: 1 })
+      fullRef = ref.replace(/^ref: /, '')
+    } else {
+      fullRef = ref.startsWith('refs/') ? ref : `refs/heads/${ref}`
+    }
+    let oid = await GitRefManager.resolve({ fs, gitdir, ref })
+    let auth
+    if (authUsername !== undefined && authPassword !== undefined) {
+      auth = {
+        username: authUsername,
+        password: authPassword
+      }
+    }
+    let GitRemoteHTTP = GitRemoteManager.getRemoteHelperFor({ url })
+    let httpRemote = await GitRemoteHTTP.discover({
+      service: 'git-receive-pack',
+      url,
+      auth
     })
-  }
-  let result = {}
-  // Parse the response!
-  let response = ''
-  let read = GitPktLine.streamReader(packfile)
-  let line = await read()
-  while (line !== true) {
-    if (line !== null) response += line.toString('utf8') + '\n'
-    line = await read()
-  }
-
-  let lines = response.toString('utf8').split('\n')
-  // We're expecting "unpack {unpack-result}"
-  line = lines.shift()
-  if (!line.startsWith('unpack ')) {
-    throw new Error(
-      `Unparsable response from server! Expected 'unpack ok' or 'unpack [error message]' but got '${line}'`
+    let commits = await listCommits({
+      fs,
+      gitdir,
+      start: [oid],
+      finish: httpRemote.refs.values()
+    })
+    let objects = await listObjects({ fs, gitdir, oids: commits })
+    let packstream = new PassThrough()
+    let oldoid =
+      httpRemote.refs.get(fullRef) || '0000000000000000000000000000000000000000'
+    const capabilities = `report-status side-band-64k agent=git/${pkg.name}@${
+      pkg.version
+    }`
+    packstream.write(
+      GitPktLine.encode(`${oldoid} ${oid} ${fullRef}\0 ${capabilities}\n`)
     )
-  }
-  if (line === 'unpack ok') {
-    result.ok = ['unpack']
-  } else {
-    result.errors = [line.trim()]
-  }
-  for (let line of lines) {
-    let status = line.slice(0, 2)
-    let refAndMessage = line.slice(3)
-    if (status === 'ok') {
-      result.ok = result.ok || []
-      result.ok.push(refAndMessage)
-    } else if (status === 'ng') {
-      result.errors = result.errors || []
-      result.errors.push(refAndMessage)
+    packstream.write(GitPktLine.flush())
+    pack({
+      fs,
+      gitdir,
+      oids: [...objects],
+      outputStream: packstream
+    })
+    let { packfile, progress } = await GitRemoteHTTP.connect({
+      service: 'git-receive-pack',
+      url,
+      auth,
+      stream: packstream
+    })
+    if (emitter) {
+      progress.on('data', chunk => {
+        let msg = chunk.toString('utf8')
+        emitter.emit('message', msg)
+      })
     }
+    let result = {}
+    // Parse the response!
+    let response = ''
+    let read = GitPktLine.streamReader(packfile)
+    let line = await read()
+    while (line !== true) {
+      if (line !== null) response += line.toString('utf8') + '\n'
+      line = await read()
+    }
+
+    let lines = response.toString('utf8').split('\n')
+    // We're expecting "unpack {unpack-result}"
+    line = lines.shift()
+    if (!line.startsWith('unpack ')) {
+      throw new Error(
+        `Unparsable response from server! Expected 'unpack ok' or 'unpack [error message]' but got '${line}'`
+      )
+    }
+    if (line === 'unpack ok') {
+      result.ok = ['unpack']
+    } else {
+      result.errors = [line.trim()]
+    }
+    for (let line of lines) {
+      let status = line.slice(0, 2)
+      let refAndMessage = line.slice(3)
+      if (status === 'ok') {
+        result.ok = result.ok || []
+        result.ok.push(refAndMessage)
+      } else if (status === 'ng') {
+        result.errors = result.errors || []
+        result.errors.push(refAndMessage)
+      }
+    }
+    log(result)
+    return result
+  } catch (err) {
+    err.caller = 'git.push'
+    throw err
   }
-  log(result)
-  return result
 }
 
 export async function listCommits ({

--- a/src/commands/readObject.js
+++ b/src/commands/readObject.js
@@ -17,76 +17,88 @@ export async function readObject ({
   filepath = undefined,
   encoding = undefined
 }) {
-  const fs = new FileSystem(_fs)
-  if (filepath !== undefined) {
-    // Ensure there are no leading or trailing directory separators.
-    // I was going to do this automatically, but then found that the Git Terminal for Windows
-    // auto-expands --filepath=/src/utils to --filepath=C:/Users/Will/AppData/Local/Programs/Git/src/utils
-    // so I figured it would be wise to promote the behavior in the application layer not just the library layer.
-    if (filepath.startsWith('/') || filepath.endsWith('/')) {
-      throw new Error(
-        `'filepath' parameter should not include leading or trailing directory separators because these can cause problems on some platforms`
-      )
-    }
-    const _oid = oid
-    let result
-    let tree
-    try {
-      result = await resolveTree({ fs, gitdir, oid })
-      tree = result.tree
-    } catch (err) {
-      throw new Error(`Could not resolve ${oid} to a tree.`)
-    }
-    try {
-      if (filepath === '') {
-        oid = result.oid
-      } else {
-        let pathArray = filepath.split('/')
-        oid = await resolveFile({ fs, gitdir, tree, pathArray })
-      }
-    } catch (err) {
-      if (err.message === 'Unexpected blob') {
+  try {
+    const fs = new FileSystem(_fs)
+    if (filepath !== undefined) {
+      // Ensure there are no leading or trailing directory separators.
+      // I was going to do this automatically, but then found that the Git Terminal for Windows
+      // auto-expands --filepath=/src/utils to --filepath=C:/Users/Will/AppData/Local/Programs/Git/src/utils
+      // so I figured it would be wise to promote the behavior in the application layer not just the library layer.
+      if (filepath.startsWith('/') || filepath.endsWith('/')) {
         throw new Error(
-          `Unable to read '${_oid}:${filepath}' because encountered a file where a directory was expected.`
+          `'filepath' parameter should not include leading or trailing directory separators because these can cause problems on some platforms`
         )
-      } else if (err.message === 'No match path') {
-        throw new Error(`No file or directory found at '${_oid}:${filepath}'.`)
-      } else {
-        throw err
       }
-    }
-  }
-  // GitObjectManager does not know how to parse content, so we tweak that parameter before passing it.
-  const _format = format === 'parsed' ? 'content' : format
-  let result = await GitObjectManager.read({ fs, gitdir, oid, format: _format })
-  result.oid = oid
-  if (format === 'parsed') {
-    result.format = 'parsed'
-    switch (result.type) {
-      case 'commit':
-        result.object = GitCommit.from(result.object).parse()
-        break
-      case 'tree':
-        result.object = { entries: GitTree.from(result.object).entries() }
-        break
-      case 'blob':
-        // Here we consider returning a raw Buffer as the 'content' format
-        // and returning a string as the 'parsed' format
-        if (encoding) {
-          result.object = result.object.toString(encoding)
+      const _oid = oid
+      let result
+      let tree
+      try {
+        result = await resolveTree({ fs, gitdir, oid })
+        tree = result.tree
+      } catch (err) {
+        throw new Error(`Could not resolve ${oid} to a tree.`)
+      }
+      try {
+        if (filepath === '') {
+          oid = result.oid
         } else {
-          result.format = 'content'
+          let pathArray = filepath.split('/')
+          oid = await resolveFile({ fs, gitdir, tree, pathArray })
         }
-        break
-      case 'tag':
-        throw new Error(
-          'TODO: Parsing annotated tag objects still needs to be implemented!!'
-        )
-      default:
-        throw new Error(`Unrecognized git object type: '${result.type}'`)
+      } catch (err) {
+        if (err.message === 'Unexpected blob') {
+          throw new Error(
+            `Unable to read '${_oid}:${filepath}' because encountered a file where a directory was expected.`
+          )
+        } else if (err.message === 'No match path') {
+          throw new Error(
+            `No file or directory found at '${_oid}:${filepath}'.`
+          )
+        } else {
+          throw err
+        }
+      }
     }
+    // GitObjectManager does not know how to parse content, so we tweak that parameter before passing it.
+    const _format = format === 'parsed' ? 'content' : format
+    let result = await GitObjectManager.read({
+      fs,
+      gitdir,
+      oid,
+      format: _format
+    })
+    result.oid = oid
+    if (format === 'parsed') {
+      result.format = 'parsed'
+      switch (result.type) {
+        case 'commit':
+          result.object = GitCommit.from(result.object).parse()
+          break
+        case 'tree':
+          result.object = { entries: GitTree.from(result.object).entries() }
+          break
+        case 'blob':
+          // Here we consider returning a raw Buffer as the 'content' format
+          // and returning a string as the 'parsed' format
+          if (encoding) {
+            result.object = result.object.toString(encoding)
+          } else {
+            result.format = 'content'
+          }
+          break
+        case 'tag':
+          throw new Error(
+            'TODO: Parsing annotated tag objects still needs to be implemented!!'
+          )
+        default:
+          throw new Error(`Unrecognized git object type: '${result.type}'`)
+      }
+    }
+    return result
+  } catch (err) {
+    err.caller = 'git.readObject'
+    throw err
   }
-  return result
 }
 
 async function resolveTree ({ fs, gitdir, oid }) {

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -16,12 +16,17 @@ export async function remove ({
   fs: _fs,
   filepath
 }) {
-  const fs = new FileSystem(_fs)
-  await GitIndexManager.acquire(
-    { fs, filepath: `${gitdir}/index` },
-    async function (index) {
-      index.delete({ filepath })
-    }
-  )
-  // TODO: return oid?
+  try {
+    const fs = new FileSystem(_fs)
+    await GitIndexManager.acquire(
+      { fs, filepath: `${gitdir}/index` },
+      async function (index) {
+        index.delete({ filepath })
+      }
+    )
+    // TODO: return oid?
+  } catch (err) {
+    err.caller = 'git.remove'
+    throw err
+  }
 }

--- a/src/commands/resolveRef.js
+++ b/src/commands/resolveRef.js
@@ -15,11 +15,17 @@ export async function resolveRef ({
   ref,
   depth
 }) {
-  const fs = new FileSystem(_fs)
-  return GitRefManager.resolve({
-    fs,
-    gitdir,
-    ref,
-    depth
-  })
+  try {
+    const fs = new FileSystem(_fs)
+    const oid = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref,
+      depth
+    })
+    return oid
+  } catch (err) {
+    err.caller = 'git.resolveRef'
+    throw err
+  }
 }

--- a/src/commands/sign.js
+++ b/src/commands/sign.js
@@ -15,29 +15,34 @@ export async function sign ({
   privateKeys,
   openpgp
 }) {
-  const fs = new FileSystem(_fs)
-  const oid = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
-  const { type, object } = await GitObjectManager.read({ fs, gitdir, oid })
-  if (type !== 'commit') {
-    throw new Error(
-      `HEAD is not pointing to a 'commit' object but a '${type}' object`
-    )
+  try {
+    const fs = new FileSystem(_fs)
+    const oid = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
+    const { type, object } = await GitObjectManager.read({ fs, gitdir, oid })
+    if (type !== 'commit') {
+      throw new Error(
+        `HEAD is not pointing to a 'commit' object but a '${type}' object`
+      )
+    }
+    let commit = SignedGitCommit.from(object)
+    commit = await commit.sign(openpgp, privateKeys)
+    const newOid = await GitObjectManager.write({
+      fs,
+      gitdir,
+      type: 'commit',
+      object: commit.toObject()
+    })
+    // Update branch pointer
+    // TODO: Use an updateBranch function instead of this.
+    const branch = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: 'HEAD',
+      depth: 2
+    })
+    await fs.write(path.join(gitdir, branch), newOid + '\n')
+  } catch (err) {
+    err.caller = 'git.sign'
+    throw err
   }
-  let commit = SignedGitCommit.from(object)
-  commit = await commit.sign(openpgp, privateKeys)
-  const newOid = await GitObjectManager.write({
-    fs,
-    gitdir,
-    type: 'commit',
-    object: commit.toObject()
-  })
-  // Update branch pointer
-  // TODO: Use an updateBranch function instead of this.
-  const branch = await GitRefManager.resolve({
-    fs,
-    gitdir,
-    ref: 'HEAD',
-    depth: 2
-  })
-  await fs.write(path.join(gitdir, branch), newOid + '\n')
 }

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -19,102 +19,107 @@ export async function status ({
   fs: _fs,
   filepath
 }) {
-  const fs = new FileSystem(_fs)
-  let ignored = await GitIgnoreManager.isIgnored({
-    gitdir,
-    dir,
-    filepath,
-    fs
-  })
-  if (ignored) {
-    return 'ignored'
-  }
-  let headTree = await getHeadTree({ fs, gitdir })
-  let treeOid = await getOidAtPath({
-    fs,
-    gitdir,
-    tree: headTree,
-    path: filepath
-  })
-  let indexEntry = null
-  // Acquire a lock on the index
-  await GitIndexManager.acquire(
-    { fs, filepath: `${gitdir}/index` },
-    async function (index) {
-      for (let entry of index) {
-        if (entry.path === filepath) {
-          indexEntry = entry
-          break
+  try {
+    const fs = new FileSystem(_fs)
+    let ignored = await GitIgnoreManager.isIgnored({
+      gitdir,
+      dir,
+      filepath,
+      fs
+    })
+    if (ignored) {
+      return 'ignored'
+    }
+    let headTree = await getHeadTree({ fs, gitdir })
+    let treeOid = await getOidAtPath({
+      fs,
+      gitdir,
+      tree: headTree,
+      path: filepath
+    })
+    let indexEntry = null
+    // Acquire a lock on the index
+    await GitIndexManager.acquire(
+      { fs, filepath: `${gitdir}/index` },
+      async function (index) {
+        for (let entry of index) {
+          if (entry.path === filepath) {
+            indexEntry = entry
+            break
+          }
         }
       }
+    )
+    let stats = null
+    try {
+      stats = await fs._lstat(path.join(dir, filepath))
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
     }
-  )
-  let stats = null
-  try {
-    stats = await fs._lstat(path.join(dir, filepath))
+
+    let H = treeOid !== null // head
+    let I = indexEntry !== null // index
+    let W = stats !== null // working dir
+
+    const getWorkdirOid = async () => {
+      if (I && !cacheIsStale({ entry: indexEntry, stats })) {
+        return indexEntry.oid
+      } else {
+        let object = await fs.read(path.join(dir, filepath))
+        let workdirOid = await GitObjectManager.hash({
+          gitdir,
+          type: 'blob',
+          object
+        })
+        return workdirOid
+      }
+    }
+
+    if (!H && !W && !I) return 'absent' // ---
+    if (!H && !W && I) return '*absent' // -A-
+    if (!H && W && !I) return '*added' // --A
+    if (!H && W && I) {
+      let workdirOid = await getWorkdirOid()
+      return workdirOid === indexEntry.oid ? 'added' : '*added' // -AA : -AB
+    }
+    if (H && !W && !I) return 'deleted' // A--
+    if (H && !W && I) {
+      return treeOid === indexEntry.oid ? '*deleted' : '*deleted' // AA- : AB-
+    }
+    if (H && W && !I) {
+      let workdirOid = await getWorkdirOid()
+      return workdirOid === treeOid ? '*undeleted' : '*undeletemodified' // A-A : A-B
+    }
+    if (H && W && I) {
+      let workdirOid = await getWorkdirOid()
+      if (workdirOid === treeOid) {
+        return workdirOid === indexEntry.oid ? 'unmodified' : '*unmodified' // AAA : ABA
+      } else {
+        return workdirOid === indexEntry.oid ? 'modified' : '*modified' // ABB : AAB
+      }
+    }
+    /*
+    ---
+    -A-
+    --A
+    -AA
+    -AB
+    A--
+    AA-
+    AB-
+    A-A
+    A-B
+    AAA
+    ABA
+    ABB
+    AAB
+    */
   } catch (err) {
-    if (err.code !== 'ENOENT') {
-      throw err
-    }
+    err.caller = 'git.status'
+    throw err
   }
-
-  let H = treeOid !== null // head
-  let I = indexEntry !== null // index
-  let W = stats !== null // working dir
-
-  const getWorkdirOid = async () => {
-    if (I && !cacheIsStale({ entry: indexEntry, stats })) {
-      return indexEntry.oid
-    } else {
-      let object = await fs.read(path.join(dir, filepath))
-      let workdirOid = await GitObjectManager.hash({
-        gitdir,
-        type: 'blob',
-        object
-      })
-      return workdirOid
-    }
-  }
-
-  if (!H && !W && !I) return 'absent' // ---
-  if (!H && !W && I) return '*absent' // -A-
-  if (!H && W && !I) return '*added' // --A
-  if (!H && W && I) {
-    let workdirOid = await getWorkdirOid()
-    return workdirOid === indexEntry.oid ? 'added' : '*added' // -AA : -AB
-  }
-  if (H && !W && !I) return 'deleted' // A--
-  if (H && !W && I) {
-    return treeOid === indexEntry.oid ? '*deleted' : '*deleted' // AA- : AB-
-  }
-  if (H && W && !I) {
-    let workdirOid = await getWorkdirOid()
-    return workdirOid === treeOid ? '*undeleted' : '*undeletemodified' // A-A : A-B
-  }
-  if (H && W && I) {
-    let workdirOid = await getWorkdirOid()
-    if (workdirOid === treeOid) {
-      return workdirOid === indexEntry.oid ? 'unmodified' : '*unmodified' // AAA : ABA
-    } else {
-      return workdirOid === indexEntry.oid ? 'modified' : '*modified' // ABB : AAB
-    }
-  }
-  /*
-  ---
-  -A-
-  --A
-  -AA
-  -AB
-  A--
-  AA-
-  AB-
-  A-A
-  A-B
-  AAA
-  ABA
-  ABB
-  AAB
-  */
 }
 
 function cacheIsStale ({ entry, stats }) {

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -6,5 +6,10 @@ import { pkg } from '../utils/pkg'
  * @link https://isomorphic-git.github.io/docs/version.html
  */
 export function version () {
-  return pkg.version
+  try {
+    return pkg.version
+  } catch (err) {
+    err.caller = 'git.version'
+    throw err
+  }
 }


### PR DESCRIPTION
@jcubic I'm taking a second swing at the error-handling problem. Thought this time I'd try a simpler route - just wrap the guts of every API function in a try/catch, and if it catches an error, assign the function name to `error.caller`, then rethrow it. This is based on your suggestion [here](https://github.com/isomorphic-git/isomorphic-git/pull/217#issuecomment-391793087).