### PR TITLE
feat: Added 'bare' parameter to init command

### DIFF
--- a/__tests__/test-init.js
+++ b/__tests__/test-init.js
@@ -13,4 +13,13 @@ describe('init', () => {
     expect(fs.existsSync(`${dir}/.git/refs/heads`)).toBe(true)
     expect(fs.existsSync(`${dir}/.git/HEAD`)).toBe(true)
   })
+  it('init --bare', async () => {
+    let { fs, dir } = await makeFixture('test-init')
+    plugins.set('fs', fs)
+    await init({ dir, bare: true })
+    expect(fs.existsSync(dir)).toBe(true)
+    expect(fs.existsSync(`${dir}/objects`)).toBe(true)
+    expect(fs.existsSync(`${dir}/refs/heads`)).toBe(true)
+    expect(fs.existsSync(`${dir}/HEAD`)).toBe(true)
+  })
 })

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -9,8 +9,9 @@ import { cores } from '../utils/plugins.js'
  */
 export async function init ({
   core = 'default',
+  bare = false,
   dir,
-  gitdir = join(dir, '.git'),
+  gitdir = bare ? dir : join(dir, '.git'),
   fs: _fs = cores.get(core).get('fs')
 }) {
   try {
@@ -32,8 +33,8 @@ export async function init ({
       '[core]\n' +
         '\trepositoryformatversion = 0\n' +
         '\tfilemode = false\n' +
-        '\tbare = false\n' +
-        '\tlogallrefupdates = true\n' +
+        `\tbare = ${bare}\n` +
+        (bare ? '' : '\tlogallrefupdates = true\n') +
         '\tsymlinks = false\n' +
         '\tignorecase = true\n'
     )

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -357,6 +357,7 @@ export function init(args: {
   fs?: any;
   dir: string;
   gitdir?: string;
+  bare?: boolean;
 }): Promise<void>;
 
 export function isDescendent(args: {


### PR DESCRIPTION
closes #598

## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] add parameter to [docs](https://github.com/isomorphic-git/isomorphic-git.github.io/tree/source/docs)/X.md
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
