### PR TITLE
feat: Added 'parent' parameter to commit command

### DIFF
--- a/__tests__/test-commit.js
+++ b/__tests__/test-commit.js
@@ -26,7 +26,8 @@ describe('commit', () => {
     })
     expect(sha).toBe('7a51c0b1181d738198ff21c4679d3aa32eb52fe0')
     // updates branch pointer
-    const { oid: currentOid } = (await log({ gitdir, depth: 1 }))[0]
+    const { oid: currentOid, parent } = (await log({ gitdir, depth: 1 }))[0]
+    expect(parent).toEqual([originalOid])
     expect(currentOid).not.toEqual(originalOid)
     expect(currentOid).toEqual(sha)
   })
@@ -82,6 +83,34 @@ describe('commit', () => {
       ref: 'master-copy'
     }))[0]
     expect(sha).toEqual(copyOid)
+  })
+
+  it('custom parents', async () => {
+    // Setup
+    const { gitdir } = await makeFixture('test-commit')
+    const { oid: originalOid } = (await log({ gitdir, depth: 1 }))[0]
+    // Test
+    const parent = [
+      '1111111111111111111111111111111111111111',
+      '2222222222222222222222222222222222222222',
+      '3333333333333333333333333333333333333333'
+    ]
+    const sha = await commit({
+      gitdir,
+      parent,
+      author: {
+        name: 'Mr. Test',
+        email: 'mrtest@example.com',
+        timestamp: 1262356920,
+        timezoneOffset: -0
+      },
+      message: 'Initial commit'
+    })
+    expect(sha).toBe('e11b6803f58bc2218f2e92a1bae0eeee0101a06c')
+    // does NOT update master branch pointer
+    const { parent: parents } = (await log({ gitdir, depth: 1 }))[0]
+    expect(parents).not.toEqual([originalOid])
+    expect(parents).toEqual(parent)
   })
 
   it('throw error if missing author', async () => {

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -20,6 +20,7 @@ import { cores } from '../utils/plugins.js'
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string} [args.ref] - The fully expanded name of the branch to commit to. Default is the current branch pointed to by HEAD. (TODO: fix it so it can expand branch names without throwing if the branch doesn't exist yet.)
+ * @param {string[]} [args.parent] - The SHA-1 object ids of the commits to use as parents. If not specified, the commit pointed to by `ref` is used.
  * @param {string} args.message - The commit message to use.
  * @param {Object} [args.author] - The details about the author.
  * @param {string} [args.author.name] - Default is `user.name` config.
@@ -51,6 +52,7 @@ export async function commit ({
   gitdir = join(dir, '.git'),
   fs: _fs = cores.get(core).get('fs'),
   ref,
+  parent,
   message,
   author,
   committer,
@@ -97,21 +99,21 @@ export async function commit ({
         const inodes = flatFileListToDirectoryStructure(index.entries)
         const inode = inodes.get('.')
         const treeRef = await constructTree({ fs, gitdir, inode })
-        let parents
-        try {
-          const parent = await GitRefManager.resolve({
-            fs,
-            gitdir,
-            ref
-          })
-          parents = [parent]
-        } catch (err) {
-          // Probably an initial commit
-          parents = []
+        if (!parent) {
+          try {
+            parent = [await GitRefManager.resolve({
+              fs,
+              gitdir,
+              ref
+            })]
+          } catch (err) {
+            // Probably an initial commit
+            parent = []
+          }
         }
         let comm = GitCommit.from({
           tree: treeRef,
-          parent: parents,
+          parent,
           author,
           committer,
           message

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -101,11 +101,13 @@ export async function commit ({
         const treeRef = await constructTree({ fs, gitdir, inode })
         if (!parent) {
           try {
-            parent = [await GitRefManager.resolve({
-              fs,
-              gitdir,
-              ref
-            })]
+            parent = [
+              await GitRefManager.resolve({
+                fs,
+                gitdir,
+                ref
+              })
+            ]
           } catch (err) {
             // Probably an initial commit
             parent = []

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -299,6 +299,7 @@ export function commit(args: GitDir & {
   core?: string;
   fs?: any;
   ref?: string;
+  parent?: string[];
   message: string;
   author: {
     name?: string;


### PR DESCRIPTION

## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
