### PR TITLE
fix: add force to addRemote typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -221,6 +221,7 @@ export function add(args: {
 export function addRemote(args: GitDir & {
   core?: string;
   fs?: any;
+  force?: boolean;
   remote: string;
   url: string;
 }): Promise<void>;


### PR DESCRIPTION
https://isomorphic-git.org/docs/en/addRemote

`force` is an option in the docs but not in the typings.
