### PR TITLE
fix(fetch): handle HTML server response better

### DIFF
--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -214,8 +214,7 @@ access it.
       expect(error.code).toEqual(E.AssertServerResponseFail)
       expect(error.data).toEqual({
         expected: `Two strings separated by '\\x00'`,
-        actual:
-          `ERR Repository not found
+        actual: `ERR Repository not found
 The requested repository does not exist, or you do not have permission to
 access it.
 `

--- a/src/managers/GitRemoteHTTP.js
+++ b/src/managers/GitRemoteHTTP.js
@@ -114,9 +114,9 @@ export class GitRemoteHTTP {
       // If they don't send the correct content-type header, that's a good indicator it is either a "dumb" HTTP
       // server, or the user specified an incorrect remote URL and the response is actually an HTML page.
       // In this case, we save the response as plain text so we can generate a better error message if needed.
-      let data = await collect(res.body)
-      let response = data.toString('utf8')
-      let preview =
+      const data = await collect(res.body)
+      const response = data.toString('utf8')
+      const preview =
         response.length < 256 ? response : response.slice(0, 256) + '...'
       // For backwards compatibility, try to parse it anyway.
       try {

--- a/src/managers/GitRemoteHTTP.js
+++ b/src/managers/GitRemoteHTTP.js
@@ -1,12 +1,12 @@
 import { E, GitError } from '../models/GitError.js'
 import { calculateBasicAuthHeader } from '../utils/calculateBasicAuthHeader.js'
 import { calculateBasicAuthUsernamePasswordPair } from '../utils/calculateBasicAuthUsernamePasswordPair.js'
+import { collect } from '../utils/collect.js'
 import { extractAuthFromUrl } from '../utils/extractAuthFromUrl.js'
 import { http as builtinHttp } from '../utils/http.js'
 import { pkg } from '../utils/pkg.js'
 import { cores } from '../utils/plugins.js'
 import { parseRefsAdResponse } from '../wire/parseRefsAdResponse.js'
-import { collect } from '../utils/collect.js'
 
 // Try to accomodate known CORS proxy implementations:
 // - https://jcubic.pl/proxy.php?  <-- uses query string
@@ -104,7 +104,9 @@ export class GitRemoteHTTP {
       })
     }
     // Git "smart" HTTP servers should respond with the correct Content-Type header.
-    if (res.headers['content-type'] === `application/x-${service}-advertisement`) {
+    if (
+      res.headers['content-type'] === `application/x-${service}-advertisement`
+    ) {
       const remoteHTTP = await parseRefsAdResponse(res.body, { service })
       remoteHTTP.auth = auth
       return remoteHTTP
@@ -114,14 +116,18 @@ export class GitRemoteHTTP {
       // In this case, we save the response as plain text so we can generate a better error message if needed.
       let data = await collect(res.body)
       let response = data.toString('utf8')
-      let preview = response.length < 256 ? response : response.slice(0, 256) + '...'
+      let preview =
+        response.length < 256 ? response : response.slice(0, 256) + '...'
       // For backwards compatibility, try to parse it anyway.
       try {
         const remoteHTTP = await parseRefsAdResponse([data], { service })
         remoteHTTP.auth = auth
         return remoteHTTP
       } catch (e) {
-        throw new GitError(E.RemoteDoesNotSupportSmartHTTP, { preview, response })
+        throw new GitError(E.RemoteDoesNotSupportSmartHTTP, {
+          preview,
+          response
+        })
       }
     }
   }

--- a/src/models/GitError.js
+++ b/src/models/GitError.js
@@ -26,7 +26,7 @@ const messages = {
   RemoteDoesNotSupportDeepenSinceFail: `Remote does not support shallow fetches by date.`,
   RemoteDoesNotSupportDeepenNotFail: `Remote does not support shallow fetches excluding commits reachable by refs.`,
   RemoteDoesNotSupportDeepenRelativeFail: `Remote does not support shallow fetches relative to the current shallow depth.`,
-  RemoteDoesNotSupportSmartHTTP: `Remote does not support the "smart" HTTP protocol, and isomorphic-git does not support the "dumb" HTTP protocol, so they are incompatible.`,
+  RemoteDoesNotSupportSmartHTTP: `Remote did not reply using the "smart" HTTP protocol. Expected "001e# service=git-upload-pack" but received: { preview }`,
   CorruptShallowOidFail: `non-40 character shallow oid: { oid }`,
   FastForwardFail: `A simple fast-forward merge was not possible.`,
   MergeNotSupportedFail: `Merges with conflicts are not supported yet.`,


### PR DESCRIPTION
`E.RemoteDoesNotSupportSmartHTTP` was originally intended to be a more helpful error than `E.AssertServerResponseFail`. But it has become apparent that it is often a red herring, leading people down the rabbit hole of investigating "smart" vs "dumb" HTTP, and does their server support it, when in reality they simply entered a wrong URL and the remote is responding with an HTML page.

To make this scenario easier to recognize, now `E.RemoteDoesNotSupportSmartHTTP` will include a snippet from the HTTP response in the error message. (The complete response is available in the error `data` property.)

### Before
![image](https://user-images.githubusercontent.com/587740/68824089-b2d42d00-0663-11ea-97ea-8d3e3a1cb8c4.png)


### After
![image](https://user-images.githubusercontent.com/587740/68824515-1e6aca00-0665-11ea-8dd3-aa7a1432ccc0.png)

