### PR TITLE
fix: cache stat values after calling git.status

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -77,13 +77,18 @@ export async function status ({
         })
         // If the oid in the index === working dir oid but stats differed update cache
         if (I && indexEntry.oid === workdirOid) {
-          // We don't await this so we can return faster.
-          GitIndexManager.acquire(
-            { fs, filepath: `${gitdir}/index` },
-            async function (index) {
-              index.insert({ filepath, stats, oid: workdirOid })
-            }
-          )
+          // and as long as our fs.stats aren't bad.
+          // size of -1 happens over a BrowserFS HTTP Backend that doesn't serve Content-Length headers
+          // because BrowserFS HTTP Backend uses HTTP HEAD requests to do fs.stat
+          if (stats.size !== -1) {
+            // We don't await this so we can return faster for one-off cases.
+            GitIndexManager.acquire(
+              { fs, filepath: `${gitdir}/index` },
+              async function (index) {
+                index.insert({ filepath, stats, oid: workdirOid })
+              }
+            )
+          }
         }
         return workdirOid
       }

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -8,6 +8,7 @@ import { FileSystem } from '../models/FileSystem.js'
 import { GitCommit } from '../models/GitCommit.js'
 import { E, GitError } from '../models/GitError.js'
 import { GitTree } from '../models/GitTree.js'
+import { compareStats } from '../utils/compareStats.js'
 
 /**
  * Tell whether a file has been changed
@@ -65,7 +66,7 @@ export async function status ({
     let W = stats !== null // working dir
 
     const getWorkdirOid = async () => {
-      if (I && !cacheIsStale({ entry: indexEntry, stats })) {
+      if (I && !compareStats({ entry: indexEntry, stats })) {
         return indexEntry.oid
       } else {
         let object = await fs.read(path.join(dir, filepath))
@@ -74,6 +75,16 @@ export async function status ({
           type: 'blob',
           object
         })
+        // If the oid in the index === working dir oid but stats differed update cache
+        if (I && indexEntry.oid === workdirOid) {
+          // We don't await this so we can return faster.
+          GitIndexManager.acquire(
+            { fs, filepath: `${gitdir}/index` },
+            async function (index) {
+              index.insert({ filepath, stats, oid: workdirOid })
+            }
+          )
+        }
         return workdirOid
       }
     }
@@ -121,20 +132,6 @@ export async function status ({
     err.caller = 'git.status'
     throw err
   }
-}
-
-function cacheIsStale ({ entry, stats }) {
-  // Comparison based on the description in Paragraph 4 of
-  // https://www.kernel.org/pub/software/scm/git/docs/technical/racy-git.txt
-  return (
-    entry.mode !== stats.mode ||
-    entry.mtime.valueOf() !== stats.mtime.valueOf() ||
-    entry.ctime.valueOf() !== stats.ctime.valueOf() ||
-    entry.uid !== stats.uid ||
-    entry.gid !== stats.gid ||
-    entry.ino !== stats.ino >> 0 ||
-    entry.size !== stats.size
-  )
 }
 
 async function getOidAtPath ({ fs, gitdir, tree, path }) {

--- a/src/utils/compareStats.js
+++ b/src/utils/compareStats.js
@@ -1,0 +1,19 @@
+import { normalizeStats } from './normalizeStats'
+
+export function compareStats ({ entry, stats }) {
+  // Comparison based on the description in Paragraph 4 of
+  // https://www.kernel.org/pub/software/scm/git/docs/technical/racy-git.txt
+  const e = normalizeStats(entry)
+  const s = normalizeStats(stats)
+  const staleness =
+    e.mode !== s.mode ||
+    e.mtimeSeconds !== s.mtimeSeconds ||
+    e.ctimeSeconds !== s.ctimeSeconds ||
+    e.uid !== s.uid ||
+    e.gid !== s.gid ||
+    e.ino !== s.ino ||
+    e.size !== s.size
+  // console.log(staleness ? 'stale:' : 'fresh:')
+  // console.table([e, s])
+  return staleness
+}

--- a/src/utils/normalizeStats.js
+++ b/src/utils/normalizeStats.js
@@ -1,0 +1,29 @@
+const MAX_UINT32 = 2 ** 32
+
+export function normalizeStats (e) {
+  const ctimeSeconds = e.ctimeSeconds !== undefined
+    ? e.ctimeSeconds
+    : Math.floor(e.ctime.valueOf() / 1000)
+  const mtimeSeconds = e.mtimeSeconds !== undefined
+    ? e.mtimeSeconds
+    : Math.floor(e.mtime.valueOf() / 1000)
+  const ctimeNanoseconds = e.ctimeNanoseconds !== undefined
+    ? e.ctimeNanoseconds
+    : (e.ctime.valueOf() - ctimeSeconds * 1000) * 1000000
+  const mtimeNanoseconds = e.mtimeNanoseconds !== undefined
+    ? e.mtimeNanoseconds
+    : (e.mtime.valueOf() - mtimeSeconds * 1000) * 1000000
+
+  return {
+    ctimeSeconds: ctimeSeconds % MAX_UINT32,
+    ctimeNanoseconds: ctimeNanoseconds % MAX_UINT32,
+    mtimeSeconds: mtimeSeconds % MAX_UINT32,
+    mtimeNanoseconds: mtimeNanoseconds % MAX_UINT32,
+    dev: e.dev % MAX_UINT32,
+    ino: e.ino % MAX_UINT32,
+    mode: e.mode % MAX_UINT32,
+    uid: e.uid % MAX_UINT32,
+    gid: e.gid % MAX_UINT32,
+    size: e.size % MAX_UINT32
+  }
+}


### PR DESCRIPTION
I think to see real perf improvements though, I need to support calling `git.status` on whole directories at a time (because status requires walking the HEAD commit, and it's better to walk just once).