### PR TITLE
fix: support 'status' and 'statusMatrix' on empty branches

### DIFF
--- a/__tests__/test-status.js
+++ b/__tests__/test-status.js
@@ -63,4 +63,17 @@ describe('status', () => {
     expect(h).toEqual('ignored')
     expect(i).toEqual('*added')
   })
+
+  it('status in an fresh git repo with no commits', async () => {
+    // Setup
+    let { fs, dir, gitdir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'a.txt'), 'Hi')
+    await fs.write(path.join(dir, 'b.txt'), 'Hi')
+    await add({ dir, gitdir, filepath: 'b.txt' })
+    // Test
+    const a = await status({ dir, gitdir, filepath: 'a.txt' })
+    expect(a).toEqual('*added')
+    const b = await status({ dir, gitdir, filepath: 'b.txt' })
+    expect(b).toEqual('added')
+  })
 })

--- a/__tests__/test-statusMatrix.js
+++ b/__tests__/test-statusMatrix.js
@@ -46,4 +46,17 @@ describe('statusMatrix', () => {
     matrix = await statusMatrix({ dir, gitdir, pattern: 'e.txt' })
     expect(matrix).toEqual([['e.txt', 0, 0, 3]])
   })
+
+  it('statusMatrix in an fresh git repo with no commits', async () => {
+    // Setup
+    let { fs, dir, gitdir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'a.txt'), 'Hi')
+    await fs.write(path.join(dir, 'b.txt'), 'Hi')
+    await add({ dir, gitdir, filepath: 'b.txt' })
+    // Test
+    let a = await statusMatrix({ dir, gitdir, pattern: 'a.txt' })
+    expect(a).toEqual([['a.txt', 0, 2, 0]])
+    const b = await statusMatrix({ dir, gitdir, pattern: 'b.txt' })
+    expect(b).toEqual([['b.txt', 0, 2, 2]])
+  })
 })

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -197,7 +197,15 @@ async function getOidAtPath ({ fs, gitdir, tree, path }) {
 
 async function getHeadTree ({ fs, gitdir }) {
   // Get the tree from the HEAD commit.
-  let oid = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
+  let oid
+  try {
+    oid = await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })
+  } catch (e) {
+    // Handle fresh branches with no commits
+    if (e.code === E.ResolveRefError) {
+      return []
+    }
+  }
   let { type, object } = await readObject({ fs, gitdir, oid })
   if (type !== 'commit') {
     throw new GitError(E.ResolveCommitError, { oid })

--- a/src/models/GitWalkerRepo.js
+++ b/src/models/GitWalkerRepo.js
@@ -2,6 +2,7 @@ import { GitRefManager } from '../managers/GitRefManager.js'
 import { readObject } from '../storage/readObject.js'
 import { join } from '../utils/join'
 import { resolveTree } from '../utils/resolveTree.js'
+import { E } from '../models/GitError.js'
 
 import { FileSystem } from './FileSystem.js'
 import { GitTree } from './GitTree.js'
@@ -13,7 +14,15 @@ export class GitWalkerRepo {
     this.gitdir = gitdir
     this.mapPromise = (async () => {
       let map = new Map()
-      let oid = await GitRefManager.resolve({ fs, gitdir, ref })
+      let oid
+      try {
+        oid = await GitRefManager.resolve({ fs, gitdir, ref })
+      } catch (e) {
+        // Handle fresh branches with no commits
+        if (e.code === E.ResolveRefError) {
+          oid = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        }
+      }
       let tree = await resolveTree({ fs, gitdir, oid })
       map.set('.', tree)
       return map

--- a/src/models/GitWalkerRepo.js
+++ b/src/models/GitWalkerRepo.js
@@ -1,8 +1,8 @@
 import { GitRefManager } from '../managers/GitRefManager.js'
+import { E } from '../models/GitError.js'
 import { readObject } from '../storage/readObject.js'
 import { join } from '../utils/join'
 import { resolveTree } from '../utils/resolveTree.js'
-import { E } from '../models/GitError.js'
 
 import { FileSystem } from './FileSystem.js'
 import { GitTree } from './GitTree.js'

--- a/src/storage/readObject.js
+++ b/src/storage/readObject.js
@@ -13,8 +13,17 @@ export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) 
   // process can acquire external ref-deltas.
   const getExternalRefDelta = oid => readObject({ fs, gitdir, oid })
 
+  let result
+  // Empty tree - hard-coded so we can use it as a shorthand.
+  // Note: I think the canonical git implementation must do this too because
+  // `git cat-file -t 4b825dc642cb6eb9a060e54bf8d69288fbee4904` prints "tree" even in empty repos.
+  if (oid === '4b825dc642cb6eb9a060e54bf8d69288fbee4904') {
+    result = { format: 'wrapped', object: Buffer.from(`tree 0\x00`) }
+  }
   // Look for it in the loose object directory.
-  let result = await readObjectLoose({ fs, gitdir, oid })
+  if (!result) {
+    result = await readObjectLoose({ fs, gitdir, oid })
+  }
   // Check to see if it's in a packfile.
   if (!result) {
     result = await readObjectPacked({ fs, gitdir, oid, getExternalRefDelta })
@@ -23,16 +32,18 @@ export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) 
   if (!result) {
     throw new GitError(E.ReadObjectFail, { oid })
   }
+
   if (format === 'deflated') {
     return result
   }
+
   // BEHOLD! THE ONLY TIME I'VE EVER WANTED TO USE A CASE STATEMENT WITH FOLLOWTHROUGH!
   // eslint-ignore
   /* eslint-disable no-fallthrough */
   switch (result.format) {
     case 'deflated':
-      let buffer = Buffer.from(pako.inflate(result.object))
-      result = { format: 'wrapped', object: buffer, source: result.source }
+      result.object = Buffer.from(pako.inflate(result.object))
+      result.format = 'wrapped'
     case 'wrapped':
       if (format === 'wrapped' && result.format === 'wrapped') {
         return result
@@ -43,8 +54,10 @@ export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) 
           message: `SHA check failed! Expected ${oid}, computed ${sha}`
         })
       }
-      let { object, type } = GitObject.unwrap(buffer)
-      result = { type, format: 'content', object, source: result.source }
+      let { object, type } = GitObject.unwrap(result.object)
+      result.type = type
+      result.object = object
+      result.format = 'content'
     case 'content':
       if (format === 'content') return result
       break

--- a/src/utils/resolveTree.js
+++ b/src/utils/resolveTree.js
@@ -5,6 +5,10 @@ import { GitTree } from '../models/GitTree.js'
 import { readObject } from '../storage/readObject.js'
 
 export async function resolveTree ({ fs, gitdir, oid }) {
+  // Empty tree - bypass `readObject`
+  if (oid === '4b825dc642cb6eb9a060e54bf8d69288fbee4904') {
+    return { tree: GitTree.from([]), oid }
+  }
   let { type, object } = await readObject({ fs, gitdir, oid })
   // Resolve annotated tag objects to whatever
   if (type === 'tag') {


### PR DESCRIPTION
close #669