### PR TITLE
feat: Added 'forPush' parameter to getRemoteInfo command

### DIFF
--- a/src/commands/getRemoteInfo.js
+++ b/src/commands/getRemoteInfo.js
@@ -13,12 +13,13 @@ export async function getRemoteInfo ({
   username = authUsername,
   password = authPassword,
   token,
-  oauth2format
+  oauth2format,
+  forPush = false
 }) {
   try {
     let auth = { username, password, token, oauth2format }
     const remote = await GitRemoteHTTP.discover({
-      service: 'git-upload-pack',
+      service: forPush ? 'git-receive-pack' : 'git-upload-pack',
       url,
       noGitSuffix,
       auth

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -228,6 +228,7 @@ export function getRemoteInfo(args: {
   password?: string,
   token?: string,
   oauth2format?: 'github' | 'bitbucket' | 'gitlab',
+  forPush?: boolean,
 }): Promise<RemoteDescription>;
 
 export function indexPack(args: {


### PR DESCRIPTION
- [x] add parameter to the function in `src/commands/X.js`
- [ ] add parameter to [docs](https://github.com/isomorphic-git/isomorphic-git.github.io/tree/source/docs)/X.md
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [ ] add a test case in `__tests__/test-X.js` if possible
- [x] make a feature commit "feat: Added 'bar' parameter to X command"

Needed for debugging #310. Turns out the list of supported capabilities a server returns (and the list of refs potentially) depends on whether you express interest in pushing or pulling.