### PR TITLE
resolves #911 handle unexpected response better

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -363,6 +363,7 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/569822?v=4",
       "profile": "https://github.com/djencks",
       "contributions": [
+        "bug",
         "code",
         "test"
       ]

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://hen.ne.ke"><img src="https://avatars0.githubusercontent.com/u/4312191?v=4&s=60" width="60px;" alt="Fabian Henneke"/><br /><sub><b>Fabian Henneke</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3AFabianHenneke" title="Bug reports">🐛</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=FabianHenneke" title="Code">💻</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://github.com/djencks"><img src="https://avatars2.githubusercontent.com/u/569822?v=4" width="60px;" alt="djencks"/><br /><sub><b>djencks</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=djencks" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=djencks" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://github.com/djencks"><img src="https://avatars2.githubusercontent.com/u/569822?v=4" width="60px;" alt="djencks"/><br /><sub><b>djencks</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Adjencks" title="Bug reports">🐛</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=djencks" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=djencks" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -218,7 +218,7 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: "Two words separated by '\0'",
+        expected: '\0',
         actual:
           '9ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development\n'
       })
@@ -246,7 +246,7 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: "Two words separated by ' '",
+        expected: ' ',
         actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7  HEAD'
       })
     }
@@ -272,7 +272,7 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: "Two words separated by ' '",
+        expected: ' ',
         actual: 'fb74ea1a9b6a9601df18c38d3de751c51f064bf7refs/heads/js2\n0'
       })
     }

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -218,7 +218,7 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: '\0',
+        expected: '\\x00',
         actual:
           '9ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development\n'
       })

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -191,7 +191,10 @@ describe('git wire protocol', () => {
       fail('expected an error')
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
-      expect(error.data).toEqual({ expected: '# service=git-upload-pack\\n', actual: '# noservice=git-upload-pac' })
+      expect(error.data).toEqual({
+        expected: '# service=git-upload-pack\\n',
+        actual: '# noservice=git-upload-pac'
+      })
     }
   })
   it('parseRefsAdResponse bad null separated', async () => {
@@ -214,7 +217,11 @@ describe('git wire protocol', () => {
       fail('expected an error')
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
-      expect(error.data).toEqual({ expected: 'Two words separated by \'\0\'', actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development\n' })
+      expect(error.data).toEqual({
+        expected: "Two words separated by '\0'",
+        actual:
+          '9ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development\n'
+      })
     }
   })
   it('parseRefsAdResponse HEAD bad space separated', async () => {
@@ -238,7 +245,10 @@ describe('git wire protocol', () => {
       fail('expected an error')
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
-      expect(error.data).toEqual({ expected: 'Two words separated by \' \'', actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7  HEAD' })
+      expect(error.data).toEqual({
+        expected: "Two words separated by ' '",
+        actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7  HEAD'
+      })
     }
   })
   it('parseRefsAdResponse refs bad space separated', async () => {
@@ -261,7 +271,10 @@ describe('git wire protocol', () => {
       fail('expected an error')
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
-      expect(error.data).toEqual({ expected: 'Two words separated by \' \'', actual: 'fb74ea1a9b6a9601df18c38d3de751c51f064bf7refs/heads/js2\n0' })
+      expect(error.data).toEqual({
+        expected: "Two words separated by ' '",
+        actual: 'fb74ea1a9b6a9601df18c38d3de751c51f064bf7refs/heads/js2\n0'
+      })
     }
   })
   it('writeUploadPackRequest', async () => {

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -5,7 +5,8 @@ const {
   parseUploadPackResponse,
   parseUploadPackRequest,
   writeRefsAdResponse,
-  writeUploadPackRequest
+  writeUploadPackRequest,
+  E
 } = require('isomorphic-git/internal-apis')
 // const stream = require('stream')
 
@@ -169,6 +170,99 @@ describe('git wire protocol', () => {
       ['refs/heads/master4', '18f4b62440abf61285fbfdcbfd990ab8434ff35c'],
       ['refs/heads/master5', 'e5c144897b64a44bd1164a0db60738452c9eaf87']
     ])
+  })
+  it('parseRefsAdResponse bad service', async () => {
+    const res = [
+      Buffer.from(`001e# noservice=git-upload-pack
+000001149ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development
+003cfb74ea1a9b6a9601df18c38d3de751c51f064bf7 refs/heads/js2
+003c5faa96fe725306e060386975a70e4b6eacb576ed refs/heads/js3
+003f9ea43b479f5fedc679e3eb37803275d727bf51b7 refs/heads/master
+0040c1751a5447a7b025e5bca507af483dde7b0b956f refs/heads/master2
+0040d85135a47c42c9c906e20c08def2fbceac4c2a4f refs/heads/master3
+004018f4b62440abf61285fbfdcbfd990ab8434ff35c refs/heads/master4
+0040e5c144897b64a44bd1164a0db60738452c9eaf87 refs/heads/master5
+0000`)
+    ]
+    try {
+      await parseRefsAdResponse(res, {
+        service: 'git-upload-pack'
+      })
+      fail('expected an error')
+    } catch (error) {
+      expect(error.code).toEqual(E.AssertServerResponseFail)
+      expect(error.data).toEqual({ expected: '# service=git-upload-pack\\n', actual: '# noservice=git-upload-pac' })
+    }
+  })
+  it('parseRefsAdResponse bad null separated', async () => {
+    const res = [
+      Buffer.from(`001e# service=git-upload-pack
+000001149ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development
+003cfb74ea1a9b6a9601df18c38d3de751c51f064bf7 refs/heads/js2
+003c5faa96fe725306e060386975a70e4b6eacb576ed refs/heads/js3
+003f9ea43b479f5fedc679e3eb37803275d727bf51b7 refs/heads/master
+0040c1751a5447a7b025e5bca507af483dde7b0b956f refs/heads/master2
+0040d85135a47c42c9c906e20c08def2fbceac4c2a4f refs/heads/master3
+004018f4b62440abf61285fbfdcbfd990ab8434ff35c refs/heads/master4
+0040e5c144897b64a44bd1164a0db60738452c9eaf87 refs/heads/master5
+0000`)
+    ]
+    try {
+      await parseRefsAdResponse(res, {
+        service: 'git-upload-pack'
+      })
+      fail('expected an error')
+    } catch (error) {
+      expect(error.code).toEqual(E.AssertServerResponseFail)
+      expect(error.data).toEqual({ expected: 'Two words separated by \'\0\'', actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development\n' })
+    }
+  })
+  it('parseRefsAdResponse HEAD bad space separated', async () => {
+    // two spaces instead of one
+    const res = [
+      Buffer.from(`001e# service=git-upload-pack
+000001149ea43b479f5fedc679e3eb37803275d727bf51b7  HEAD\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development
+003cfb74ea1a9b6a9601df18c38d3de751c51f064bf7 refs/heads/js2
+003c5faa96fe725306e060386975a70e4b6eacb576ed refs/heads/js3
+003f9ea43b479f5fedc679e3eb37803275d727bf51b7 refs/heads/master
+0040c1751a5447a7b025e5bca507af483dde7b0b956f refs/heads/master2
+0040d85135a47c42c9c906e20c08def2fbceac4c2a4f refs/heads/master3
+004018f4b62440abf61285fbfdcbfd990ab8434ff35c refs/heads/master4
+0040e5c144897b64a44bd1164a0db60738452c9eaf87 refs/heads/master5
+0000`)
+    ]
+    try {
+      await parseRefsAdResponse(res, {
+        service: 'git-upload-pack'
+      })
+      fail('expected an error')
+    } catch (error) {
+      expect(error.code).toEqual(E.AssertServerResponseFail)
+      expect(error.data).toEqual({ expected: 'Two words separated by \' \'', actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7  HEAD' })
+    }
+  })
+  it('parseRefsAdResponse refs bad space separated', async () => {
+    const res = [
+      Buffer.from(`001e# service=git-upload-pack
+000001149ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development
+003cfb74ea1a9b6a9601df18c38d3de751c51f064bf7refs/heads/js2
+003c5faa96fe725306e060386975a70e4b6eacb576ed refs/heads/js3
+003f9ea43b479f5fedc679e3eb37803275d727bf51b7 refs/heads/master
+0040c1751a5447a7b025e5bca507af483dde7b0b956f refs/heads/master2
+0040d85135a47c42c9c906e20c08def2fbceac4c2a4f refs/heads/master3
+004018f4b62440abf61285fbfdcbfd990ab8434ff35c refs/heads/master4
+0040e5c144897b64a44bd1164a0db60738452c9eaf87 refs/heads/master5
+0000`)
+    ]
+    try {
+      await parseRefsAdResponse(res, {
+        service: 'git-upload-pack'
+      })
+      fail('expected an error')
+    } catch (error) {
+      expect(error.code).toEqual(E.AssertServerResponseFail)
+      expect(error.data).toEqual({ expected: 'Two words separated by \' \'', actual: 'fb74ea1a9b6a9601df18c38d3de751c51f064bf7refs/heads/js2\n0' })
+    }
   })
   it('writeUploadPackRequest', async () => {
     const req = {

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -200,15 +200,10 @@ describe('git wire protocol', () => {
   it('parseRefsAdResponse bad null separated', async () => {
     const res = [
       Buffer.from(`001e# service=git-upload-pack
-000001149ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development
-003cfb74ea1a9b6a9601df18c38d3de751c51f064bf7 refs/heads/js2
-003c5faa96fe725306e060386975a70e4b6eacb576ed refs/heads/js3
-003f9ea43b479f5fedc679e3eb37803275d727bf51b7 refs/heads/master
-0040c1751a5447a7b025e5bca507af483dde7b0b956f refs/heads/master2
-0040d85135a47c42c9c906e20c08def2fbceac4c2a4f refs/heads/master3
-004018f4b62440abf61285fbfdcbfd990ab8434ff35c refs/heads/master4
-0040e5c144897b64a44bd1164a0db60738452c9eaf87 refs/heads/master5
-0000`)
+0072ERR Repository not found
+The requested repository does not exist, or you do not have permission to
+access it.
+`)
     ]
     try {
       await parseRefsAdResponse(res, {
@@ -218,9 +213,12 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: '\\x00',
+        expected: `Two strings separated by '\\x00'`,
         actual:
-          '9ea43b479f5fedc679e3eb37803275d727bf51b7 HEAD multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done symref=HEAD:refs/heads/master agent=git/isomorphic-git@0.0.0-development\n'
+          `ERR Repository not found
+The requested repository does not exist, or you do not have permission to
+access it.
+`
       })
     }
   })
@@ -246,7 +244,7 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: ' ',
+        expected: `Two strings separated by ' '`,
         actual: '9ea43b479f5fedc679e3eb37803275d727bf51b7  HEAD'
       })
     }
@@ -272,7 +270,7 @@ describe('git wire protocol', () => {
     } catch (error) {
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
-        expected: ' ',
+        expected: `Two strings separated by ' '`,
         actual: 'fb74ea1a9b6a9601df18c38d3de751c51f064bf7refs/heads/js2\n0'
       })
     }

--- a/src/wire/parseRefsAdResponse.js
+++ b/src/wire/parseRefsAdResponse.js
@@ -58,7 +58,7 @@ function splitAndAssert (line, sep, expected) {
   const split = line.trim().split(sep)
   if (split.length !== 2) {
     throw new GitError(E.AssertServerResponseFail, {
-      expected,
+      expected: `Two strings separated by '${expected}'`,
       actual: line.toString('utf8')
     })
   }

--- a/src/wire/parseRefsAdResponse.js
+++ b/src/wire/parseRefsAdResponse.js
@@ -26,18 +26,18 @@ export async function parseRefsAdResponse (stream, { service }) {
   // In the edge case of a brand new repo, zero refs (and zero capabilities)
   // are returned.
   if (lineTwo === true) return { capabilities, refs, symrefs }
-  const [firstRef, capabilitiesLine] = splitAndCheck(
+  const [firstRef, capabilitiesLine] = splitAndAssert(
     lineTwo.toString('utf8'),
     '\x00'
   )
   capabilitiesLine.split(' ').map(x => capabilities.add(x))
-  const [ref, name] = splitAndCheck(firstRef, ' ')
+  const [ref, name] = splitAndAssert(firstRef, ' ')
   refs.set(name, ref)
   while (true) {
     const line = await read()
     if (line === true) break
     if (line !== null) {
-      const [ref, name] = splitAndCheck(line.toString('utf8'), ' ')
+      const [ref, name] = splitAndAssert(line.toString('utf8'), ' ')
       refs.set(name, ref)
     }
   }
@@ -53,11 +53,11 @@ export async function parseRefsAdResponse (stream, { service }) {
   return { capabilities, refs, symrefs }
 }
 
-function splitAndCheck (line, sep) {
+function splitAndAssert (line, sep) {
   const split = line.trim().split(sep)
   if (split.length !== 2) {
     throw new GitError(E.AssertServerResponseFail, {
-      expected: `Two words separated by '${sep}'`,
+      expected: sep,
       actual: line.toString('utf8')
     })
   }

--- a/src/wire/parseRefsAdResponse.js
+++ b/src/wire/parseRefsAdResponse.js
@@ -28,16 +28,17 @@ export async function parseRefsAdResponse (stream, { service }) {
   if (lineTwo === true) return { capabilities, refs, symrefs }
   const [firstRef, capabilitiesLine] = splitAndAssert(
     lineTwo.toString('utf8'),
-    '\x00'
+    '\x00',
+    '\\x00'
   )
   capabilitiesLine.split(' ').map(x => capabilities.add(x))
-  const [ref, name] = splitAndAssert(firstRef, ' ')
+  const [ref, name] = splitAndAssert(firstRef, ' ', ' ')
   refs.set(name, ref)
   while (true) {
     const line = await read()
     if (line === true) break
     if (line !== null) {
-      const [ref, name] = splitAndAssert(line.toString('utf8'), ' ')
+      const [ref, name] = splitAndAssert(line.toString('utf8'), ' ', ' ')
       refs.set(name, ref)
     }
   }
@@ -53,11 +54,11 @@ export async function parseRefsAdResponse (stream, { service }) {
   return { capabilities, refs, symrefs }
 }
 
-function splitAndAssert (line, sep) {
+function splitAndAssert (line, sep, expected) {
   const split = line.trim().split(sep)
   if (split.length !== 2) {
     throw new GitError(E.AssertServerResponseFail, {
-      expected: sep,
+      expected,
       actual: line.toString('utf8')
     })
   }

--- a/src/wire/parseRefsAdResponse.js
+++ b/src/wire/parseRefsAdResponse.js
@@ -26,7 +26,10 @@ export async function parseRefsAdResponse (stream, { service }) {
   // In the edge case of a brand new repo, zero refs (and zero capabilities)
   // are returned.
   if (lineTwo === true) return { capabilities, refs, symrefs }
-  const [firstRef, capabilitiesLine] = splitAndCheck(lineTwo.toString('utf8'), '\x00')
+  const [firstRef, capabilitiesLine] = splitAndCheck(
+    lineTwo.toString('utf8'),
+    '\x00'
+  )
   capabilitiesLine.split(' ').map(x => capabilities.add(x))
   const [ref, name] = splitAndCheck(firstRef, ' ')
   refs.set(name, ref)
@@ -51,9 +54,7 @@ export async function parseRefsAdResponse (stream, { service }) {
 }
 
 function splitAndCheck (line, sep) {
-  const split = line
-    .trim()
-    .split(sep)
+  const split = line.trim().split(sep)
   if (split.length !== 2) {
     throw new GitError(E.AssertServerResponseFail, {
       expected: `Two words separated by '${sep}'`,


### PR DESCRIPTION
This fixes the 3 places in parseRefsAdResponse I see where the result of split(sep) is assumed to have two elements.  I'm throwing a hopefully informative error including the actual problematical response line.

There's one test for missing `\0`, one for missing space, and one for double space.

Currently the error message doesn't display the `\0` separator visibly, is there an easy way to do this?

I'm happy to squash the tests into the code change if desirable.

fixes #911