### PR TITLE
[WIP] 'httpAgent' plugin

### DIFF
--- a/__tests__/server-only.test-GitRemoteHTTP.js
+++ b/__tests__/server-only.test-GitRemoteHTTP.js
@@ -22,6 +22,7 @@ describe('GitRemoteHTTP', () => {
     )
     // Test
     let remote = await GitRemoteHTTP.discover({
+      core: 'default',
       service: 'git-upload-pack',
       url: 'https://github.com/isomorphic-git/isomorphic-git'
     })
@@ -39,6 +40,7 @@ describe('GitRemoteHTTP', () => {
     )
     // Test
     let remote = await GitRemoteHTTP.discover({
+      core: 'default',
       service: 'git-upload-pack',
       url: 'http://example.dev/test-GitRemoteHTTP'
     })
@@ -54,6 +56,7 @@ describe('GitRemoteHTTP', () => {
     )
     // Test
     let remote = await GitRemoteHTTP.discover({
+      core: 'default',
       service: 'git-receive-pack',
       url: 'http://example.dev/test-GitRemoteHTTP'
     })
@@ -69,6 +72,7 @@ describe('GitRemoteHTTP', () => {
     let error = null
     try {
       await GitRemoteHTTP.discover({
+        core: 'default',
         service: 'git-receive-pack',
         url: 'https://github.com/isomorphic-git/not-there'
       })

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -55,6 +55,7 @@ export async function fetch ({
     }
     const fs = new FileSystem(_fs)
     let response = await fetchPackfile({
+      core,
       gitdir,
       fs,
       ref,
@@ -117,6 +118,7 @@ export async function fetch ({
 }
 
 async function fetchPackfile ({
+  core,
   gitdir,
   fs: _fs,
   ref,
@@ -159,6 +161,7 @@ async function fetchPackfile ({
   let auth = { username, password, token, oauth2format }
   let GitRemoteHTTP = GitRemoteManager.getRemoteHelperFor({ url })
   let remoteHTTP = await GitRemoteHTTP.discover({
+    core,
     corsProxy,
     service: 'git-upload-pack',
     url,
@@ -225,6 +228,7 @@ async function fetchPackfile ({
   // so we can't stream the body.
   packstream = await pify(concat)(packstream)
   let raw = await GitRemoteHTTP.connect({
+    core,
     corsProxy,
     service: 'git-upload-pack',
     url,

--- a/src/commands/getRemoteInfo.js
+++ b/src/commands/getRemoteInfo.js
@@ -6,6 +6,7 @@ import { GitRemoteHTTP } from '../managers/GitRemoteHTTP.js'
  * @link https://isomorphic-git.github.io/docs/getRemoteInfo.html
  */
 export async function getRemoteInfo ({
+  core = 'default',
   corsProxy,
   url,
   authUsername,
@@ -20,6 +21,7 @@ export async function getRemoteInfo ({
   try {
     let auth = { username, password, token, oauth2format }
     const remote = await GitRemoteHTTP.discover({
+      core,
       corsProxy,
       service: forPush ? 'git-receive-pack' : 'git-upload-pack',
       url,

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -65,6 +65,7 @@ export async function push ({
     let auth = { username, password, token, oauth2format }
     let GitRemoteHTTP = GitRemoteManager.getRemoteHelperFor({ url })
     let httpRemote = await GitRemoteHTTP.discover({
+      core,
       corsProxy,
       service: 'git-receive-pack',
       url,
@@ -134,6 +135,7 @@ export async function push ({
     })
     let { packfile, progress } = await GitSideBand.demux(
       await GitRemoteHTTP.connect({
+        core,
         corsProxy,
         service: 'git-receive-pack',
         url,

--- a/src/models/PluginCore.js
+++ b/src/models/PluginCore.js
@@ -1,7 +1,8 @@
 import { GitError, E } from './GitError'
 
 const pluginSchemas = {
-  'fs': ['lstat', 'mkdir', 'readdir', 'readFile', 'rmdir', 'stat', 'unlink', 'writeFile']
+  'fs': ['lstat', 'mkdir', 'readdir', 'readFile', 'rmdir', 'stat', 'unlink', 'writeFile'],
+  'httpAgent': [] // It's complicated.
 }
 
 function verifySchema (key, value) {
@@ -20,6 +21,9 @@ export class PluginCore extends Map {
     verifySchema(key, value)
     if (key === 'fs') {
       // There can be only one.
+      super.set(key, value)
+    }
+    if (key === 'httpAgent') {
       super.set(key, value)
     }
   }


### PR DESCRIPTION
Example usage:
```js
const fs = require('fs')
const ProxyAgent = require('proxy-agent')
const {fetch, plugins} = require('.')
plugins.set('fs', fs)
plugins.set('httpAgent', new ProxyAgent('http://localhost:8080'))

fetch({ dir: '.'}).then(console.log)
```

I'm not sure if this works yet though - I still get self-signed cert errors.

I want to see if this can solve both #202 and #386