### PR TITLE
fix: resolve "treeNotSorted: not properly sorted" git fsck error

### DIFF
--- a/__tests__/test-writeObject.js
+++ b/__tests__/test-writeObject.js
@@ -261,47 +261,45 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     // Setup
     const { gitdir } = await makeFixture('test-writeObject')
     // Test
-    const oid = await writeObject(
-      {
-        gitdir,
-        type: 'tree',
-        format: 'parsed',
-        object: {
-          entries: [
-            {
-              mode: '040000',
-              path: 'config',
-              oid: 'd564d0bc3dd917926892c55e3706cc116d5b165e',
-              type: 'tree'
-            },
-            {
-              mode: '100644',
-              path: 'config ',
-              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-              type: 'blob'
-            },
-            {
-              mode: '100644',
-              path: 'config.',
-              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-              type: 'blob'
-            },
-            {
-              mode: '100644',
-              path: 'config0',
-              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-              type: 'blob'
-            },
-            {
-              mode: '100644',
-              path: 'config~',
-              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-              type: 'blob'
-            }
-          ]
-        }
+    const oid = await writeObject({
+      gitdir,
+      type: 'tree',
+      format: 'parsed',
+      object: {
+        entries: [
+          {
+            mode: '040000',
+            path: 'config',
+            oid: 'd564d0bc3dd917926892c55e3706cc116d5b165e',
+            type: 'tree'
+          },
+          {
+            mode: '100644',
+            path: 'config ',
+            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+            type: 'blob'
+          },
+          {
+            mode: '100644',
+            path: 'config.',
+            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+            type: 'blob'
+          },
+          {
+            mode: '100644',
+            path: 'config0',
+            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+            type: 'blob'
+          },
+          {
+            mode: '100644',
+            path: 'config~',
+            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+            type: 'blob'
+          }
+        ]
       }
-    )
+    })
     expect(oid).toEqual('c8a72f5bd8633663210490897b798ddc3ff9ca64')
   })
   it('annotated tag', async () => {

--- a/__tests__/test-writeObject.js
+++ b/__tests__/test-writeObject.js
@@ -257,6 +257,53 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     })
     expect(oid).toEqual('6257985e3378ec42a03a57a7dc8eb952d69a5ff3')
   })
+  it('tree entries sorted correctly', async () => {
+    // Setup
+    const { gitdir } = await makeFixture('test-writeObject')
+    // Test
+    const oid = await writeObject(
+      {
+        gitdir,
+        type: 'tree',
+        format: 'parsed',
+        object: {
+          entries: [
+            {
+              mode: '040000',
+              path: 'config',
+              oid: 'd564d0bc3dd917926892c55e3706cc116d5b165e',
+              type: 'tree'
+            },
+            {
+              mode: '100644',
+              path: 'config ',
+              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+              type: 'blob'
+            },
+            {
+              mode: '100644',
+              path: 'config.',
+              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+              type: 'blob'
+            },
+            {
+              mode: '100644',
+              path: 'config0',
+              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+              type: 'blob'
+            },
+            {
+              mode: '100644',
+              path: 'config~',
+              oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+              type: 'blob'
+            }
+          ]
+        }
+      }
+    )
+    expect(oid).toEqual('c8a72f5bd8633663210490897b798ddc3ff9ca64')
+  })
   it('annotated tag', async () => {
     // Setup
     const { gitdir } = await makeFixture('test-writeObject')

--- a/src/utils/compareTreeEntryPath.js
+++ b/src/utils/compareTreeEntryPath.js
@@ -1,0 +1,10 @@
+import { compareStrings } from './compareStrings'
+
+export function compareTreeEntryPath (a, b) {
+  // Git sorts tree entries as if there is a trailing slash on directory names.
+  return compareStrings(appendSlashIfDir(a), appendSlashIfDir(b))
+}
+
+function appendSlashIfDir (entry) {
+  return entry.mode === '040000' ? entry.path + '/' : entry.path
+}


### PR DESCRIPTION
It turns out the proper sort order of `config`, `config0`, and `config.txt` in a Git Tree if `config` is a directory is:
- `config.txt`
- `config`
- `config0`

because git adds a virtual trailing slash to directory names, and in ASCII ordering `.` comes before `/` comes before `0`.

## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"
