### PR TITLE
feat: Added 'tree' parameter to commit command

### DIFF
--- a/__tests__/test-commit.js
+++ b/__tests__/test-commit.js
@@ -110,7 +110,10 @@ describe('commit', () => {
     })
     expect(sha).toBe('43fbc94f2c1db655a833e08c72d005954ff32f32')
     // does NOT update master branch pointer
-    const { parent: parents, tree: _tree } = (await log({ gitdir, depth: 1 }))[0]
+    const { parent: parents, tree: _tree } = (await log({
+      gitdir,
+      depth: 1
+    }))[0]
     expect(parents).not.toEqual([originalOid])
     expect(parents).toEqual(parent)
     expect(_tree).toEqual(tree)

--- a/__tests__/test-commit.js
+++ b/__tests__/test-commit.js
@@ -85,7 +85,7 @@ describe('commit', () => {
     expect(sha).toEqual(copyOid)
   })
 
-  it('custom parents', async () => {
+  it('custom parents and tree', async () => {
     // Setup
     const { gitdir } = await makeFixture('test-commit')
     const { oid: originalOid } = (await log({ gitdir, depth: 1 }))[0]
@@ -95,9 +95,11 @@ describe('commit', () => {
       '2222222222222222222222222222222222222222',
       '3333333333333333333333333333333333333333'
     ]
+    const tree = '4444444444444444444444444444444444444444'
     const sha = await commit({
       gitdir,
       parent,
+      tree,
       author: {
         name: 'Mr. Test',
         email: 'mrtest@example.com',
@@ -106,11 +108,12 @@ describe('commit', () => {
       },
       message: 'Initial commit'
     })
-    expect(sha).toBe('e11b6803f58bc2218f2e92a1bae0eeee0101a06c')
+    expect(sha).toBe('43fbc94f2c1db655a833e08c72d005954ff32f32')
     // does NOT update master branch pointer
-    const { parent: parents } = (await log({ gitdir, depth: 1 }))[0]
+    const { parent: parents, tree: _tree } = (await log({ gitdir, depth: 1 }))[0]
     expect(parents).not.toEqual([originalOid])
     expect(parents).toEqual(parent)
+    expect(_tree).toEqual(tree)
   })
 
   it('throw error if missing author', async () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -298,8 +298,6 @@ export function clone(args: WorkDir & GitDir & {
 export function commit(args: GitDir & {
   core?: string;
   fs?: any;
-  ref?: string;
-  parent?: string[];
   message: string;
   author: {
     name?: string;
@@ -317,6 +315,9 @@ export function commit(args: GitDir & {
   };
   signingKey?: string;
   noUpdateBranch?: boolean;
+  ref?: string;
+  parent?: string[];
+  tree?: string;
 }): Promise<string>;
 
 export function config(args: GitDir & {


### PR DESCRIPTION

## I'm adding a parameter to an existing command:

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] add parameter to the function in `src/commands/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
