### PR TITLE
fix: the `headers` returned by the HTTP plugin should be JSON

### DIFF
--- a/src/utils/http-browser.js
+++ b/src/utils/http-browser.js
@@ -19,12 +19,17 @@ export async function http ({
     res.body && res.body.getReader
       ? fromStream(res.body)
       : [new Uint8Array(await res.arrayBuffer())]
+  // convert Header object to ordinary JSON
+  headers = {}
+  for (let [key, value] of res.headers.entries()) {
+    headers[key] = value
+  }
   return {
     url: res.url,
     method: res.method,
     statusCode: res.status,
     statusMessage: res.statusText,
     body: iter,
-    headers: res.headers
+    headers: headers
   }
 }


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] squash merge the PR with commit message "fix: [Description of fix]"

The browser HTTP plugin is returning [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) not [`headers`](https://nodejs.org/api/http.html#http_message_headers) like the node plugin. I discovered this because `Headers` objects are not clonable and thus the result of `push` and `fetch` can't be returned via `postMessage` without an error. Which is bad.