### PR TITLE
feat: prefer fs.promises over wrapping fs with pify

### DIFF
--- a/__tests__/__helpers__/FixtureFS/makeLightningFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeLightningFS.js
@@ -7,7 +7,7 @@ async function makeLightningFS (dir) {
     wipe: true,
     url: 'http://localhost:9876/base/__tests__/__fixtures__'
   })
-  plugins.set('fs', _fs)
+  plugins.set('fs', { promises: _fs.promises })
   const fs = new FileSystem(_fs)
   dir = `/${dir}`
   let gitdir = `/${dir}.git`

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -86,7 +86,7 @@ module.exports = function (config) {
         platformName: 'iOS',
         platformVersion: '11.2',
         browserName: 'Safari',
-        appiumVersion: '1.7.2'
+        appiumVersion: '1.9.1'
       },
       sl_ios_safari12: {
         base: 'SauceLabs',
@@ -102,7 +102,7 @@ module.exports = function (config) {
         platformName: 'Android',
         platformVersion: '7.1',
         browserName: 'Chrome',
-        appiumVersion: '1.7.2'
+        appiumVersion: '1.9.1'
       },
       FirefoxHeadless: {
         base: 'Firefox',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -139,6 +139,10 @@ export interface GitEmitterPlugin {
   emit: any;
 }
 
+export interface GitFsPromisesPlugin {
+  promises: GitFsPlugin;
+}
+
 export interface GitFsPlugin {
   readFile: any;
   writeFile: any;
@@ -179,7 +183,7 @@ export type GitHttpPlugin = (
 
 export type GitPluginName = "credentialManager" | "emitter" | "fs" | "pgp" | "http"
 
-export type AnyGitPlugin = GitFsPlugin | GitCredentialManagerPlugin | GitEmitterPlugin | GitPgpPlugin | GitHttpPlugin
+export type AnyGitPlugin = GitFsPlugin | GitFsPromisesPlugin | GitCredentialManagerPlugin | GitEmitterPlugin | GitPgpPlugin | GitHttpPlugin
 
 export type GitPluginCore = Map<GitPluginName, AnyGitPlugin>
 

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -17,16 +17,29 @@ export class FileSystem {
       throw new GitError(E.PluginUndefined, { plugin: 'fs' })
     }
     if (typeof fs._readFile !== 'undefined') return fs
-    this._readFile = pify(fs.readFile.bind(fs))
-    this._writeFile = pify(fs.writeFile.bind(fs))
-    this._mkdir = pify(fs.mkdir.bind(fs))
-    this._rmdir = pify(fs.rmdir.bind(fs))
-    this._unlink = pify(fs.unlink.bind(fs))
-    this._stat = pify(fs.stat.bind(fs))
-    this._lstat = pify(fs.lstat.bind(fs))
-    this._readdir = pify(fs.readdir.bind(fs))
-    this._readlink = pify(fs.readlink.bind(fs))
-    this._symlink = pify(fs.symlink.bind(fs))
+    if (fs.promises) {
+      this._readFile = fs.promises.readFile.bind(fs.promises)
+      this._writeFile = fs.promises.writeFile.bind(fs.promises)
+      this._mkdir = fs.promises.mkdir.bind(fs.promises)
+      this._rmdir = fs.promises.rmdir.bind(fs.promises)
+      this._unlink = fs.promises.unlink.bind(fs.promises)
+      this._stat = fs.promises.stat.bind(fs.promises)
+      this._lstat = fs.promises.lstat.bind(fs.promises)
+      this._readdir = fs.promises.readdir.bind(fs.promises)
+      this._readlink = fs.promises.readlink.bind(fs.promises)
+      this._symlink = fs.promises.symlink.bind(fs.promises)
+    } else {
+      this._readFile = pify(fs.readFile.bind(fs))
+      this._writeFile = pify(fs.writeFile.bind(fs))
+      this._mkdir = pify(fs.mkdir.bind(fs))
+      this._rmdir = pify(fs.rmdir.bind(fs))
+      this._unlink = pify(fs.unlink.bind(fs))
+      this._stat = pify(fs.stat.bind(fs))
+      this._lstat = pify(fs.lstat.bind(fs))
+      this._readdir = pify(fs.readdir.bind(fs))
+      this._readlink = pify(fs.readlink.bind(fs))
+      this._symlink = pify(fs.symlink.bind(fs))
+    }
   }
   /**
    * Return true if a file exists, false if it doesn't exist.

--- a/src/utils/plugins.js
+++ b/src/utils/plugins.js
@@ -13,6 +13,10 @@ import { E, GitError } from '../models/GitError'
 class PluginCore extends Map {
   set (key, value) {
     const verifySchema = (key, value) => {
+      // ugh. this sucks
+      if (key === 'fs' && value.promises) {
+        value = value.promises
+      }
       const pluginSchemas = {
         credentialManager: ['fill', 'approved', 'rejected'],
         emitter: ['emit'],


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

This adds slight (probably not measurable) perf improvement but more importantly, simplifies creating a wrapped `fs` plugin that (say) emits events to emulate a file watcher. 👀 

## I'm updating a plugin:

- [x] update docs
- [x] update TypeScript library definition for X in `src/index.d.ts`
- [x] update tests
