### PR TITLE
add TypeScript definitions for walkBeta1

### DIFF
--- a/src/commands/walkBeta1.js
+++ b/src/commands/walkBeta1.js
@@ -1,8 +1,4 @@
-import path from 'path'
-
-import { FileSystem } from '../models/FileSystem.js'
 import { arrayRange } from '../utils/arrayRange.js'
-import { cores } from '../utils/plugins.js'
 import { GitWalkerSymbol } from '../utils/symbols.js'
 import { unionOfIterators } from '../utils/unionOfIterators.js'
 
@@ -13,15 +9,12 @@ import { unionOfIterators } from '../utils/unionOfIterators.js'
  */
 export async function walkBeta1 ({
   core = 'default',
-  dir,
-  gitdir = path.join(dir, '.git'),
-  fs: _fs = cores.get(core).get('fs'),
   trees,
   map = async entry => entry,
   filter = async () => true,
   // The default reducer is a flatmap that filters out undefineds.
   reduce = async (parent, children) => {
-    // TODO: replace with `results.flat()` once that gets standardized
+    // TODO: replace with `[parent, children].flat()` once that gets standardized
     let flatten = children.reduce((acc, x) => acc.concat(x), [])
     if (parent !== undefined) flatten.unshift(parent)
     return flatten
@@ -30,11 +23,7 @@ export async function walkBeta1 ({
   iterate = (recurse, children) => Promise.all([...children].map(recurse))
 }) {
   try {
-    const fs = new FileSystem(_fs)
-
-    let walkers = trees.map(proxy => {
-      return proxy[GitWalkerSymbol]({ fs, gitdir, dir })
-    })
+    let walkers = trees.map(proxy => proxy[GitWalkerSymbol]())
 
     let root = new Array(walkers.length).fill({
       fullpath: '.',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,7 +92,28 @@ export interface RemoteDescription {
   url: string; // url of the remote
 }
 
-export type StatusMatrix = Array<[string, ...number[]]>;
+export interface Walker {}
+
+export interface WalkerTree {
+  fullpath: string;
+  basename: string;
+  exists: boolean;
+  populateStat: () => Promise<void>;
+  type?: 'tree' | 'blob';
+  ctimeSeconds?: number;
+  mtimeSeconds?: number;
+  mtimeNanoseconds?: number;
+  dev?: number;
+  ino?: number;
+  mode?: number;
+  uid?: number;
+  gid?: number;
+  size?: number;
+  populateContent: () => Promise<void>;
+  content?: Buffer;
+  populatHash: () => Promise<void>;
+  oid?: string;
+}
 
 export interface GitFsPlugin {
   readFile: any;
@@ -119,9 +140,30 @@ export type AnyGitPlugin = GitFsPlugin | GitCredentialManagerPlugin | GitEmitter
 
 export type GitPluginCore = Map<string, AnyGitPlugin>
 
+export type StatusMatrix = Array<[string, number, number, number]>;
+
+export type WalkerEntry = WalkerTree[];
+
 export const plugins: GitPluginCore
 
 export const cores: Map<string, GitPluginCore>
+
+export function WORKDIR(args: {
+  fs: any;
+  dir: string;
+  gitdir: string;
+}): Walker;
+
+export function TREE(args: {
+  fs: any;
+  gitdir: string;
+  ref: string;
+}): Walker;
+
+export function STAGE(args: {
+  fs: any;
+  gitdir: string;
+}): Walker;
 
 export function add(args: {
   core?: string;
@@ -487,6 +529,15 @@ export function verify(args: {
 }): Promise<false | Array<string>>;
 
 export function version(): string;
+
+export function walkBeta1<T, Q>(args: {
+  core?: string;
+  trees: Walker[];
+  filter: (entry: WalkerEntry) => Promise<boolean>;
+  map: (entry: WalkerEntry) => Promise<T | undefined>;
+  reduce: (parent: T | undefined, children: Q[]) => Promise<Q>;
+  iterate: (recurse: (parent: WalkerEntry) => Promise<Q>, children: Iterable<WalkerEntry>) => Promise<Array<Q|undefined>>;
+}): Promise<Q|undefined>;
 
 export function writeObject(args: {
   core?: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -536,7 +536,7 @@ export function walkBeta1<T, Q>(args: {
   filter: (entry: WalkerEntry) => Promise<boolean>;
   map: (entry: WalkerEntry) => Promise<T | undefined>;
   reduce: (parent: T | undefined, children: Q[]) => Promise<Q>;
-  iterate: (recurse: (parent: WalkerEntry) => Promise<Q>, children: Iterable<WalkerEntry>) => Promise<Array<Q|undefined>>;
+  iterate: (walk: (parent: WalkerEntry) => Promise<Q>, children: Iterable<WalkerEntry>) => Promise<Array<Q|undefined>>;
 }): Promise<Q|undefined>;
 
 export function writeObject(args: {


### PR DESCRIPTION
That was about as hard as I expected. ☹️ Not sure if they're 100% correct.

This part is easy:
```ts
export interface Walker {}

export function WORKDIR(args: {
  fs: any;
  dir: string;
  gitdir: string;
}): Walker;

export function TREE(args: {
  fs: any;
  gitdir: string;
  ref: string;
}): Walker;

export function STAGE(args: {
  fs: any;
  gitdir: string;
}): Walker;
```

> Note: in the future, the 'fs' argument may be optional now that we have the plugin system.

This next part is awkward because almost all the props are marked optional. Maybe in `walkBeta2` I'll have the `.populate` methods return a new object instead of modifying the current one? Then we can provide stronger assertions by making the return type equal to the current type + some new properties. (Something like `populateHash: () => this & {oid: string}; populateContent: () => this & {content: Buffer};`) If that's possible.
```ts
export interface WalkerTree {
  fullpath: string;
  basename: string;
  exists: boolean;
  populateStat: () => Promise<void>;
  type?: 'tree' | 'blob';
  ctimeSeconds?: number;
  mtimeSeconds?: number;
  mtimeNanoseconds?: number;
  dev?: number;
  ino?: number;
  mode?: number;
  uid?: number;
  gid?: number;
  size?: number;
  populateContent: () => Promise<void>;
  content?: Buffer;
  populatHash: () => Promise<void>;
  oid?: string;
}

export type WalkerEntry = WalkerTree[];
```

### HERE IS WHERE IT GETS COMPLICATED
I'm not 100% sure about my typings for `reduce` and `iterate`.

```ts
export function walkBeta1<T, Q>(args: {
  core?: string;
  trees: Walker[];
  filter: (entry: WalkerEntry) => Promise<boolean>;
  map: (entry: WalkerEntry) => Promise<T | undefined>;
  reduce: (parent: T | undefined, children: Q[]) => Promise<Q>;
  iterate: (walk: (parent: WalkerEntry) => Promise<Q>, children: Iterable<WalkerEntry>) => Promise<Array<Q|undefined>>;
}): Promise<Q|undefined>;

```

For example, for `statusMatrix` the `T` type is `[string, number, number, number]` and the `Q` type is `T[]`.

If you were building a hierarchy, you might have `T` and `Q` be the same:
```ts
interface Node {
  filename: string,
  sha: string;
  children?: Node[]
}
let root: Node = await walkBeta1<Node, Node>({
  trees: [TREE({ fs, gitdir, ref: 'HEAD' })],
  map ([entry]: WalkerEntry): Node {
    await entry.populateHash();
    return {
      filename: entry.basename,
      sha: entry.oid
    }
  },
  reduce (parent: Node, children: Node): Node {
    return { ...parent, children }
  }
})
```