### PR TITLE
resolves #793 avoid experimental feature warning on Node 10

### DIFF
--- a/src/utils/AsyncIterator.js
+++ b/src/utils/AsyncIterator.js
@@ -37,8 +37,8 @@ export function fromValue (value) {
 
 // Convert a Node stream to an Async Iterator
 export function fromNodeStream (stream) {
-  // Use native async iteration if it's available.
-  if (stream[Symbol.asyncIterator]) return stream
+  // Use native async iteration if it's available without a warning.
+  if (stream[Symbol.asyncIterator] && !Object.getOwnPropertyDescriptor(global, 'Buffer').enumerable) return stream
   // Author's Note
   // I tried many MANY ways to do this.
   // I tried two npm modules (stream-to-async-iterator and streams-to-async-iterator) with no luck.


### PR DESCRIPTION
Strengthen feature detection for asyncIterator to avoid experimental feature warning on Node 10. In other words, don't use the asyncIterator on Node 10.