### PR TITLE
feat: Added 'dryRun' parameter to merge command

### DIFF
--- a/__tests__/test-merge.js
+++ b/__tests__/test-merge.js
@@ -96,4 +96,33 @@ describe('merge', () => {
     })
     expect(oid).toEqual(desiredOid)
   })
+
+  it('merge newest into master --dryRun', async () => {
+    // Setup
+    let { gitdir } = await makeFixture('test-merge')
+    // Test
+    let originalOid = await resolveRef({
+      gitdir,
+      ref: 'master'
+    })
+    let desiredOid = await resolveRef({
+      gitdir,
+      ref: 'newest'
+    })
+    let m = await merge({
+      gitdir,
+      ours: 'master',
+      theirs: 'newest',
+      fastForwardOnly: true,
+      dryRun: true
+    })
+    expect(m.oid).toEqual(desiredOid)
+    expect(m.alreadyMerged).toBeFalsy()
+    expect(m.fastForward).toBeTruthy()
+    let oid = await resolveRef({
+      gitdir,
+      ref: 'master'
+    })
+    expect(oid).toEqual(originalOid)
+  })
 })

--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -47,7 +47,7 @@ export async function merge ({
   ours,
   theirs,
   fastForwardOnly = false,
-  dryRun = false,
+  dryRun = false
 }) {
   try {
     const fs = new FileSystem(_fs)

--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -29,6 +29,7 @@ import { log } from './log'
  * @param {string} [args.ours] - The branch receiving the merge. If undefined, defaults to the current branch.
  * @param {string} args.theirs - The branch to be merged
  * @param {boolean} [args.fastForwardOnly = false] - If true, then non-fast-forward merges will throw an Error instead of performing a merge.
+ * @param {boolean} [args.dryRun = false] - If true, simulates a merge so you can test whether it would succeed.
  *
  * @returns {Promise<MergeReport>} Resolves to a description of the merge operation
  * @see MergeReport
@@ -45,7 +46,8 @@ export async function merge ({
   fs: _fs = cores.get(core).get('fs'),
   ours,
   theirs,
-  fastForwardOnly
+  fastForwardOnly = false,
+  dryRun = false,
 }) {
   try {
     const fs = new FileSystem(_fs)
@@ -82,7 +84,9 @@ export async function merge ({
       }
     }
     if (baseOid === ourOid) {
-      await GitRefManager.writeRef({ fs, gitdir, ref: ours, value: theirOid })
+      if (!dryRun) {
+        await GitRefManager.writeRef({ fs, gitdir, ref: ours, value: theirOid })
+      }
       return {
         oid: theirOid,
         fastForward: true

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -480,6 +480,7 @@ export function merge(args: GitDir & {
   ours?: string;
   theirs: string;
   fastForwardOnly?: boolean;
+  dryRun?: boolean;
 }): Promise<MergeReport>;
 
 export function packObjects(args: GitDir & {

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -17,7 +17,10 @@ export class FileSystem {
       throw new GitError(E.PluginUndefined, { plugin: 'fs' })
     }
     if (typeof fs._readFile !== 'undefined') return fs
-    if (Object.getOwnPropertyDescriptor(fs, 'promises') && Object.getOwnPropertyDescriptor(fs, 'promises').enumerable) {
+    if (
+      Object.getOwnPropertyDescriptor(fs, 'promises') &&
+      Object.getOwnPropertyDescriptor(fs, 'promises').enumerable
+    ) {
       this._readFile = fs.promises.readFile.bind(fs.promises)
       this._writeFile = fs.promises.writeFile.bind(fs.promises)
       this._mkdir = fs.promises.mkdir.bind(fs.promises)

--- a/src/utils/plugins.js
+++ b/src/utils/plugins.js
@@ -14,7 +14,11 @@ class PluginCore extends Map {
   set (key, value) {
     const verifySchema = (key, value) => {
       // ugh. this sucks
-      if (key === 'fs' && Object.getOwnPropertyDescriptor(value, 'promises') && Object.getOwnPropertyDescriptor(value, 'promises').enumerable) {
+      if (
+        key === 'fs' &&
+        Object.getOwnPropertyDescriptor(value, 'promises') &&
+        Object.getOwnPropertyDescriptor(value, 'promises').enumerable
+      ) {
         value = value.promises
       }
       const pluginSchemas = {


### PR DESCRIPTION

## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
