### PR TITLE
fix: avoid unnecessary match if emitter is not defined

### DIFF
--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -83,15 +83,15 @@ export async function fetch ({
     response.progress.pipe(split2(/(\r\n)|\r|\n/)).on('data', line => {
       if (emitter) {
         emitter.emit(`${emitterPrefix}message`, line.trim())
-      }
-      let matches = line.match(/([^:]*).*\((\d+?)\/(\d+?)\)/)
-      if (matches && emitter) {
-        emitter.emit(`${emitterPrefix}progress`, {
-          phase: matches[1].trim(),
-          loaded: parseInt(matches[2], 10),
-          total: parseInt(matches[3], 10),
-          lengthComputable: true
-        })
+        let matches = line.match(/([^:]*).*\((\d+?)\/(\d+?)\)/)
+        if (matches) {
+          emitter.emit(`${emitterPrefix}progress`, {
+            phase: matches[1].trim(),
+            loaded: parseInt(matches[2], 10),
+            total: parseInt(matches[3], 10),
+            lengthComputable: true
+          })
+        }
       }
     })
     let packfile = await pify(concat)(response.packfile)


### PR DESCRIPTION
## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"