### PR TITLE
fix: tests weren't passing in Windows

### DIFF
--- a/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
+++ b/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
@@ -10,7 +10,7 @@ async function makeNodeFixture (fixture) {
   const core = `core-node-${i++}`
   cores.create(core).set('fs', _fs)
   plugins.set('fs', _fs) // deprecated
-  
+
   const fs = new FileSystem(_fs)
 
   const {

--- a/__tests__/test-utils-join.js
+++ b/__tests__/test-utils-join.js
@@ -1,5 +1,5 @@
 /* eslint-env node, browser, jasmine */
-const path = require('path')
+const path = require('path').posix || require('path')
 const { join } = require('isomorphic-git/internal-apis')
 
 describe('utils/join', () => {


### PR DESCRIPTION
should fix #783

My Windows machine is borked at the moment (keeps trying to use Python 3 with gyp...) so I can't actually test whether it's working.