### PR TITLE
fix(statusMatrix): fix a bug in walkBeta2 that returned doubled entries

### DIFF
--- a/src/models/GitTree.js
+++ b/src/models/GitTree.js
@@ -84,9 +84,6 @@ export class GitTree {
   constructor (entries) {
     if (Buffer.isBuffer(entries)) {
       this._entries = parseBuffer(entries)
-      // There appears to be an edge case (in this repo no less) where
-      // the tree is NOT sorted as expected if some directories end with ".git"
-      this._entries.sort(comparePath)
     } else if (Array.isArray(entries)) {
       this._entries = entries.map(nudgeIntoShape)
     } else {
@@ -94,6 +91,9 @@ export class GitTree {
         message: 'invalid type passed to GitTree constructor'
       })
     }
+    // There appears to be an edge case (in this repo no less) where
+    // the tree is NOT sorted as expected if some directories end with ".git"
+    this._entries.sort(comparePath)
   }
 
   static from (tree) {

--- a/src/models/GitWalkerIndex2.js
+++ b/src/models/GitWalkerIndex2.js
@@ -54,13 +54,9 @@ export class GitWalkerIndex2 {
     if (inode.type !== 'tree') {
       throw new Error(`ENOTDIR: not a directory, scandir '${filepath}'`)
     }
-    return inode.children
-      .map(
-        inode => inode.fullpath
-        // TODO: Figure out why flatFileListToDirectoryStructure is not returning children
-        // sorted correctly for "__tests__/__fixtures__/test-push.git"
-      )
-      .sort((a, b) => compareStrings(a.fullpath, b.fullpath))
+    const names = inode.children.map(inode => inode.fullpath)
+    names.sort(compareStrings)
+    return names
   }
 
   async type (entry) {


### PR DESCRIPTION
## I'm fixing a rather embarassing bug or typo

- [x] squash merge the PR with commit message "fix: [Description of fix]"
