### PR TITLE
perf: cache .git/index for better performance

### DIFF
--- a/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
@@ -32,10 +32,10 @@ async function makeBrowserFS (dir) {
     browserFSwritable.empty()
 
     const core = `core-browserfs-${i++}`
-    cores.create(core).set('fs', { ..._fs })
+    cores.create(core).set('fs', Object.assign({}, _fs))
     plugins.set('fs', _fs) // deprecated
 
-    const fs = new FileSystem({ ..._fs })
+    const fs = new FileSystem(Object.assign({}, _fs))
 
     dir = `/${dir}`
     let gitdir = `/${dir}.git`

--- a/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
@@ -28,14 +28,14 @@ async function makeBrowserFS (dir) {
       browserFS = BrowserFS.BFSRequire('fs')
       browserFSwritable = writable
     }
-    const _fs = browserFS
+    const _fs = Object.assign({}, browserFS)
     browserFSwritable.empty()
 
     const core = `core-browserfs-${i++}`
-    cores.create(core).set('fs', Object.assign({}, _fs))
+    cores.create(core).set('fs', _fs)
     plugins.set('fs', _fs) // deprecated
 
-    const fs = new FileSystem(Object.assign({}, _fs))
+    const fs = new FileSystem(_fs)
 
     dir = `/${dir}`
     let gitdir = `/${dir}.git`

--- a/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
@@ -3,7 +3,7 @@ const pify = require('pify')
 const { cores, plugins } = require('isomorphic-git')
 const { FileSystem } = require('isomorphic-git/internal-apis')
 
-let i = 0;
+let i = 0
 
 let browserFS = null
 let browserFSwritable = null
@@ -32,10 +32,10 @@ async function makeBrowserFS (dir) {
     browserFSwritable.empty()
 
     const core = `core-browserfs-${i++}`
-    cores.create(core).set('fs', {..._fs})
+    cores.create(core).set('fs', { ..._fs })
     plugins.set('fs', _fs) // deprecated
 
-    const fs = new FileSystem({..._fs})
+    const fs = new FileSystem({ ..._fs })
 
     dir = `/${dir}`
     let gitdir = `/${dir}.git`

--- a/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
@@ -1,7 +1,9 @@
 const pify = require('pify')
 
-const { plugins } = require('isomorphic-git')
+const { cores, plugins } = require('isomorphic-git')
 const { FileSystem } = require('isomorphic-git/internal-apis')
+
+let i = 0;
 
 let browserFS = null
 let browserFSwritable = null
@@ -28,8 +30,13 @@ async function makeBrowserFS (dir) {
     }
     const _fs = browserFS
     browserFSwritable.empty()
-    plugins.set('fs', _fs)
-    const fs = new FileSystem(_fs)
+
+    const core = `core-browserfs-${i++}`
+    cores.create(core).set('fs', {..._fs})
+    plugins.set('fs', _fs) // deprecated
+
+    const fs = new FileSystem({..._fs})
+
     dir = `/${dir}`
     let gitdir = `/${dir}.git`
     await fs.mkdir(dir)
@@ -38,7 +45,8 @@ async function makeBrowserFS (dir) {
       _fs,
       fs,
       dir,
-      gitdir
+      gitdir,
+      core
     }
   }
 }

--- a/__tests__/__helpers__/FixtureFS/makeLightningFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeLightningFS.js
@@ -1,5 +1,7 @@
-const { plugins } = require('isomorphic-git')
+const { cores, plugins } = require('isomorphic-git')
 const { FileSystem } = require('isomorphic-git/internal-apis')
+
+let i = 0;
 
 async function makeLightningFS (dir) {
   const FS = require('@isomorphic-git/lightning-fs')
@@ -7,13 +9,15 @@ async function makeLightningFS (dir) {
     wipe: true,
     url: 'http://localhost:9876/base/__tests__/__fixtures__'
   })
-  plugins.set('fs', { promises: _fs.promises })
-  const fs = new FileSystem(_fs)
+  const core = `core-lightningfs-${i++}`
+  cores.create(core).set('fs', {..._fs})
+  plugins.set('fs', {..._fs}) // deprecated
+  const fs = new FileSystem({..._fs})
   dir = `/${dir}`
   let gitdir = `/${dir}.git`
   await fs.mkdir(dir)
   await fs.mkdir(gitdir)
-  return { _fs, fs, dir, gitdir }
+  return { _fs, fs, dir, gitdir, core }
 }
 
 module.exports.makeLightningFS = makeLightningFS

--- a/__tests__/__helpers__/FixtureFS/makeLightningFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeLightningFS.js
@@ -10,9 +10,9 @@ async function makeLightningFS (dir) {
     url: 'http://localhost:9876/base/__tests__/__fixtures__'
   })
   const core = `core-lightningfs-${i++}`
-  cores.create(core).set('fs', Object.assign({}, _fs))
-  plugins.set('fs', Object.assign({}, _fs)) // deprecated
-  const fs = new FileSystem(Object.assign({}, _fs))
+  cores.create(core).set('fs', _fs)
+  plugins.set('fs', _fs) // deprecated
+  const fs = new FileSystem(_fs)
   dir = `/${dir}`
   let gitdir = `/${dir}.git`
   await fs.mkdir(dir)

--- a/__tests__/__helpers__/FixtureFS/makeLightningFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeLightningFS.js
@@ -10,9 +10,9 @@ async function makeLightningFS (dir) {
     url: 'http://localhost:9876/base/__tests__/__fixtures__'
   })
   const core = `core-lightningfs-${i++}`
-  cores.create(core).set('fs', { ..._fs })
-  plugins.set('fs', { ..._fs }) // deprecated
-  const fs = new FileSystem({ ..._fs })
+  cores.create(core).set('fs', Object.assign({}, _fs))
+  plugins.set('fs', Object.assign({}, _fs)) // deprecated
+  const fs = new FileSystem(Object.assign({}, _fs))
   dir = `/${dir}`
   let gitdir = `/${dir}.git`
   await fs.mkdir(dir)

--- a/__tests__/__helpers__/FixtureFS/makeLightningFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeLightningFS.js
@@ -1,7 +1,7 @@
 const { cores, plugins } = require('isomorphic-git')
 const { FileSystem } = require('isomorphic-git/internal-apis')
 
-let i = 0;
+let i = 0
 
 async function makeLightningFS (dir) {
   const FS = require('@isomorphic-git/lightning-fs')
@@ -10,9 +10,9 @@ async function makeLightningFS (dir) {
     url: 'http://localhost:9876/base/__tests__/__fixtures__'
   })
   const core = `core-lightningfs-${i++}`
-  cores.create(core).set('fs', {..._fs})
-  plugins.set('fs', {..._fs}) // deprecated
-  const fs = new FileSystem({..._fs})
+  cores.create(core).set('fs', { ..._fs })
+  plugins.set('fs', { ..._fs }) // deprecated
+  const fs = new FileSystem({ ..._fs })
   dir = `/${dir}`
   let gitdir = `/${dir}.git`
   await fs.mkdir(dir)

--- a/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
+++ b/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
@@ -1,25 +1,35 @@
 const path = require('path')
 
-const { plugins } = require('isomorphic-git')
+const { cores, plugins } = require('isomorphic-git')
 const { FileSystem } = require('isomorphic-git/internal-apis')
+
+let i = 0;
 
 async function makeNodeFixture (fixture) {
   const _fs = require('fs')
-  plugins.set('fs', _fs)
-  const fs = new FileSystem(_fs)
+  const core = `core-node-${i++}`
+  cores.create(core).set('fs', _fs)
+  plugins.set('fs', _fs) // deprecated
+  
+  const fs = new FileSystem({..._fs})
+
   const {
     getFixturePath,
     createTempDir,
     copyFixtureIntoTempDir
   } = require('jest-fixtures')
+
   let testsDir = path.resolve(__dirname, '..')
+
   let dir = (await getFixturePath(testsDir, fixture))
     ? await copyFixtureIntoTempDir(testsDir, fixture)
     : await createTempDir()
+
   let gitdir = (await getFixturePath(testsDir, `${fixture}.git`))
     ? await copyFixtureIntoTempDir(testsDir, `${fixture}.git`)
     : await createTempDir()
-  return { _fs, fs, dir, gitdir }
+
+  return { _fs, fs, dir, gitdir, core }
 }
 
 module.exports.makeNodeFixture = makeNodeFixture

--- a/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
+++ b/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
@@ -3,15 +3,15 @@ const path = require('path')
 const { cores, plugins } = require('isomorphic-git')
 const { FileSystem } = require('isomorphic-git/internal-apis')
 
-let i = 0;
+let i = 0
 
 async function makeNodeFixture (fixture) {
   const _fs = require('fs')
   const core = `core-node-${i++}`
   cores.create(core).set('fs', _fs)
   plugins.set('fs', _fs) // deprecated
-  
-  const fs = new FileSystem({..._fs})
+
+  const fs = new FileSystem({ ..._fs })
 
   const {
     getFixturePath,

--- a/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
+++ b/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
@@ -8,10 +8,10 @@ let i = 0
 async function makeNodeFixture (fixture) {
   const _fs = require('fs')
   const core = `core-node-${i++}`
-  cores.create(core).set('fs', _fs)
-  plugins.set('fs', _fs) // deprecated
-
-  const fs = new FileSystem({ ..._fs })
+  cores.create(core).set('fs', Object.assign({}, _fs))
+  plugins.set('fs', Object.assign({}, _fs)) // deprecated
+  
+  const fs = new FileSystem(Object.assign({}, _fs))
 
   const {
     getFixturePath,

--- a/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
+++ b/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
@@ -6,12 +6,12 @@ const { FileSystem } = require('isomorphic-git/internal-apis')
 let i = 0
 
 async function makeNodeFixture (fixture) {
-  const _fs = require('fs')
+  const _fs = Object.assign({}, require('fs'))
   const core = `core-node-${i++}`
-  cores.create(core).set('fs', Object.assign({}, _fs))
-  plugins.set('fs', Object.assign({}, _fs)) // deprecated
+  cores.create(core).set('fs', _fs)
+  plugins.set('fs', _fs) // deprecated
   
-  const fs = new FileSystem(Object.assign({}, _fs))
+  const fs = new FileSystem(_fs)
 
   const {
     getFixturePath,

--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -13,35 +13,35 @@ const writeGitIgnore = async (fs, dir) =>
 describe('add', () => {
   it('file', async () => {
     // Setup
-    let { dir } = await makeFixture('test-add')
+    let { core, dir } = await makeFixture('test-add')
     // Test
-    await init({ dir })
-    await add({ dir, filepath: 'a.txt' })
-    expect((await listFiles({ dir })).length).toEqual(1)
-    await add({ dir, filepath: 'a.txt' })
-    expect((await listFiles({ dir })).length).toEqual(1)
-    await add({ dir, filepath: 'a-copy.txt' })
-    expect((await listFiles({ dir })).length).toEqual(2)
-    await add({ dir, filepath: 'b.txt' })
-    expect((await listFiles({ dir })).length).toEqual(3)
+    await init({ core, dir })
+    await add({ core, dir, filepath: 'a.txt' })
+    expect((await listFiles({ core, dir })).length).toEqual(1)
+    await add({ core, dir, filepath: 'a.txt' })
+    expect((await listFiles({ core, dir })).length).toEqual(1)
+    await add({ core, dir, filepath: 'a-copy.txt' })
+    expect((await listFiles({ core, dir })).length).toEqual(2)
+    await add({ core, dir, filepath: 'b.txt' })
+    expect((await listFiles({ core, dir })).length).toEqual(3)
   })
   it('ignored file', async () => {
     // Setup
-    let { fs, dir } = await makeFixture('test-add')
+    let { fs, core, dir } = await makeFixture('test-add')
     await writeGitIgnore(fs, dir)
     // Test
-    await init({ dir })
-    await add({ dir, filepath: 'i.txt' })
-    expect((await listFiles({ dir })).length).toEqual(0)
+    await init({ core, dir })
+    await add({ core, dir, filepath: 'i.txt' })
+    expect((await listFiles({ core, dir })).length).toEqual(0)
   })
   it('non-existant file', async () => {
     // Setup
-    let { dir } = await makeFixture('test-add')
+    let { core, dir } = await makeFixture('test-add')
     // Test
-    await init({ dir })
+    await init({ core, dir })
     let err = null
     try {
-      await add({ dir, filepath: 'asdf.txt' })
+      await add({ core, dir, filepath: 'asdf.txt' })
     } catch (e) {
       err = e
     }
@@ -49,31 +49,31 @@ describe('add', () => {
   })
   it('folder', async () => {
     // Setup
-    let { dir } = await makeFixture('test-add')
+    let { core, dir } = await makeFixture('test-add')
     // Test
-    await init({ dir })
-    expect((await listFiles({ dir })).length).toEqual(0)
-    await add({ dir, filepath: 'c' })
-    expect((await listFiles({ dir })).length).toEqual(4)
+    await init({ core, dir })
+    expect((await listFiles({ core, dir })).length).toEqual(0)
+    await add({ core, dir, filepath: 'c' })
+    expect((await listFiles({ core, dir })).length).toEqual(4)
   })
   it('folder with .gitignore', async () => {
     // Setup
-    let { fs, dir } = await makeFixture('test-add')
+    let { fs, core, dir } = await makeFixture('test-add')
     await writeGitIgnore(fs, dir)
     // Test
-    await init({ dir })
-    expect((await listFiles({ dir })).length).toEqual(0)
-    await add({ dir, filepath: 'c' })
-    expect((await listFiles({ dir })).length).toEqual(3)
+    await init({ core, dir })
+    expect((await listFiles({ core, dir })).length).toEqual(0)
+    await add({ core, dir, filepath: 'c' })
+    expect((await listFiles({ core, dir })).length).toEqual(3)
   })
   it('git add .', async () => {
     // Setup
-    let { fs, dir } = await makeFixture('test-add')
+    let { fs, core, dir } = await makeFixture('test-add')
     await writeGitIgnore(fs, dir)
     // Test
-    await init({ dir })
-    expect((await listFiles({ dir })).length).toEqual(0)
-    await add({ dir, filepath: '.' })
-    expect((await listFiles({ dir })).length).toEqual(7)
+    await init({ core, dir })
+    expect((await listFiles({ core, dir })).length).toEqual(0)
+    await add({ core, dir, filepath: '.' })
+    expect((await listFiles({ core, dir })).length).toEqual(7)
   })
 })

--- a/__tests__/test-unicode-paths.js
+++ b/__tests__/test-unicode-paths.js
@@ -15,33 +15,34 @@ const {
 describe('unicode filepath support', () => {
   it('write/read index 日本語', async () => {
     // Setup
-    let { dir, gitdir } = await makeFixture('test-unicode-paths')
-    await init({ dir, gitdir })
+    let { core, dir, gitdir } = await makeFixture('test-unicode-paths')
+    await init({ core, dir, gitdir })
     // Test
-    await add({ dir, gitdir, filepath: '日本語' })
-    expect((await listFiles({ dir, gitdir }))[0]).toBe('日本語')
-    await remove({ dir, gitdir, filepath: '日本語' })
-    expect((await listFiles({ dir, gitdir })).length).toBe(0)
+    await add({ core, dir, gitdir, filepath: '日本語' })
+    expect((await listFiles({ core, dir, gitdir }))[0]).toBe('日本語')
+    await remove({ core, dir, gitdir, filepath: '日本語' })
+    expect((await listFiles({ core, dir, gitdir })).length).toBe(0)
   })
   it('write/read index docs/日本語', async () => {
     // Setup
-    let { fs, dir, gitdir } = await makeFixture('test-unicode-paths')
-    await init({ dir, gitdir })
+    let { fs, core, dir, gitdir } = await makeFixture('test-unicode-paths')
+    await init({ core, dir, gitdir })
     // Test
     await fs.mkdir(path.join(dir, 'docs'))
     await fs.write(path.join(dir, 'docs/日本語'), '')
-    await add({ dir, gitdir, filepath: 'docs/日本語' })
-    expect((await listFiles({ dir, gitdir }))[0]).toBe('docs/日本語')
-    await remove({ dir, gitdir, filepath: 'docs/日本語' })
-    expect((await listFiles({ dir, gitdir })).length).toBe(0)
+    await add({ core, dir, gitdir, filepath: 'docs/日本語' })
+    expect((await listFiles({ core, dir, gitdir }))[0]).toBe('docs/日本語')
+    await remove({ core, dir, gitdir, filepath: 'docs/日本語' })
+    expect((await listFiles({ core, dir, gitdir })).length).toBe(0)
   })
   it('write/read commit 日本語', async () => {
     // Setup
-    let { dir, gitdir } = await makeFixture('test-unicode-paths')
-    await init({ dir, gitdir })
-    await add({ dir, gitdir, filepath: '日本語' })
+    let { core, dir, gitdir } = await makeFixture('test-unicode-paths')
+    await init({ core, dir, gitdir })
+    await add({ core, dir, gitdir, filepath: '日本語' })
     // Test
     let sha = await commit({
+      core,
       dir,
       gitdir,
       author: {
@@ -53,17 +54,18 @@ describe('unicode filepath support', () => {
       message: '日本語'
     })
     // Check GitCommit object
-    let { object: comm } = await readObject({ dir, gitdir, oid: sha })
+    let { object: comm } = await readObject({ core, dir, gitdir, oid: sha })
     expect(comm.author.name).toBe('日本語')
     expect(comm.author.email).toBe('日本語@example.com')
     expect(comm.message).toBe('日本語\n')
   })
   it('write/read tree 日本語', async () => {
     // Setup
-    let { dir, gitdir } = await makeFixture('test-unicode-paths')
-    await init({ dir, gitdir })
-    await add({ dir, gitdir, filepath: '日本語' })
+    let { core, dir, gitdir } = await makeFixture('test-unicode-paths')
+    await init({ core, dir, gitdir })
+    await add({ core, dir, gitdir, filepath: '日本語' })
     let sha = await commit({
+      core,
       dir,
       gitdir,
       author: {
@@ -74,18 +76,19 @@ describe('unicode filepath support', () => {
       },
       message: '日本語'
     })
-    let { object: comm } = await readObject({ dir, gitdir, oid: sha })
+    let { object: comm } = await readObject({ core, dir, gitdir, oid: sha })
     // Test
     // Check GitTree object
-    let { object: tree } = await readObject({ dir, gitdir, oid: comm.tree })
+    let { object: tree } = await readObject({ core, dir, gitdir, oid: comm.tree })
     expect(tree.entries[0].path).toBe('日本語')
   })
   it('checkout 日本語', async () => {
     // Setup
-    let { dir, gitdir } = await makeFixture('test-unicode-paths')
-    await init({ dir, gitdir })
-    await add({ dir, gitdir, filepath: '日本語' })
+    let { core, dir, gitdir } = await makeFixture('test-unicode-paths')
+    await init({ core, dir, gitdir })
+    await add({ core, dir, gitdir, filepath: '日本語' })
     await commit({
+      core,
       dir,
       gitdir,
       author: {
@@ -96,20 +99,21 @@ describe('unicode filepath support', () => {
       },
       message: '日本語'
     })
-    await remove({ dir, gitdir, filepath: '日本語' })
+    await remove({ core, dir, gitdir, filepath: '日本語' })
     // Test
     // Check GitIndex object
-    await checkout({ dir, gitdir, ref: 'HEAD' })
-    expect((await listFiles({ dir, gitdir }))[0]).toBe('日本語')
+    await checkout({ core, dir, gitdir, ref: 'HEAD' })
+    expect((await listFiles({ core, dir, gitdir }))[0]).toBe('日本語')
   })
   it('checkout docs/日本語', async () => {
     // Setup
-    let { fs, dir, gitdir } = await makeFixture('test-unicode-paths')
+    let { fs, core, dir, gitdir } = await makeFixture('test-unicode-paths')
     await fs.mkdir(path.join(dir, 'docs'))
     await fs.write(path.join(dir, 'docs/日本語'), '')
-    await init({ dir, gitdir })
-    await add({ dir, gitdir, filepath: 'docs/日本語' })
+    await init({ core, dir, gitdir })
+    await add({ core, dir, gitdir, filepath: 'docs/日本語' })
     await commit({
+      core,
       dir,
       gitdir,
       author: {
@@ -120,10 +124,10 @@ describe('unicode filepath support', () => {
       },
       message: '日本語'
     })
-    await remove({ dir, gitdir, filepath: 'docs/日本語' })
+    await remove({ core, dir, gitdir, filepath: 'docs/日本語' })
     // Test
     // Check GitIndex object
-    await checkout({ dir, gitdir, ref: 'HEAD' })
-    expect((await listFiles({ dir, gitdir }))[0]).toBe('docs/日本語')
+    await checkout({ core, dir, gitdir, ref: 'HEAD' })
+    expect((await listFiles({ core, dir, gitdir }))[0]).toBe('docs/日本語')
   })
 })

--- a/__tests__/test-unicode-paths.js
+++ b/__tests__/test-unicode-paths.js
@@ -79,7 +79,12 @@ describe('unicode filepath support', () => {
     let { object: comm } = await readObject({ core, dir, gitdir, oid: sha })
     // Test
     // Check GitTree object
-    let { object: tree } = await readObject({ core, dir, gitdir, oid: comm.tree })
+    let { object: tree } = await readObject({
+      core,
+      dir,
+      gitdir,
+      oid: comm.tree
+    })
     expect(tree.entries[0].path).toBe('日本語')
   })
   it('checkout 日本語', async () => {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,6 @@ jobs:
       SAUCE_ACCESS_KEY: $(SAUCE_ACCESS_KEY)
       SAUCE_USERNAME: $(SAUCE_USERNAME)
       TEST_BROWSERS: 'ChromeHeadlessNoSandbox,FirefoxHeadless,sl_edge,sl_ios_safari,sl_safari,sl_android_chrome'
-      ENABLE_LIGHTNINGFS: 'true'
 
   - task: PublishTestResults@2
     displayName: 'Save test results'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -151,9 +151,7 @@ module.exports = function (config) {
         new webpack.DefinePlugin({
           'process.env.TEST_PUSH_GITHUB_TOKEN': `'${
             process.env.TEST_PUSH_GITHUB_TOKEN
-          }'`,
-          'process.env.ENABLE_LIGHTNINGFS': `${!!process.env
-            .ENABLE_LIGHTNINGFS}`
+          }'`
         })
       ],
       resolve: {

--- a/src/managers/GitIndexManager.js
+++ b/src/managers/GitIndexManager.js
@@ -3,47 +3,62 @@ import AsyncLock from 'async-lock'
 
 import { FileSystem } from '../models/FileSystem.js'
 import { GitIndex } from '../models/GitIndex.js'
+import { compareStats } from '../utils/compareStats.js'
+import { DeepMap } from '../utils/DeepMap.js'
 
 // import Lock from '../utils.js'
 
 // TODO: replace with an LRU cache?
-const map = new Map()
+const map = new DeepMap()
+const stats = new DeepMap()
 // const lm = new LockManager()
 let lock = null
+
+async function updateCachedIndexFile (fs, filepath) {
+  const stat = await fs.lstat(filepath)
+  const rawIndexFile = await fs.read(filepath)
+  const index = GitIndex.from(rawIndexFile)
+  // cache the GitIndex object so we don't need to re-read it
+  // every time.
+  map.set([fs, filepath], index)
+  // Save the stat data for the index so we know whether
+  // the cached file is stale (modified by an outside process).
+  stats.set([fs, filepath], stat)
+}
+
+// Determine whether our copy of the index file is stale
+async function isIndexStale (fs, filepath) {
+  const savedStats = stats.get([fs, filepath])
+  if (savedStats === undefined) return true
+  const currStats = await fs.lstat(filepath)
+  if (savedStats === null) return false
+  if (currStats === null) return false
+  return compareStats(savedStats, currStats)
+}
 
 export class GitIndexManager {
   static async acquire ({ fs: _fs, filepath }, closure) {
     const fs = new FileSystem(_fs)
     if (lock === null) lock = new AsyncLock({ maxPending: Infinity })
     await lock.acquire(filepath, async function () {
-      let index = map.get(filepath)
-      if (index === undefined) {
-        // Acquire a file lock while we're reading the index
-        // to make sure other processes aren't writing to it
-        // simultaneously, which could result in a corrupted index.
-        // const fileLock = await Lock(filepath)
-        const rawIndexFile = await fs.read(filepath)
-        index = GitIndex.from(rawIndexFile)
-        // cache the GitIndex object so we don't need to re-read it
-        // every time.
-        // TODO: save the stat data for the index so we know whether
-        // the cached file is stale (modified by an outside process).
-        map.set(filepath, index)
-        // await fileLock.cancel()
+      // Acquire a file lock while we're reading the index
+      // to make sure other processes aren't writing to it
+      // simultaneously, which could result in a corrupted index.
+      // const fileLock = await Lock(filepath)
+      if (await isIndexStale(fs, filepath)) {
+        await updateCachedIndexFile(fs, filepath)
       }
+      let index = map.get([fs, filepath])
       await closure(index)
       if (index._dirty) {
         // Acquire a file lock while we're writing the index file
         // let fileLock = await Lock(filepath)
         const buffer = index.toObject()
         await fs.write(filepath, buffer)
+        // Update cached stat value
+        stats.set([fs, filepath], await fs.lstat(filepath))
         index._dirty = false
       }
-      // For now, discard our cached object so that external index
-      // manipulation is picked up. TODO: use lstat and compare
-      // file times to determine if our cached object should be
-      // discarded.
-      map.delete(filepath)
     })
   }
 }

--- a/src/managers/GitIndexManager.js
+++ b/src/managers/GitIndexManager.js
@@ -3,8 +3,8 @@ import AsyncLock from 'async-lock'
 
 import { FileSystem } from '../models/FileSystem.js'
 import { GitIndex } from '../models/GitIndex.js'
-import { compareStats } from '../utils/compareStats.js'
 import { DeepMap } from '../utils/DeepMap.js'
+import { compareStats } from '../utils/compareStats.js'
 
 // import Lock from '../utils.js'
 

--- a/src/utils/DeepMap.js
+++ b/src/utils/DeepMap.js
@@ -1,0 +1,28 @@
+const deepget = (keys, map) => {
+  for (let key of keys) {
+    if (!map.has(key)) map.set(key, new Map())
+    map = map.get(key)
+  }
+  return map
+}
+
+export class DeepMap {
+  constructor () {
+    this._root = new Map()
+  }
+  set (keys, value) {
+    let lastKey = keys.pop()
+    let lastMap = deepget(keys, this._root)
+    lastMap.set(lastKey, value)
+  }
+  get (keys) {
+    let lastKey = keys.pop()
+    let lastMap = deepget(keys, this._root)
+    return lastMap.get(lastKey)
+  }
+  has (keys) {
+    let lastKey = keys.pop()
+    let lastMap = deepget(keys, this._root)
+    return lastMap.has(lastKey)
+  }
+}


### PR DESCRIPTION
## I'm improving performance

This speeds up running `statusMatrix` on large repos like https://github.com/ianstormtaylor/slate from ~80 seconds to ~1 second. (These times measured on a proprietary Electron app. How big the perf hit is depends highly on the latency of the filesystem... on Electron the latency is very bad because it is proxied to the worker over IPC.)

## Possible Dangers

It does caching based on the compound key `[fs, filepathOfIndexFile]`. It uses `lstat` to determine whether the index file has been modified. 99% of the time this should be enough! However... if you  are "resetting" a filesystem mock behind the scenes (like my BrowserFS tests were), that might not be enough. In such cases that the index file returns the same `stat` information but it actually has changed different, then your tests may too fail. (This caching may also be susceptible to "racy-git"-like race conditions, since it depends on the last-modified timestamp.)

The solution is to make sure whenever you are "resetting" the filesystem to set the filesystem to a new object, i.e.
```js
plugins.set('fs', {...fs})
```
so that the old cached index file will not be used.