### PR TITLE
Mark readObject's arguments 'format', 'filepath' and 'encoding' as optional because they are.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -336,9 +336,9 @@ export function readObject(args: {
   dir: string,
   gitdir?: string,
   oid: string,
-  format: 'deflated' | 'wrapped' | 'content' | 'parsed',
-  filepath: string,
-  encoding: string
+  format?: 'deflated' | 'wrapped' | 'content' | 'parsed',
+  filepath?: string,
+  encoding?: string
 }): Promise<GitObjectDescription>
 
 export function remove(args: {


### PR DESCRIPTION
It's not just a nuisance, since TypeScript complains when 'filepath' is not given, but you have to omit it in order to be able to get readObject to return commit objects.
