### PR TITLE
resolves #899 do not overwrite existing .git/config on init

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -356,6 +356,17 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "djencks",
+      "name": "djencks",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/569822?v=4",
+      "profile": "https://github.com/djencks",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
-  ]
+  ],
+  "commitConvention": "angular"
 }

--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://twitter.com/addaleax"><img src="https://avatars2.githubusercontent.com/u/899444?v=4&s=60" width="60px;" alt="Anna Henningsen"/><br /><sub><b>Anna Henningsen</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=addaleax" title="Code">💻</a></td>
     <td align="center"><a href="https://hen.ne.ke"><img src="https://avatars0.githubusercontent.com/u/4312191?v=4&s=60" width="60px;" alt="Fabian Henneke"/><br /><sub><b>Fabian Henneke</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3AFabianHenneke" title="Bug reports">🐛</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=FabianHenneke" title="Code">💻</a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/djencks"><img src="https://avatars2.githubusercontent.com/u/569822?v=4" width="60px;" alt="djencks"/><br /><sub><b>djencks</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=djencks" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=djencks" title="Tests">⚠️</a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-enable -->

--- a/__tests__/test-init.js
+++ b/__tests__/test-init.js
@@ -22,6 +22,7 @@ describe('init', () => {
     expect(await fs.exists(`${dir}/HEAD`)).toBe(true)
   })
   it('init config init overwrite', async () => {
+    // Setup
     const { fs, dir } = await makeFixture('test-init')
     const name = 'me'
     const email = 'meme'
@@ -30,15 +31,16 @@ describe('init', () => {
     expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
     await config({ dir, path: 'user.name', value: name })
     await config({ dir, path: 'user.email', value: email })
-    // init again
+    // Test
     await init({ dir })
     expect(await fs.exists(dir)).toBe(true)
     expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
-    // check that the properties we added are still there.
-    expect(await config({ dir, path: 'user.name' })).toBe(undefined)
-    expect(await config({ dir, path: 'user.email' })).toBe(undefined)
+    // check that the properties we added got removed
+    expect(await config({ dir, path: 'user.name' })).toBeUndefined()
+    expect(await config({ dir, path: 'user.email' })).toBeUndefined()
   })
   it('init config init no overwrite', async () => {
+    // Setup
     const { fs, dir } = await makeFixture('test-init')
     const name = 'me'
     const email = 'meme'
@@ -47,7 +49,7 @@ describe('init', () => {
     expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
     await config({ dir, path: 'user.name', value: name })
     await config({ dir, path: 'user.email', value: email })
-    // init again
+    // Test
     await init({ dir, noOverwrite: true })
     expect(await fs.exists(dir)).toBe(true)
     expect(await fs.exists(`${dir}/.git/config`)).toBe(true)

--- a/__tests__/test-init.js
+++ b/__tests__/test-init.js
@@ -2,6 +2,7 @@
 const { makeFixture } = require('./__helpers__/FixtureFS.js')
 
 const { init } = require('isomorphic-git')
+const { config } = require('isomorphic-git')
 
 describe('init', () => {
   it('init', async () => {
@@ -19,5 +20,39 @@ describe('init', () => {
     expect(await fs.exists(`${dir}/objects`)).toBe(true)
     expect(await fs.exists(`${dir}/refs/heads`)).toBe(true)
     expect(await fs.exists(`${dir}/HEAD`)).toBe(true)
+  })
+  it('init config init overwrite', async () => {
+    const { fs, dir } = await makeFixture('test-init')
+    const name = 'me'
+    const email = 'meme'
+    await init({ dir })
+    expect(await fs.exists(dir)).toBe(true)
+    expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
+    await config({ dir, path: 'user.name', value: name })
+    await config({ dir, path: 'user.email', value: email })
+    // init again
+    await init({ dir })
+    expect(await fs.exists(dir)).toBe(true)
+    expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
+    // check that the properties we added are still there.
+    expect(await config({ dir, path: 'user.name' })).toBe(undefined)
+    expect(await config({ dir, path: 'user.email' })).toBe(undefined)
+  })
+  it('init config init no overwrite', async () => {
+    const { fs, dir } = await makeFixture('test-init')
+    const name = 'me'
+    const email = 'meme'
+    await init({ dir })
+    expect(await fs.exists(dir)).toBe(true)
+    expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
+    await config({ dir, path: 'user.name', value: name })
+    await config({ dir, path: 'user.email', value: email })
+    // init again
+    await init({ dir, noOverwrite: true })
+    expect(await fs.exists(dir)).toBe(true)
+    expect(await fs.exists(`${dir}/.git/config`)).toBe(true)
+    // check that the properties we added are still there.
+    expect(await config({ dir, path: 'user.name' })).toEqual(name)
+    expect(await config({ dir, path: 'user.email' })).toEqual(email)
   })
 })

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -24,7 +24,8 @@ export async function init ({
   bare = false,
   dir,
   gitdir = bare ? dir : join(dir, '.git'),
-  fs: _fs = cores.get(core).get('fs')
+  fs: _fs = cores.get(core).get('fs'),
+  noOverwrite = false
 }) {
   try {
     const fs = new FileSystem(_fs)
@@ -40,16 +41,18 @@ export async function init ({
     for (const folder of folders) {
       await fs.mkdir(folder)
     }
-    await fs.write(
-      gitdir + '/config',
-      '[core]\n' +
+    if (!noOverwrite || !await fs.exists(gitdir + '/config')) {
+      await fs.write(
+        gitdir + '/config',
+        '[core]\n' +
         '\trepositoryformatversion = 0\n' +
         '\tfilemode = false\n' +
         `\tbare = ${bare}\n` +
         (bare ? '' : '\tlogallrefupdates = true\n') +
         '\tsymlinks = false\n' +
         '\tignorecase = true\n'
-    )
+      )
+    }
     await fs.write(gitdir + '/HEAD', 'ref: refs/heads/master\n')
   } catch (err) {
     err.caller = 'git.init'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -428,6 +428,7 @@ export function init(args: GitDir & {
   core?: string;
   fs?: any;
   bare?: boolean;
+  noOverwrite?: boolean;
 }): Promise<void>;
 
 export function isDescendent(args: GitDir & {


### PR DESCRIPTION
resolves #899 
## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README

running this made no changes, I got:

$ npm run add-contributor

> isomorphic-git@0.0.0-development add-contributor /Users/david/projects/isomorphic-git/isomorphic-git
> nps contributors.add

nps is executing `contributors.add` : all-contributors add
 is/are invalid contribution type(s)
The script called "contributors.add" which runs "all-contributors add" failed with exit code 1 https://github.com/sezna/nps/blob/v5.9.8/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! isomorphic-git@0.0.0-development add-contributor: `nps contributors.add`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the isomorphic-git@0.0.0-development add-contributor script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/david/.npm/_logs/2019-10-19T02_31_37_634Z-debug.log

