### PR TITLE
feat: Added 'corsProxy' parameter to pull command

### DIFF
--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -21,6 +21,7 @@ import { merge } from './merge'
  * @param {string} args.dir] - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string} [args.ref] - Which branch to fetch. By default this is the currently checked out branch.
+ * @param {string} [args.corsProxy] - Optional [CORS proxy](https://www.npmjs.com/%40isomorphic-git/cors-proxy). Overrides value in repo config.
  * @param {boolean} [args.singleBranch = false] - Instead of the default behavior of fetching all the branches, only fetch a single branch.
  * @param {boolean} [args.fastForwardOnly = false] - Only perform simple fast-forward merges. (Don't create merge commits.)
  * @param {boolean} [args.noGitSuffix = false] - If true, do not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**)
@@ -51,6 +52,7 @@ export async function pull ({
   ref,
   fastForwardOnly = false,
   noGitSuffix = false,
+  corsProxy,
   emitter = cores.get(core).get('emitter'),
   emitterPrefix = '',
   // @ts-ignore
@@ -83,6 +85,7 @@ export async function pull ({
       emitter,
       emitterPrefix,
       noGitSuffix,
+      corsProxy,
       ref,
       remote,
       username,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -495,6 +495,7 @@ export function pull(args: WorkDir & GitDir & {
   core?: string;
   fs?: any;
   ref?: string;
+  corsProxy?: string;
   singleBranch?: boolean;
   fastForwardOnly?: boolean;
   username?: string;


### PR DESCRIPTION
## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"