### PR TITLE
fix: remove false positive from license check

### DIFF
--- a/src/commands/sign.js
+++ b/src/commands/sign.js
@@ -13,7 +13,7 @@ import { cores } from '../utils/plugins.js'
  * Create a signed commit
  *
  * <aside>
- * OpenPGP.js is unfortunately licensed under the LGPL-3.0 and thus cannot be included in a minified bundle with
+ * OpenPGP.js is unfortunately licensed under an incompatible license and thus cannot be included in a minified bundle with
  * isomorphic-git which is an MIT/BSD style library, because that would violate the "dynamically linked" stipulation.
  * To use this feature you include openpgp with a separate script tag and pass it in as an argument.
  * </aside>


### PR DESCRIPTION
## what's with the "LGPL-3.0-only - 20%" thing?!
![image](https://user-images.githubusercontent.com/587740/63817229-4faae800-c909-11e9-9162-33df9d6e060e.png)

## answer
OK... this is hilarious. FOSSA is being triggered by this comment I wrote talking about why I don't include any LGPL dependencies:
![image](https://user-images.githubusercontent.com/587740/63817210-386bfa80-c909-11e9-8c88-98b8b584ace7.png)

I am therefore REMOVING the phrase "LGPL" from the documentation, since "manually ignoring" it in the FOSSA admin panel has not had the effect of updating this graphic. 🙄 