### PR TITLE
feat: Push a local branch/tag to a differently named branch/tag on the remote

### DIFF
--- a/__tests__/test-push.js
+++ b/__tests__/test-push.js
@@ -53,4 +53,23 @@ describe('push', () => {
       expect(res.ok[1]).toBe('refs/heads/master')
     }
   )
+  ;(process.browser ? it : xit)(
+    'push to karma-git-http-server-middleware with ref !== remoteRef',
+    async () => {
+      // Setup
+      let { fs, gitdir } = await makeFixture('test-push')
+      plugins.set('fs', fs)
+      // Test
+      let res = await push({
+        gitdir,
+        remote: 'karma',
+        ref: 'master',
+        remoteRef: 'foobar'
+      })
+      expect(res).toBeTruthy()
+      expect(res.ok).toBeTruthy()
+      expect(res.ok[0]).toBe('unpack')
+      expect(res.ok[1]).toBe('refs/heads/foobar')
+    }
+  )
 })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -382,6 +382,7 @@ export function push(args: {
   dir: string;
   gitdir?: string;
   ref?: string;
+  remoteRef?: string;
   remote?: string;
   url?: string;
   corsProxy?: string;

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -153,6 +153,15 @@ export class GitRefManager {
     // Do we give up?
     throw new GitError(E.ExpandRefError, { ref })
   }
+  static async expandAgainstMap ({ fs: _fs, gitdir, ref, map }) {
+    // Look in all the proper paths, in this order
+    const allpaths = refpaths(ref)
+    for (let ref of allpaths) {
+      if (await map.has(ref)) return ref
+    }
+    // Do we give up?
+    throw new GitError(E.ExpandRefError, { ref })
+  }
   static resolveAgainstMap ({ ref, fullref = ref, depth, map }) {
     if (depth !== undefined) {
       depth--


### PR DESCRIPTION
Fixes #348

Just a quick & dirty patch to make this work:

```js
git.push({ ...pushDetails, ref: 'feature-branch:refs/heads/master' }))
```