### PR TITLE
fix: fixed crash when shallow cloning certain repositories

### DIFF
--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -193,6 +193,19 @@ async function fetchPackfile ({
     ref,
     map: remoteHTTP.refs
   })
+  // Filter out the refs we want to ignore
+  for (let ref of remoteHTTP.refs.keys()) {
+    // Keep the one we're cloning obviously
+    if (ref === fullref) continue
+    // Keep head
+    if (ref === 'HEAD') continue
+    // Keep branches
+    if (ref.startsWith('refs/heads/')) continue
+    // Keep tags if we're keeping tags
+    if (tags && ref.startsWith('refs/tags/')) continue
+    // Remove pull requests and other junk
+    remoteHTTP.refs.delete(ref)
+  }
   // Assemble the application/x-git-upload-pack-request
   const capabilities = filterCapabilities(
     [...remoteHTTP.capabilities],

--- a/src/wire/parseUploadPackResponse.js
+++ b/src/wire/parseUploadPackResponse.js
@@ -40,13 +40,6 @@ export async function parseUploadPackResponse (stream) {
         }
         next(null, data)
       })
-    )
-    // For some reason, clone --depth=1 returns >300 'shallow's but no ACK or NAK
-    // This is the failsafe in case there's no ack or nak
-    packetlines.on('end', () => {
-      if (!done) {
-        resolve({ shallows, unshallows, acks, nak, packfile, progress })
-      }
-    })
+    ).resume()
   })
 }


### PR DESCRIPTION
fixes #624 Issue was through2 stopped reading from packetlines after the highWaterLimit (~16kb)