### PR TITLE
fix: add 'phase' to progress events

### DIFF
--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -112,10 +112,7 @@ export async function fetch ({
     // c) compare the computed SHA with the last 20 bytes of the stream before saving to disk, and throwing a "packfile got corrupted during download" error if the SHA doesn't match.
     if (packfileSha !== '') {
       res.packfile = `objects/pack/pack-${packfileSha}.pack`
-      await fs.write(
-        path.join(gitdir, res.packfile),
-        packfile
-      )
+      await fs.write(path.join(gitdir, res.packfile), packfile)
     }
     return res
   } catch (err) {

--- a/src/commands/indexPack.js
+++ b/src/commands/indexPack.js
@@ -14,12 +14,15 @@ export async function indexPack ({
   dir,
   gitdir = path.join(dir, '.git'),
   fs: _fs = cores.get(core).get('fs'),
+  emitter = cores.get(core).get('emitter'),
+  emitterPrefix = '',
   filepath
 }) {
   try {
     const fs = new FileSystem(_fs)
-    const pack = await fs.read(path.join(dir, filepath))
-    const idx = await GitPackIndex.fromPack({ pack })
+    filepath = path.join(dir, filepath)
+    const pack = await fs.read(filepath)
+    const idx = await GitPackIndex.fromPack({ pack, emitter, emitterPrefix })
     await fs.write(filepath.replace(/\.pack$/, '.idx'), idx.toBuffer())
   } catch (err) {
     err.caller = 'git.indexPack'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -220,6 +220,8 @@ export function checkout(args: {
   fs?: any;
   dir: string;
   gitdir?: string;
+  emitter?: EventEmitter;
+  emitterPrefix?: string;
   remote?: string;
   ref?: string;
 }): Promise<void>;
@@ -344,6 +346,8 @@ export function indexPack(args: {
   fs?: any;
   dir: string;
   gitdir?: string;
+  emitter?: EventEmitter;
+  emitterPrefix?: string;
   filepath: string;
 }): Promise<void>;
 

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -105,7 +105,7 @@ export class GitPackIndex {
       getExternalRefDelta
     })
   }
-  static async fromPack ({ pack, getExternalRefDelta }) {
+  static async fromPack ({ pack, getExternalRefDelta, emitter, emitterPrefix }) {
     const listpackTypes = {
       1: 'commit',
       2: 'tree',
@@ -158,6 +158,14 @@ export class GitPackIndex {
           ((totalObjectCount - num) * 100) / totalObjectCount
         )
         if (percent !== lastPercent) {
+          if (emitter) {
+            emitter.emit(`${emitterPrefix}progress`, {
+              phase: 'Receiving objects',
+              loaded: totalObjectCount - num,
+              total: totalObjectCount,
+              lengthComputable: true
+            })
+          }
           log(
             `${percent}%\t${Math.floor(
               marky.stop('percent').duration
@@ -249,6 +257,14 @@ export class GitPackIndex {
             marky.stop('percent').duration
           )}\t${callsToReadSlice}\t${callsToGetExternal}`
         )
+        if (emitter) {
+          emitter.emit(`${emitterPrefix}progress`, {
+            phase: 'Resolving deltas',
+            loaded: count,
+            total: totalObjectCount,
+            lengthComputable: true
+          })
+        }
         marky.mark('percent')
         callsToReadSlice = 0
         callsToGetExternal = 0


### PR DESCRIPTION
fixes #596
This PR adds more events and adds a 'phase' to the events. So you can drive pretty progress bars like this:

![capture10](https://user-images.githubusercontent.com/587740/49271761-08a4ca80-f43d-11e8-8e9e-5222756cf1aa.gif)

## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] add parameter to [docs](https://github.com/isomorphic-git/isomorphic-git.github.io/tree/source/docs)/X.md
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [ ] add a test case in `__tests__/test-X.js` if possible
- [x] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
