### PR TITLE
chore: fix linting on Windows

### DIFF
--- a/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
@@ -18,12 +18,12 @@ async function makeBrowserFS (dir) {
       const InMemoryFS = pify(BrowserFS.FileSystem.InMemory.Create)
       const OverlayFS = pify(BrowserFS.FileSystem.OverlayFS.Create)
       const index = require('../../__fixtures__/index.json')
-      let readable = await HTTPRequestFS({
+      const readable = await HTTPRequestFS({
         index,
         baseUrl: '/base/__tests__/__fixtures__/'
       })
-      let writable = await InMemoryFS()
-      let ofs = await OverlayFS({ readable, writable })
+      const writable = await InMemoryFS()
+      const ofs = await OverlayFS({ readable, writable })
       BrowserFS.initialize(ofs)
       browserFS = BrowserFS.BFSRequire('fs')
       browserFSwritable = writable
@@ -38,7 +38,7 @@ async function makeBrowserFS (dir) {
     const fs = new FileSystem(_fs)
 
     dir = `/${dir}`
-    let gitdir = `/${dir}.git`
+    const gitdir = `/${dir}.git`
     await fs.mkdir(dir)
     await fs.mkdir(gitdir)
     return {

--- a/__tests__/__helpers__/FixtureFS/makeLightningFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeLightningFS.js
@@ -18,7 +18,7 @@ async function makeLightningFS (dir) {
   plugins.set('fs', _fs) // deprecated
   const fs = new FileSystem(_fs)
   dir = `/${dir}`
-  let gitdir = `/${dir}.git`
+  const gitdir = `/${dir}.git`
   await fs.mkdir(dir)
   await fs.mkdir(gitdir)
   return { _fs, fs, dir, gitdir, core }

--- a/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
+++ b/__tests__/__helpers__/FixtureFS/makeNodeFixture.js
@@ -19,13 +19,13 @@ async function makeNodeFixture (fixture) {
     copyFixtureIntoTempDir
   } = require('jest-fixtures')
 
-  let testsDir = path.resolve(__dirname, '..')
+  const testsDir = path.resolve(__dirname, '..')
 
-  let dir = (await getFixturePath(testsDir, fixture))
+  const dir = (await getFixturePath(testsDir, fixture))
     ? await copyFixtureIntoTempDir(testsDir, fixture)
     : await createTempDir()
 
-  let gitdir = (await getFixturePath(testsDir, `${fixture}.git`))
+  const gitdir = (await getFixturePath(testsDir, `${fixture}.git`))
     ? await copyFixtureIntoTempDir(testsDir, `${fixture}.git`)
     : await createTempDir()
 


### PR DESCRIPTION
I don't understand why `standard` caught this on Windows but not on Mac or Linux. But... I see no reason to disagree with it.