### PR TITLE
fix: only update remote refs that we actually have downloaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '10'
+  - '10.3.0'
 install:
   - npm i
 before_script:

--- a/__tests__/test-GitRefSpecSet.js
+++ b/__tests__/test-GitRefSpecSet.js
@@ -29,4 +29,11 @@ describe('GitRefSpecSet', () => {
       ['refs/heads/master', 'refs/foo/master']
     ])
   })
+
+  it('weird HEAD implicit rule', async () => {
+    const refspec = new GitRefSpecSet()
+    refspec.add('+HEAD:refs/remotes/origin/HEAD')
+    const result = refspec.translate(['HEAD'])
+    expect(result).toEqual([['HEAD', 'refs/remotes/origin/HEAD']])
+  })
 })

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -24,6 +24,8 @@ describe('fetch', () => {
       remote: 'origin',
       ref: 'test-branch-shallow-clone'
     })
+    expect(fs.existsSync(`${gitdir}/refs/remotes/origin/test-branch-shallow-clone`)).toBe(true)
+    expect(fs.existsSync(`${gitdir}/refs/remotes/origin/master`)).toBe(false)
   })
 
   it('shallow fetch (from Github)', async () => {

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -24,7 +24,9 @@ describe('fetch', () => {
       remote: 'origin',
       ref: 'test-branch-shallow-clone'
     })
-    expect(fs.existsSync(`${gitdir}/refs/remotes/origin/test-branch-shallow-clone`)).toBe(true)
+    expect(
+      fs.existsSync(`${gitdir}/refs/remotes/origin/test-branch-shallow-clone`)
+    ).toBe(true)
     expect(fs.existsSync(`${gitdir}/refs/remotes/origin/master`)).toBe(false)
   })
 

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -66,7 +66,7 @@ module.exports = {
       size: optional(timeout(1)('bundlesize')),
       jasmine: retry3('cross-env NODE_PATH=./dist/for-node jasmine'),
       jest: process.env.CI
-        ? retry3(`cross-env BABEL_ENV=jest ${timeout5('jest --ci --coverage')}`)
+        ? retry3(`cross-env BABEL_ENV=jest ${timeout5('jest --ci')}`)
         : 'cross-env BABEL_ENV=jest jest --ci',
       uploadcoverage: optional(timeout(1)('codecov')),
       karma: process.env.CI

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -8,13 +8,15 @@ const retry = n => cmd =>
     .join(` || `)
 const retry3 = retry(3)
 
-const quote = cmd => cmd.replace(new RegExp("'", 'g'), "\\'")
+const quote = cmd => cmd.replace(new RegExp("'", 'g'), "\\'").replace(new RegExp('"', 'g'), '\\"')
 
 const optional = cmd =>
-  `${cmd} || echo "Optional command '${quote(cmd)}' failed".`
+  `(${cmd}) || echo "Optional command '${quote(cmd)}' failed".`
 
 const timeout = n => cmd => `timeout --signal=KILL ${n}m ${cmd}`
 const timeout5 = timeout(5)
+
+const or = (a, b) => `(${a}) || (${b})`
 
 const srcPaths = '*.js src/*.js src/**/*.js __tests__/*.js __tests__/**/*.js'
 
@@ -55,19 +57,21 @@ module.exports = {
       default: process.env.CI
         ? series.nps(
           'lint',
-          'test.jest',
-          'test.uploadcoverage',
           'build',
           'test.size',
-          'test.jasmine',
+          'test.one',
+          'test.uploadcoverage',
           'test.karma'
         )
         : series.nps('lint', 'build', 'test.jasmine', 'test.karma'),
       size: optional(timeout(1)('bundlesize')),
-      jasmine: retry3('cross-env NODE_PATH=./dist/for-node jasmine'),
+      one: retry3(or('nps test.jest', 'nps test.jasmine')),
+      jasmine: process.env.CI
+        ? `cross-env NODE_PATH=./dist/for-node ${timeout5('jasmine')}`
+        : `cross-env NODE_PATH=./dist/for-node jasmine`,
       jest: process.env.CI
-        ? retry3(`cross-env BABEL_ENV=jest ${timeout5('jest --ci')}`)
-        : 'cross-env BABEL_ENV=jest jest --ci',
+        ? `cross-env BABEL_ENV=jest ${timeout5('jest --ci')}`
+        : `cross-env BABEL_ENV=jest jest --ci`,
       uploadcoverage: optional(timeout(1)('codecov')),
       karma: process.env.CI
         ? retry3('karma start --single-run')


### PR DESCRIPTION
## I'm fixing a bug

- [x] add a test case in `__tests__/test-X.js` if possible
- [x] make a fix commit "fix: [Description of fix]"

This is a (surprisingly complicated) set of changes so that when you do `isogit clone --singleBranch` you end up with the same entries in `remotes/origin` as you do when you run `git clone --single-branch`. 
- It doesn't update the references until _after_ the packfile is downloaded. Before, it erroneously reported having all the refs!
- It now saves the remote `HEAD` to `remotes/origin/HEAD` if you clone the default branch, even though that's not in the git config refspec (🤷‍♂️ ).
- If you clone with `singleBranch: true` it only saves the refs (and symrefs) for the branch you download.

**This should fix some of the spurious errors with `clone` and `checkout` we have been seeing!**