### PR TITLE
fix: listRemotes function return type was incorrect.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -96,7 +96,7 @@ export interface MergeReport {
   fastForward?: boolean;
 }
 
-export interface RemoteDescription {
+export interface RemoteDefinition {
   remote: string; // name of the remote
   url: string; // url of the remote
 }
@@ -430,7 +430,7 @@ export function listFiles(args: GitDir & {
 export function listRemotes(args: GitDir & {
   core?: string;
   fs?: any;
-}): Promise<Array<RemoteDescription>>;
+}): Promise<Array<RemoteDefinition>>;
 
 export function listTags(args: GitDir & {
   core?: string;


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

It looks like there were two interfaces defined by mistake with the same name `RemoteDescription`, and that name is used in return type for `listBranches()` and `getRemoteInfo()` functions. According to the code, only one of the `RemoteDescription` types is correct for `listBranches()` function. 

I renamed the one that `listBranches()` returns to `RemoteDefinition` (as a set of url and name defines the remote, but does not describe it in detail), and left `RemoteDescription` type as a return for `getRemoteInfo()`.

Looks like it was a simple mixup.

## I'm fixing a bug or typo

- [X] squash merge the PR with commit message "fix: [Description of fix]"

