### PR TITLE
experiment: use node-fetch instead of simple-get

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13343,14 +13343,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -17078,6 +17073,18 @@
       "requires": {
         "node-fetch": "^1.3.3",
         "node-localstorage": "~1.3.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "opn": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "marky": "^1.2.1",
     "minimisted": "^2.0.0",
     "nick": "^0.1.3",
+    "node-fetch": "^2.3.0",
     "pako": "^1.0.6",
     "pify": "^4.0.1",
     "readable-stream": "2 || 3",

--- a/src/models/GitPktLine.js
+++ b/src/models/GitPktLine.js
@@ -81,7 +81,9 @@ export class GitPktLine {
     }
   }
 
+  // Note: also accepts buffer input for flexibility
   static streamReader (stream) {
+    if (!stream.on) return GitPktLine.reader(stream)
     const bufferstream = streamSource(stream)
     return async function read () {
       try {

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,0 +1,3 @@
+export function fetch (...args) {
+  return global.fetch ? global.fetch(...args) : require('node-fetch')(...args)
+}

--- a/src/utils/wrapStream.js
+++ b/src/utils/wrapStream.js
@@ -1,0 +1,14 @@
+import pify from 'pify'
+import concat from 'simple-concat'
+
+export async function wrapStream (stream) {
+  if (stream === undefined) return stream
+  // Because of edge case with AWS CodeCommit, stream might actually be a buffer
+  if (!stream.on) return stream
+  // Browsers can't yet stream uploads
+  if (typeof window !== 'undefined') {
+    let buffer = await pify(concat)(stream)
+    return buffer
+  }
+  return stream
+}


### PR DESCRIPTION
Immediate benefit in bundle size. Went from 84.73kb to 75.63kb.
But the price we pay is we lose [streaming](https://github.com/jhiesey/stream-http) in the handful of browsers that support it.

Currently node also loses streaming because I'm trying to make the same code support both browser and node. But future commits will pull `fetch` into its own plugin, and then hopefully we won't have that limitation.