### PR TITLE
Provide a noSubmodules switch for clone to avoid logging the no submodule support error

### DIFF
--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -57,7 +57,8 @@ export async function checkout ({
   ref,
   filepaths = ['.'],
   pattern = null,
-  noCheckout = false
+  noCheckout = false,
+  noSubmodules = false
 }) {
   try {
     const fs = new FileSystem(_fs)
@@ -165,11 +166,14 @@ export async function checkout ({
                 }
                 case 'commit': {
                   // gitlinks
-                  console.log(
-                    new GitError(E.NotImplementedFail, {
-                      thing: 'submodule support'
-                    })
-                  )
+                  if (!noSubmodules) {
+                    console.log(
+                      new GitError(E.NotImplementedFail, {
+                        thing: 'submodule support'
+                      })
+                    )
+                  }
+                  
                   break
                 }
                 case 'blob': {

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -173,7 +173,7 @@ export async function checkout ({
                       })
                     )
                   }
-                  
+
                   break
                 }
                 case 'blob': {

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -32,6 +32,7 @@ import { walkBeta2 } from './walkBeta2.js'
  * @param {string} [args.pattern = null] - Only checkout the files that match a glob pattern. (Pattern is relative to `filepaths` if `filepaths` is provided.)
  * @param {string} [args.remote = 'origin'] - Which remote repository to use
  * @param {boolean} [args.noCheckout = false] - If true, will update HEAD but won't update the working directory
+ * @param {boolean} [args.noSubmodules = false] - If true, will not print out an error about missing submodules support. TODO: Skip checkout out submodules when supported instead.
  *
  * @returns {Promise<void>} Resolves successfully when filesystem operations are complete
  *

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -23,6 +23,7 @@ import { init } from './init.js'
  * @param {string} [args.ref] - Which branch to clone. By default this is the designated "main branch" of the repository.
  * @param {boolean} [args.singleBranch = false] - Instead of the default behavior of fetching all the branches, only fetch a single branch.
  * @param {boolean} [args.noCheckout = false] - If true, clone will only fetch the repo, not check out a branch. Skipping checkout can save a lot of time normally spent writing files to disk.
+ * @param {boolean} [args.noSubmodules = false] - If true, clone will not log an error about missing submodule support. TODO: Make this not check out submodules when ther's submodule support
  * @param {boolean} [args.noGitSuffix = false] - If true, clone will not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**.)
  * @param {boolean} [args.noTags = false] - By default clone will fetch all tags. `noTags` disables that behavior.
  * @param {string} [args.remote = 'origin'] - What to name the remote that is created.
@@ -77,6 +78,7 @@ export async function clone ({
   relative = false,
   singleBranch = false,
   noCheckout = false,
+  noSubmodules = false,
   noTags = false,
   headers = {},
   // @ts-ignore
@@ -147,7 +149,8 @@ export async function clone ({
       emitterPrefix,
       ref,
       remote,
-      noCheckout
+      noCheckout,
+      noSubmodules
     })
   } catch (err) {
     err.caller = 'git.clone'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -294,6 +294,7 @@ export function checkout(args: WorkDir & GitDir & {
   ref: string;
   filepaths?: string[];
   pattern?: string;
+  noSubmodules?: boolean;
 }): Promise<void>;
 
 export function clone(args: WorkDir & GitDir & {
@@ -315,6 +316,7 @@ export function clone(args: WorkDir & GitDir & {
   relative?: boolean;
   singleBranch?: boolean;
   noCheckout?: boolean;
+  noSubmodules?: boolean;
   noTags?: boolean;
   headers?: { [key: string]: string };
 }): Promise<void>;


### PR DESCRIPTION
## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/clone.js` (and `checkout.js`)
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"

Maybe-fix for #942. Let me know if you are okay with this. I didn't have time to add a test case as I was editing this in the GitHub web UI. Feel free to add one or wait for me to add it, I'll try to take a look at this again.

I don't think the tests are failing because of me so I'm not looking into that closely.