### PR TITLE
perf(shasum): use SubtleCrypto.digest if available

### DIFF
--- a/__tests__/test-GitIndex.js
+++ b/__tests__/test-GitIndex.js
@@ -15,10 +15,10 @@ describe('GitIndex', () => {
   it('GitIndex.from(buffer) - Simple', async () => {
     const { fs, dir } = await makeFixture('test-GitIndex')
     const buffer = await fs.read(path.join(dir, 'simple-index'))
-    const index = GitIndex.from(buffer)
+    const index = await GitIndex.from(buffer)
     const rendering = index.render()
     expect(rendering).toMatchSnapshot()
-    const buffer2 = index.toObject()
+    const buffer2 = await index.toObject()
     expect(buffer.slice(0, buffer2.length - 20).buffer).toEqual(
       buffer2.slice(0, -20).buffer
     )
@@ -27,10 +27,10 @@ describe('GitIndex', () => {
   it('GitIndex.from(buffer)', async () => {
     const { fs, dir } = await makeFixture('test-GitIndex')
     const buffer = await fs.read(path.join(dir, 'index'))
-    const index = GitIndex.from(buffer)
+    const index = await GitIndex.from(buffer)
     const rendering = index.render()
     expect(rendering).toMatchSnapshot()
-    const buffer2 = index.toObject()
+    const buffer2 = await index.toObject()
     expect(buffer.slice(0, buffer2.length - 20).buffer).toEqual(
       buffer2.slice(0, -20).buffer
     )
@@ -39,10 +39,10 @@ describe('GitIndex', () => {
   it('GitIndex round trip', async () => {
     const { fs, dir } = await makeFixture('test-GitIndex')
     const buffer = await fs.read(path.join(dir, 'index'))
-    const index = GitIndex.from(buffer)
-    const buffer2 = index.toObject()
-    const index2 = GitIndex.from(buffer2)
-    const buffer3 = index2.toObject()
+    const index = await GitIndex.from(buffer)
+    const buffer2 = await index.toObject()
+    const index2 = await GitIndex.from(buffer2)
+    const buffer3 = await index2.toObject()
     expect(buffer2.buffer).toEqual(buffer3.buffer)
   })
 })

--- a/__tests__/test-GitPackIndex.js
+++ b/__tests__/test-GitPackIndex.js
@@ -23,7 +23,9 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromIdx({ idx })
-    expect(await shasum(Buffer.from(JSON.stringify(p.hashes)))).toMatchSnapshot()
+    expect(
+      await shasum(Buffer.from(JSON.stringify(p.hashes)))
+    ).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
     expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(
@@ -51,7 +53,9 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromPack({ pack })
-    expect(await shasum(Buffer.from(JSON.stringify(p.hashes)))).toMatchSnapshot()
+    expect(
+      await shasum(Buffer.from(JSON.stringify(p.hashes)))
+    ).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
     expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(

--- a/__tests__/test-GitPackIndex.js
+++ b/__tests__/test-GitPackIndex.js
@@ -23,7 +23,7 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromIdx({ idx })
-    expect(shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
+    expect(await shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
     expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(
@@ -51,7 +51,7 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromPack({ pack })
-    expect(shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
+    expect(await shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
     expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(
@@ -85,7 +85,7 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromPack({ pack })
-    const idxbuffer = p.toBuffer()
+    const idxbuffer = await p.toBuffer()
     expect(idxbuffer.byteLength).toBe(idx.byteLength)
     expect(idxbuffer.equals(idx)).toBe(true)
   })
@@ -110,7 +110,7 @@ describe('GitPackIndex', () => {
     })
     expect(type).toBe('commit')
     expect(object.toString('utf8')).toMatchSnapshot()
-    const oid = shasum(GitObject.wrap({ type, object }))
+    const oid = await shasum(GitObject.wrap({ type, object }))
     expect(oid).toBe('637c4e69d85e0dcc18898ec251377453d0891585')
   })
   it('read deltified object', async () => {
@@ -134,7 +134,7 @@ describe('GitPackIndex', () => {
     })
     expect(type).toBe('blob')
     expect(object.toString('utf8')).toMatchSnapshot()
-    const oid = shasum(GitObject.wrap({ type, object }))
+    const oid = await shasum(GitObject.wrap({ type, object }))
     expect(oid).toBe('7fb539a8e8488c3fd2793e7dda8a44693e25cce1')
   })
 })

--- a/__tests__/test-GitPackIndex.js
+++ b/__tests__/test-GitPackIndex.js
@@ -23,7 +23,7 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromIdx({ idx })
-    expect(await shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
+    expect(await shasum(Buffer.from(JSON.stringify(p.hashes)))).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
     expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(
@@ -51,7 +51,7 @@ describe('GitPackIndex', () => {
       )
     )
     const p = await GitPackIndex.fromPack({ pack })
-    expect(await shasum(JSON.stringify(p.hashes))).toMatchSnapshot()
+    expect(await shasum(Buffer.from(JSON.stringify(p.hashes)))).toMatchSnapshot()
     expect(p.packfileSha).toBe('1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888')
     // Test a handful of known offsets.
     expect(p.offsets.get('0b8faa11b353db846b40eb064dfb299816542a46')).toEqual(

--- a/__tests__/test-fastCheckout.js
+++ b/__tests__/test-fastCheckout.js
@@ -241,12 +241,11 @@ describe('fastCheckout', () => {
     // Test
     let error = null
     try {
-      const ops = await fastCheckout({
+      await fastCheckout({
         dir,
         gitdir,
         force: true
       })
-      console.log(ops)
     } catch (e) {
       error = e
     }

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -205,7 +205,7 @@ export async function fetch ({
         emitter,
         emitterPrefix
       })
-      await fs.write(fullpath.replace(/\.pack$/, '.idx'), idx.toBuffer())
+      await fs.write(fullpath.replace(/\.pack$/, '.idx'), await idx.toBuffer())
     }
     return res
   } catch (err) {

--- a/src/commands/indexPack.js
+++ b/src/commands/indexPack.js
@@ -46,7 +46,7 @@ export async function indexPack ({
       emitter,
       emitterPrefix
     })
-    await fs.write(filepath.replace(/\.pack$/, '.idx'), idx.toBuffer())
+    await fs.write(filepath.replace(/\.pack$/, '.idx'), await idx.toBuffer())
   } catch (err) {
     err.caller = 'git.indexPack'
     throw err

--- a/src/managers/GitIndexManager.js
+++ b/src/managers/GitIndexManager.js
@@ -17,7 +17,7 @@ let lock = null
 async function updateCachedIndexFile (fs, filepath) {
   const stat = await fs.lstat(filepath)
   const rawIndexFile = await fs.read(filepath)
-  const index = GitIndex.from(rawIndexFile)
+  const index = await GitIndex.from(rawIndexFile)
   // cache the GitIndex object so we don't need to re-read it
   // every time.
   map.set([fs, filepath], index)
@@ -60,7 +60,7 @@ export class GitIndexManager {
       if (index._dirty) {
         // Acquire a file lock while we're writing the index file
         // let fileLock = await Lock(filepath)
-        const buffer = index.toObject()
+        const buffer = await index.toObject()
         await fs.write(filepath, buffer)
         // Update cached stat value
         stats.set([fs, filepath], await fs.lstat(filepath))

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -277,7 +277,7 @@ export class GitPackIndex {
         timeByDepth[p.readDepth] += time
         objectsByDepth[p.readDepth] += 1
         marky.mark('hash')
-        const oid = shasum(GitObject.wrap({ type, object }))
+        const oid = await shasum(GitObject.wrap({ type, object }))
         times.hash += marky.stop('hash').duration
         o.oid = oid
         hashes.push(oid)
@@ -312,7 +312,7 @@ export class GitPackIndex {
     return p
   }
 
-  toBuffer () {
+  async toBuffer () {
     const buffers = []
     const write = (str, encoding) => {
       buffers.push(Buffer.from(str, encoding))
@@ -351,7 +351,7 @@ export class GitPackIndex {
     write(this.packfileSha, 'hex')
     // Write out shasum
     const totalBuffer = Buffer.concat(buffers)
-    const sha = shasum(totalBuffer)
+    const sha = await shasum(totalBuffer)
     const shaBuffer = Buffer.alloc(20)
     shaBuffer.write(sha, 'hex')
     return Buffer.concat([totalBuffer, shaBuffer])

--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -88,7 +88,7 @@ export class GitWalkerFs {
       if (!stage || compareStats(entry, stage)) {
         log(`INDEX CACHE MISS: calculating SHA for ${entry.fullpath}`)
         if (!entry.content) await entry.populateContent()
-        const oid = shasum(
+        const oid = await shasum(
           GitObject.wrap({ type: 'blob', object: entry.content })
         )
         if (stage && oid === stage.oid) {

--- a/src/models/GitWalkerFs2.js
+++ b/src/models/GitWalkerFs2.js
@@ -126,7 +126,7 @@ export class GitWalkerFs2 {
           if (content === void 0) {
             oid = void 0
           } else {
-            oid = shasum(
+            oid = await shasum(
               GitObject.wrap({ type: 'blob', object: await entry.content() })
             )
             if (stage && oid === stage.oid) {

--- a/src/storage/hashObject.js
+++ b/src/storage/hashObject.js
@@ -11,7 +11,7 @@ export async function hashObject ({
     if (format !== 'wrapped') {
       object = GitObject.wrap({ type, object })
     }
-    oid = shasum(object)
+    oid = await shasum(object)
   }
   return { oid, object }
 }

--- a/src/storage/readObject.js
+++ b/src/storage/readObject.js
@@ -48,7 +48,7 @@ export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) 
       if (format === 'wrapped' && result.format === 'wrapped') {
         return result
       }
-      const sha = shasum(result.object)
+      const sha = await shasum(result.object)
       if (sha !== oid) {
         throw new GitError(E.InternalFail, {
           message: `SHA check failed! Expected ${oid}, computed ${sha}`

--- a/src/storage/writeObject.js
+++ b/src/storage/writeObject.js
@@ -18,7 +18,7 @@ export async function writeObject ({
     if (format !== 'wrapped') {
       object = GitObject.wrap({ type, object })
     }
-    oid = shasum(object)
+    oid = await shasum(object)
     object = Buffer.from(pako.deflate(object))
   }
   if (!dryRun) {

--- a/src/utils/shasum.js
+++ b/src/utils/shasum.js
@@ -3,6 +3,6 @@ import Hash from 'sha.js/sha1'
 // This is modeled after @dominictarr's "shasum" module,
 // but without the 'json-stable-stringify' dependency and
 // extra type-casting features.
-export function shasum (buffer) {
+export async function shasum (buffer) {
   return new Hash().update(buffer).digest('hex')
 }

--- a/src/utils/shasum.js
+++ b/src/utils/shasum.js
@@ -1,8 +1,37 @@
+/* eslint-env node, browser */
 import Hash from 'sha.js/sha1'
+
+import { toHex } from './toHex.js'
+
+let supportsSubtleSHA1 = null
+
+export async function shasum (buffer) {
+  if (supportsSubtleSHA1 === null) {
+    supportsSubtleSHA1 = await testSubtleSHA1()
+  }
+  return supportsSubtleSHA1 ? subtleSHA1(buffer) : shasumSync(buffer)
+}
 
 // This is modeled after @dominictarr's "shasum" module,
 // but without the 'json-stable-stringify' dependency and
 // extra type-casting features.
-export async function shasum (buffer) {
+function shasumSync (buffer) {
   return new Hash().update(buffer).digest('hex')
+}
+
+async function subtleSHA1 (buffer) {
+  const hash = await crypto.subtle.digest('SHA-1', buffer)
+  return toHex(hash)
+}
+
+async function testSubtleSHA1 () {
+  // I'm using a rather crude method of progressive enhancement, because
+  // some browsers that have crypto.subtle.digest don't actually implement SHA-1.
+  try {
+    const hash = await subtleSHA1(new Uint8Array([]))
+    if (hash === 'da39a3ee5e6b4b0d3255bfef95601890afd80709') return true
+  } catch (_) {
+    // no bother
+  }
+  return false
 }

--- a/src/utils/toHex.js
+++ b/src/utils/toHex.js
@@ -1,0 +1,8 @@
+export function toHex (buffer) {
+  let hex = ''
+  for (const byte of new Uint8Array(buffer)) {
+    if (byte < 16) hex += '0'
+    hex += byte.toString(16)
+  }
+  return hex
+}


### PR DESCRIPTION
Add progressive enhancement to use `crypto.subtle.digest` if is available instead of the pure JS implementation in `sha.js/sha1`.

I must say, I'm super pleased at how far I’ve come with `isomorphic-git`. For a loooooong time, I was picking such low-hanging fruit when it came to performance, and all the performance issues were async. The bottlenecks were file IO/IndexedDB, serial vs concurrent, concurrent but with head-of-line-blocking problems, and insufficient caching. To have reached the point where the synchronous hashing speed is the bottleneck feels AMAZING.