### PR TITLE
fix: Make the 'ours' parameter of merge optional

### DIFF
--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -5,6 +5,7 @@ import { GitRefManager } from '../managers/GitRefManager.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 
+import { currentBranch } from './currentBranch.js'
 import { log } from './log'
 
 /**
@@ -22,6 +23,9 @@ export async function merge ({
 }) {
   try {
     const fs = new FileSystem(_fs)
+    if (ours === undefined) {
+      ours = await currentBranch({ fs, gitdir, fullname: true })
+    }
     ours = await GitRefManager.expand({
       fs,
       gitdir,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -298,7 +298,7 @@ export function merge(args: {
   fs: any,
   dir: string,
   gitdir?: string
-  ours: string,
+  ours?: string,
   theirs: string,
   fastForwardOnly?: boolean
 }): Promise<MergeReport>;


### PR DESCRIPTION
The documentation erroneously said the 'ours' parameter was optional. Now it actually is.