### PR TITLE
chore: rewrite "Edit" button link in docs

### DIFF
--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -175,7 +175,9 @@ function gendoc (filepath) {
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/${obj.name}.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/${
+  obj.name
+}.js';
   }
 })();
 </script>`

--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -168,6 +168,18 @@ function gendoc (filepath) {
           text += '\n```\n'
         }
       }
+      if (obj.name) {
+        // This rewrites the "Edit" button on the docs page to point to the JSDoc page instead of the raw Markdown page.
+        text += `
+<script>
+(function rewriteEditLink() {
+  const el = document.querySelector('a.edit-page-link.button');
+  if (el) {
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/${obj.name}.js';
+  }
+})();
+</script>`
+      }
     }
   }
   return text


### PR DESCRIPTION
update to `generate-docs.js`

This is so when people click the "Edit" button on the docs page,
![image](https://user-images.githubusercontent.com/587740/59003547-6f3be400-87e4-11e9-9fd5-c220856e73b7.png)
they won't be taken to the raw Markdown. Since the Markdown is generated _from_ the JSDoc, it makes more sense for them to be taken to the actual JS file.