### PR TITLE
perf: do less parsing of idx files to save time

### DIFF
--- a/__tests__/test-GitPackIndex.js
+++ b/__tests__/test-GitPackIndex.js
@@ -24,11 +24,11 @@ describe('GitPackIndex', () => {
     expect(shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
-    expect(p.offsets['0b8faa11b353db846b40eb064dfb299816542a46']).toEqual(40077)
-    expect(p.offsets['637c4e69d85e0dcc18898ec251377453d0891585']).toEqual(39860)
-    expect(p.offsets['98e9fde3ee878fa985a143fc5fe05d4e6d8e637b']).toEqual(39036)
-    expect(p.offsets['43c49edb213748626fc363c890c01a9e55a1b8da']).toEqual(38202)
-    expect(p.offsets['5f1f014326b1d7e8079d00b87fa7a9913bd91324']).toEqual(20855)
+    expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(40077)
+    expect(p.offsets.get('637c4e69d85e0dcc18898ec251377453d0891585')).toEqual(39860)
+    expect(p.offsets.get('98e9fde3ee878fa985a143fc5fe05d4e6d8e637b')).toEqual(39036)
+    expect(p.offsets.get('43c49edb213748626fc363c890c01a9e55a1b8da')).toEqual(38202)
+    expect(p.offsets.get('5f1f014326b1d7e8079d00b87fa7a9913bd91324')).toEqual(20855)
   })
   it('from .pack', async () => {
     let { fs, gitdir } = await makeFixture('test-GitPackIndex')
@@ -42,25 +42,11 @@ describe('GitPackIndex', () => {
     expect(shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
-    expect(p.offsets['0b8faa11b353db846b40eb064dfb299816542a46']).toEqual(40077)
-    expect(p.offsets['637c4e69d85e0dcc18898ec251377453d0891585']).toEqual(39860)
-    expect(p.offsets['98e9fde3ee878fa985a143fc5fe05d4e6d8e637b']).toEqual(39036)
-    expect(p.offsets['43c49edb213748626fc363c890c01a9e55a1b8da']).toEqual(38202)
-    expect(p.offsets['5f1f014326b1d7e8079d00b87fa7a9913bd91324']).toEqual(20855)
-  })
-
-  it('to .idx file', async () => {
-    let { fs, gitdir } = await makeFixture('test-GitPackIndex')
-    let idx = await pify(fs.readFile)(
-      path.join(
-        gitdir,
-        'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.idx'
-      )
-    )
-    let p = await GitPackIndex.fromIdx({ idx })
-    let idxbuffer = p.toBuffer()
-    expect(idxbuffer.byteLength).toBe(idx.byteLength)
-    expect(idxbuffer.equals(idx)).toBe(true)
+    expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(40077)
+    expect(p.offsets.get('637c4e69d85e0dcc18898ec251377453d0891585')).toEqual(39860)
+    expect(p.offsets.get('98e9fde3ee878fa985a143fc5fe05d4e6d8e637b')).toEqual(39036)
+    expect(p.offsets.get('43c49edb213748626fc363c890c01a9e55a1b8da')).toEqual(38202)
+    expect(p.offsets.get('5f1f014326b1d7e8079d00b87fa7a9913bd91324')).toEqual(20855)
   })
   it('to .idx file from .pack', async () => {
     let { fs, gitdir } = await makeFixture('test-GitPackIndex')
@@ -81,7 +67,6 @@ describe('GitPackIndex', () => {
     expect(idxbuffer.byteLength).toBe(idx.byteLength)
     expect(idxbuffer.equals(idx)).toBe(true)
   })
-
   it('read undeltified object', async () => {
     let { fs, gitdir } = await makeFixture('test-GitPackIndex')
     let idx = await pify(fs.readFile)(

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -1,8 +1,12 @@
+import debug from 'debug'
 import path from 'path'
 import pify from 'pify'
+import * as marky from 'marky'
 
 import { E, GitError } from '../models/GitError'
 import { sleep } from '../utils'
+
+const readFileLog = debug('readFile')
 
 const delayedReleases = new Map()
 /**
@@ -42,7 +46,9 @@ export class FileSystem {
    */
   async read (filepath, options = {}) {
     try {
+      marky.mark(filepath)
       let buffer = await this._readFile(filepath, options)
+      readFileLog(`${filepath} ${marky.stop(filepath).duration}`)
       return buffer
     } catch (err) {
       return null

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -57,6 +57,7 @@ export class GitPackIndex {
     this.offsetCache = {}
   }
   static async fromIdx ({ idx, getExternalRefDelta }) {
+    marky.mark('fromIdx')
     let reader = new BufferCursor(idx)
     let magic = reader.slice(4).toString('hex')
     // Check for IDX v2 magic number
@@ -69,41 +70,36 @@ export class GitPackIndex {
         message: `Unable to read version ${version} packfile IDX. (Only version 2 supported)`
       })
     }
-    // Verify checksums
-    let shaComputed = shasum(idx.slice(0, -20))
-    let shaClaimed = idx.slice(-20).toString('hex')
-    if (shaClaimed !== shaComputed) {
-      throw new GitError(E.InternalFail, {
-        message: `Invalid checksum in IDX buffer: expected ${shaClaimed} but saw ${shaComputed}`
-      })
-    }
     if (idx.byteLength > 2048 * 1024 * 1024) {
       throw new GitError(E.InternalFail, {
         message: `To keep implementation simple, I haven't implemented the layer 5 feature needed to support packfiles > 2GB in size.`
       })
     }
-    let fanout = []
-    for (let i = 0; i < 256; i++) {
-      fanout.push(reader.readUInt32BE())
-    }
-    let size = fanout[255]
-    // For now we'll parse the whole thing. We can optimize later if we need to.
+    // Skip over fanout table
+    reader.seek(reader.tell() + 4 * 255)
+    // Get hashes
+    let size = reader.readUInt32BE()
+    marky.mark('hashes')
     let hashes = []
     for (let i = 0; i < size; i++) {
-      hashes.push(reader.slice(20).toString('hex'))
+      let hash = reader.slice(20).toString('hex')
+      hashes[i] = hash
     }
-    let crcs = {}
+    log(`hashes ${marky.stop('hashes').duration}`)
+    reader.seek(reader.tell() + 4 * size)
+    // Skip over CRCs
+    marky.mark('offsets')
+    // Get offsets
+    let offsets = new Map()
     for (let i = 0; i < size; i++) {
-      crcs[hashes[i]] = reader.readUInt32BE()
+      offsets.set(hashes[i], reader.readUInt32BE())
     }
-    let offsets = {}
-    for (let i = 0; i < size; i++) {
-      offsets[hashes[i]] = reader.readUInt32BE()
-    }
+    log(`offsets ${marky.stop('offsets').duration}`)
     let packfileSha = reader.slice(20).toString('hex')
+    log(`fromIdx ${marky.stop('fromIdx').duration}`)
     return new GitPackIndex({
       hashes,
-      crcs,
+      crcs: {},
       offsets,
       packfileSha,
       getExternalRefDelta
@@ -128,7 +124,7 @@ export class GitPackIndex {
 
     let hashes = []
     let crcs = {}
-    let offsets = {}
+    let offsets = new Map()
     let totalObjectCount = null
     let lastPercent = null
     let times = {
@@ -280,7 +276,7 @@ export class GitPackIndex {
         times.hash += marky.stop('hash').duration
         o.oid = oid
         hashes.push(oid)
-        offsets[oid] = offset
+        offsets.set(oid, offset)
         crcs[oid] = o.crc
       } catch (err) {
         log('ERROR', err)
@@ -342,7 +338,7 @@ export class GitPackIndex {
     // Write out offsets
     let offsetsBuffer = new BufferCursor(Buffer.alloc(this.hashes.length * 4))
     for (let hash of this.hashes) {
-      offsetsBuffer.writeUInt32BE(this.offsets[hash])
+      offsetsBuffer.writeUInt32BE(this.offsets.get(hash))
     }
     buffers.push(offsetsBuffer.buffer)
     // Write out packfile checksum
@@ -361,7 +357,7 @@ export class GitPackIndex {
     this.pack = null
   }
   async read ({ oid }) {
-    if (!this.offsets[oid]) {
+    if (!this.offsets.get(oid)) {
       if (this.getExternalRefDelta) {
         this.externalReadDepth++
         return this.getExternalRefDelta(oid)
@@ -371,7 +367,7 @@ export class GitPackIndex {
         })
       }
     }
-    let start = this.offsets[oid]
+    let start = this.offsets.get(oid)
     return this.readSlice({ start })
   }
   async readSlice ({ start }) {


### PR DESCRIPTION
the branch name is a misnomer. True lazy parsing would only access the file on readObject and only parse the relevant entries in the idx file. This is just me speeding up the existing eager idx parser.