### PR TITLE
fix: remove 'ExperimentalWarning: The fs.promises API is experimental'

### DIFF
--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -17,7 +17,7 @@ export class FileSystem {
       throw new GitError(E.PluginUndefined, { plugin: 'fs' })
     }
     if (typeof fs._readFile !== 'undefined') return fs
-    if (fs.promises) {
+    if (Object.getOwnPropertyDescriptor(fs, 'promises') && Object.getOwnPropertyDescriptor(fs, 'promises').enumerable) {
       this._readFile = fs.promises.readFile.bind(fs.promises)
       this._writeFile = fs.promises.writeFile.bind(fs.promises)
       this._mkdir = fs.promises.mkdir.bind(fs.promises)

--- a/src/utils/plugins.js
+++ b/src/utils/plugins.js
@@ -14,7 +14,7 @@ class PluginCore extends Map {
   set (key, value) {
     const verifySchema = (key, value) => {
       // ugh. this sucks
-      if (key === 'fs' && value.promises) {
+      if (key === 'fs' && Object.getOwnPropertyDescriptor(value, 'promises') && Object.getOwnPropertyDescriptor(value, 'promises').enumerable) {
         value = value.promises
       }
       const pluginSchemas = {


### PR DESCRIPTION
fixes #771

## Before
```js
> node
> require('.').plugins.set('fs', require('fs'))
undefined
> (node:8427) ExperimentalWarning: The fs.promises API is experimental

(To exit, press ^C again or type .exit)
>
```

## After
```js
> node
> require('.').plugins.set('fs', require('fs'))
undefined
>
(To exit, press ^C again or type .exit)
>
```
---
This exploits the fact that there is a subtle difference between how `fs.promises` is exposed in v10 (which prints a warning) and v12 (which does not)

v10
```js
> Object.getOwnPropertyDescriptor(fs, 'promises')
{ get: [Function: get],
  set: undefined,
  enumerable: false,
  configurable: true }
```

v12
```js
> Object.getOwnPropertyDescriptor(fs, 'promises')
{
  get: [Function: get],
  set: undefined,
  enumerable: true,
  configurable: true
}
```

LightningFS
```js
> Object.getOwnPropertyDescriptor(fs, 'promises')
{value: t.exports, writable: true, enumerable: true, configurable: true}
```