### PR TITLE
feat: include HTTP headers in the results for fetch and push

### DIFF
--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -108,10 +108,14 @@ export async function fetch ({
       )
     }
     // TODO: Return more metadata?
-    return {
+    let res = {
       defaultBranch: response.HEAD,
       fetchHead: response.FETCH_HEAD
     }
+    if (response.headers) {
+      res.headers = response.headers
+    }
+    return res
   } catch (err) {
     err.caller = 'git.fetch'
     throw err
@@ -240,6 +244,9 @@ async function fetchPackfile ({
   // Normally I would await this, but for some reason I'm having trouble detecting
   // when this header portion is over.
   let response = await parseUploadPackResponse(raw)
+  if (raw.headers) {
+    response.headers = raw.headers
+  }
   // Apply all the 'shallow' and 'unshallow' commands
   for (const oid of response.shallows) {
     oids.add(oid)

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -139,16 +139,15 @@ export async function push ({
       oids: [...objects],
       outputStream: packstream
     })
-    let { packfile, progress } = await GitSideBand.demux(
-      await GitRemoteHTTP.connect({
-        corsProxy,
-        service: 'git-receive-pack',
-        url,
-        noGitSuffix,
-        auth,
-        stream: packstream
-      })
-    )
+    let res = await GitRemoteHTTP.connect({
+      corsProxy,
+      service: 'git-receive-pack',
+      url,
+      noGitSuffix,
+      auth,
+      stream: packstream
+    })
+    let { packfile, progress } = await GitSideBand.demux(res)
     if (emitter) {
       progress.on('data', chunk => {
         let msg = chunk.toString('utf8')
@@ -157,6 +156,9 @@ export async function push ({
     }
     // Parse the response!
     let result = await parseReceivePackResponse(packfile)
+    if (res.headers) {
+      result.headers = res.headers
+    }
     return result
   } catch (err) {
     err.caller = 'git.push'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,10 +66,12 @@ export interface TreeEntry {
 export interface PushResponse {
   ok?: string[];
   errors?: string[];
+  headers?: object;
 }
 
 export interface FetchResponse {
   defaultBranch: string;
+  headers?: object;
 }
 
 export interface RemoteDescription {


### PR DESCRIPTION
## I'm adding a return value to an existing command:

- [ ] add to [docs](https://github.com/isomorphic-git/isomorphic-git.github.io/tree/source/docs)/X.md
- [X] add to the TypeScript library definition for X in `src/index.d.ts`
- [X] make a feature commit "feat: Added 'bar' parameter to X command"

resolves #500 