### PR TITLE
fix: don't error if process.env is undefined

### DIFF
--- a/__tests__/test-walkBeta1.js
+++ b/__tests__/test-walkBeta1.js
@@ -14,9 +14,12 @@ describe('walkBeta1', () => {
         TREE({ fs, gitdir, ref: 'HEAD' }),
         STAGE({ fs, gitdir })
       ],
-      map: (entries) => entries.map(
-        ({ basename, exists, fullpath }) => ({ basename, exists, fullpath })
-      )
+      map: entries =>
+        entries.map(({ basename, exists, fullpath }) => ({
+          basename,
+          exists,
+          fullpath
+        }))
     })
     expect(matrix).toEqual([
       [

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -3,8 +3,9 @@ let shouldLog = null
 export function log (...args) {
   if (shouldLog === null) {
     shouldLog =
-      process.env.DEBUG === '*' ||
-      process.env.DEBUG === 'isomorphic-git' ||
+      (process && process.env && process.env.DEBUG &&
+        (process.env.DEBUG === '*' ||
+          process.env.DEBUG === 'isomorphic-git')) ||
       (typeof window !== 'undefined' &&
         typeof window.localStorage !== 'undefined' &&
         (window.localStorage.debug === '*' ||

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -3,7 +3,9 @@ let shouldLog = null
 export function log (...args) {
   if (shouldLog === null) {
     shouldLog =
-      (process && process.env && process.env.DEBUG &&
+      (process &&
+        process.env &&
+        process.env.DEBUG &&
         (process.env.DEBUG === '*' ||
           process.env.DEBUG === 'isomorphic-git')) ||
       (typeof window !== 'undefined' &&


### PR DESCRIPTION
related to #698 