### PR TITLE
fix: add 'headers' param to clone, fetch, and getRemoteInfo

### DIFF
--- a/src/commands/annotatedTag.js
+++ b/src/commands/annotatedTag.js
@@ -5,8 +5,8 @@ import { E, GitError } from '../models/GitError.js'
 import { readObject } from '../storage/readObject.js'
 import { writeObject } from '../storage/writeObject.js'
 import { join } from '../utils/join.js'
-import { cores } from '../utils/plugins.js'
 import { normalizeAuthorObject } from '../utils/normalizeAuthorObject.js'
+import { cores } from '../utils/plugins.js'
 
 /**
  * Create an annotated tag.

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -38,6 +38,7 @@ export async function clone ({
   singleBranch,
   noCheckout = false,
   noTags = false,
+  headers = {},
   onprogress
 }) {
   try {
@@ -89,6 +90,7 @@ export async function clone ({
       exclude,
       relative,
       singleBranch,
+      headers,
       tags: !noTags
     })
     ref = ref || defaultBranch

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -7,8 +7,8 @@ import { GitTree } from '../models/GitTree.js'
 import { writeObject } from '../storage/writeObject.js'
 import { flatFileListToDirectoryStructure } from '../utils/flatFileListToDirectoryStructure.js'
 import { join } from '../utils/join.js'
-import { cores } from '../utils/plugins.js'
 import { normalizeAuthorObject } from '../utils/normalizeAuthorObject.js'
+import { cores } from '../utils/plugins.js'
 
 /**
  * Create a new commit

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -203,7 +203,9 @@ async function fetchPackfile ({
       remoteRef === 'HEAD' ||
       remoteRef.startsWith('refs/heads/') ||
       (tags && remoteRef.startsWith('refs/tags/'))
-    ) { continue }
+    ) {
+      continue
+    }
     remoteRefs.delete(remoteRef)
   }
   // Assemble the application/x-git-upload-pack-request

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -40,12 +40,13 @@ export async function fetch ({
   password = authPassword,
   token,
   oauth2format,
-  depth,
-  since,
-  exclude,
-  relative,
-  tags,
-  singleBranch,
+  depth = null,
+  since = null,
+  exclude = [],
+  relative = false,
+  tags = false,
+  singleBranch = false,
+  headers = {},
   onprogress // deprecated
 }) {
   try {
@@ -74,7 +75,8 @@ export async function fetch ({
       exclude,
       relative,
       tags,
-      singleBranch
+      singleBranch,
+      headers
     })
     // Note: progress messages are designed to be written directly to the terminal,
     // so they are often sent with just a carriage return to overwrite the last line of output.
@@ -135,13 +137,13 @@ async function fetchPackfile ({
   password,
   token,
   oauth2format,
-  depth = null,
-  since = null,
-  exclude = [],
-  relative = false,
-  tags = false,
-  singleBranch = false,
-  headers = {}
+  depth,
+  since,
+  exclude,
+  relative,
+  tags,
+  singleBranch,
+  headers
 }) {
   const fs = new FileSystem(_fs)
   // Sanity checks

--- a/src/commands/getRemoteInfo.js
+++ b/src/commands/getRemoteInfo.js
@@ -16,6 +16,7 @@ export async function getRemoteInfo ({
   password = authPassword,
   token,
   oauth2format,
+  headers = {},
   forPush = false
 }) {
   try {
@@ -27,7 +28,7 @@ export async function getRemoteInfo ({
       url,
       noGitSuffix,
       auth,
-      headers: {}
+      headers
     })
     auth = remote.auth // hack to get new credentials from CredentialManager API
     const result = {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -260,6 +260,7 @@ export function clone(args: {
   singleBranch?: boolean;
   noCheckout?: boolean;
   noTags?: boolean;
+  headers?: { [key: string]: string };
 }): Promise<void>;
 
 export function commit(args: {
@@ -386,6 +387,7 @@ export function getRemoteInfo(args: {
   token?: string;
   oauth2format?: 'github' | 'bitbucket' | 'gitlab';
   forPush?: boolean;
+  headers?: { [key: string]: string };
 }): Promise<RemoteDescription>;
 
 export function indexPack(args: {

--- a/src/utils/normalizeAuthorObject.js
+++ b/src/utils/normalizeAuthorObject.js
@@ -2,8 +2,8 @@ import { config } from '../commands/config'
 
 export async function normalizeAuthorObject ({ fs, gitdir, author = {} }) {
   let { name, email, date, timestamp, timezoneOffset } = author
-  name = name || await config({ fs, gitdir, path: 'user.name' })
-  email = email || await config({ fs, gitdir, path: 'user.email' })
+  name = name || (await config({ fs, gitdir, path: 'user.name' }))
+  email = email || (await config({ fs, gitdir, path: 'user.email' }))
 
   if (name === undefined || email === undefined) {
     return undefined
@@ -11,7 +11,8 @@ export async function normalizeAuthorObject ({ fs, gitdir, author = {} }) {
 
   date = date || new Date()
   timestamp = timestamp != null ? timestamp : Math.floor(date.valueOf() / 1000)
-  timezoneOffset = timezoneOffset != null ? timezoneOffset : date.getTimezoneOffset()
+  timezoneOffset =
+    timezoneOffset != null ? timezoneOffset : date.getTimezoneOffset()
 
   return { name, email, date, timestamp, timezoneOffset }
 }


### PR DESCRIPTION
## I'm adding a parameter to an existing command:
- [x] add parameter to the function in `src/commands/X.js`
- [x] add parameter to [docs](https://github.com/isomorphic-git/isomorphic-git.github.io/tree/source/docs)/X.md
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
