### PR TITLE
feat(fetch, push, clone, pull): add autoTranslateSSH param

### DIFF
--- a/__tests__/__fixtures__/test-fetch-cors.git/config
+++ b/__tests__/__fixtures__/test-fetch-cors.git/config
@@ -7,5 +7,8 @@
 [remote "origin"]
 	url = https://github.com/isomorphic-git/isomorphic-git
 	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "ssh"]
+	url = git@github.com:isomorphic-git/isomorphic-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
 [http]
   corsProxy = http://localhost:9999

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -73,6 +73,76 @@ describe('fetch', () => {
     expect(shallow === '86ec153c7b48e02f92930d07542680f60d104d31\n').toBe(true)
   })
 
+  it('throws UnknownTransportError if using shorter scp-like syntax', async () => {
+    const { gitdir } = await makeFixture('test-fetch-cors')
+    await config({
+      gitdir,
+      path: 'http.corsProxy',
+      value: `http://${localhost}:9999`
+    })
+    // Test
+    let err = null
+    try {
+      await fetch({
+        gitdir,
+        depth: 1,
+        singleBranch: true,
+        remote: 'ssh',
+        ref: 'test-branch-shallow-clone'
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeDefined()
+    expect(err.code).toEqual(E.UnknownTransportError)
+  })
+
+  it('shallow fetch using autoTranslateSSH param (from Github)', async () => {
+    const { fs, gitdir } = await makeFixture('test-fetch-cors')
+    await config({
+      gitdir,
+      path: 'http.corsProxy',
+      value: `http://${localhost}:9999`
+    })
+    // Test
+    await fetch({
+      gitdir,
+      depth: 1,
+      singleBranch: true,
+      remote: 'ssh',
+      ref: 'test-branch-shallow-clone',
+      autoTranslateSSH: true
+    })
+    expect(await fs.exists(`${gitdir}/shallow`)).toBe(true)
+    const shallow = (await fs.read(`${gitdir}/shallow`)).toString('utf8')
+    expect(shallow === '92e7b4123fbf135f5ffa9b6fe2ec78d07bbc353e\n').toBe(true)
+  })
+
+  it('shallow fetch using autoTranslateSSH config (from Github)', async () => {
+    const { fs, gitdir } = await makeFixture('test-fetch-cors')
+    await config({
+      gitdir,
+      path: 'http.corsProxy',
+      value: `http://${localhost}:9999`
+    })
+    await config({
+      gitdir,
+      path: 'isomorphic-git.autoTranslateSSH',
+      value: true
+    })
+    // Test
+    await fetch({
+      gitdir,
+      depth: 1,
+      singleBranch: true,
+      remote: 'ssh',
+      ref: 'test-branch-shallow-clone'
+    })
+    expect(await fs.exists(`${gitdir}/shallow`)).toBe(true)
+    const shallow = (await fs.read(`${gitdir}/shallow`)).toString('utf8')
+    expect(shallow === '92e7b4123fbf135f5ffa9b6fe2ec78d07bbc353e\n').toBe(true)
+  })
+
   it('shallow fetch since (from Github)', async () => {
     const { fs, gitdir } = await makeFixture('test-fetch-cors')
     await config({

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -37,6 +37,7 @@ import { init } from './init.js'
  * @param {object} [args.headers = {}] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
  * @param {import('events').EventEmitter} [args.emitter] - [deprecated] Overrides the emitter set via the ['emitter' plugin](./plugin_emitter.md)
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name
+ * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  *
  * @returns {Promise<void>} Resolves successfully when clone completes
  *
@@ -79,6 +80,7 @@ export async function clone ({
   noCheckout = false,
   noTags = false,
   headers = {},
+  autoTranslateSSH = false,
   // @ts-ignore
   onprogress
 }) {
@@ -133,7 +135,8 @@ export async function clone ({
       relative,
       singleBranch,
       headers,
-      tags: !noTags
+      tags: !noTags,
+      autoTranslateSSH
     })
     if (fetchHead === null) return
     ref = ref || defaultBranch

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -17,6 +17,7 @@ import { join } from '../utils/join.js'
 import { pkg } from '../utils/pkg.js'
 import { cores } from '../utils/plugins.js'
 import { splitLines } from '../utils/splitLines.js'
+import { translateSSHtoHTTP } from '../utils/translateSSHtoHTTP.js'
 import { parseUploadPackResponse } from '../wire/parseUploadPackResponse.js'
 import { writeUploadPackRequest } from '../wire/writeUploadPackRequest.js'
 
@@ -63,6 +64,7 @@ import { config } from './config'
  * @param {object} [args.headers] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
  * @param {boolean} [args.prune] - Delete local remote-tracking branches that are not present on the remote
  * @param {boolean} [args.pruneTags] - Prune local tags that don’t exist on the remote, and force-update those tags that differ
+ * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  * @param {import('events').EventEmitter} [args.emitter] - [deprecated] Overrides the emitter set via the ['emitter' plugin](./plugin_emitter.md).
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name.
  *
@@ -113,6 +115,7 @@ export async function fetch ({
   headers = {},
   prune = false,
   pruneTags = false,
+  autoTranslateSSH = false,
   // @ts-ignore
   onprogress // deprecated
 }) {
@@ -147,7 +150,8 @@ export async function fetch ({
       singleBranch,
       headers,
       prune,
-      pruneTags
+      pruneTags,
+      autoTranslateSSH
     })
     if (response === null) {
       return {
@@ -238,7 +242,8 @@ async function fetchPackfile ({
   singleBranch,
   headers,
   prune,
-  pruneTags
+  pruneTags,
+  autoTranslateSSH
 }) {
   const fs = new FileSystem(_fs)
   // Sanity checks
@@ -257,6 +262,12 @@ async function fetchPackfile ({
       path: `remote.${remote}.url`
     })
   }
+
+  // Try to convert SSH URLs to HTTPS ones
+  if (autoTranslateSSH || await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` })) {
+    url = translateSSHtoHTTP(url)
+  }
+
   if (corsProxy === undefined) {
     corsProxy = await config({ fs, gitdir, path: 'http.corsProxy' })
   }

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -264,7 +264,10 @@ async function fetchPackfile ({
   }
 
   // Try to convert SSH URLs to HTTPS ones
-  if (autoTranslateSSH || await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` })) {
+  if (
+    autoTranslateSSH ||
+    (await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` }))
+  ) {
     url = translateSSHtoHTTP(url)
   }
 

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -36,6 +36,7 @@ import { merge } from './merge'
  * @param {Object} [args.author] - passed to [commit](commit.md) when creating a merge commit
  * @param {Object} [args.committer] - passed to [commit](commit.md) when creating a merge commit
  * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
+ * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  * @param {boolean} [args.fast = false] - use fastCheckout instead of regular checkout
  *
  * @returns {Promise<void>} Resolves successfully when pull operation completes
@@ -73,6 +74,7 @@ export async function pull ({
   author,
   committer,
   signingKey,
+  autoTranslateSSH = false,
   fast = false
 }) {
   try {
@@ -102,7 +104,8 @@ export async function pull ({
       token,
       oauth2format,
       singleBranch,
-      headers
+      headers,
+      autoTranslateSSH
     })
     // Merge the remote tracking branch into the local one.
     await merge({

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -112,7 +112,10 @@ export async function push ({
     }
 
     // Try to convert SSH URLs to HTTPS ones
-    if (autoTranslateSSH || await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` })) {
+    if (
+      autoTranslateSSH ||
+      (await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` }))
+    ) {
       url = translateSSHtoHTTP(url)
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -317,6 +317,7 @@ export function clone(args: WorkDir & GitDir & {
   noCheckout?: boolean;
   noTags?: boolean;
   headers?: { [key: string]: string };
+  autoTranslateSSH?: boolean;
 }): Promise<void>;
 
 export function commit(args: GitDir & {
@@ -432,6 +433,7 @@ export function fetch(args: GitDir & {
   prune?: boolean;
   pruneTags?: boolean;
   headers?: { [key: string]: string };
+  autoTranslateSSH?: boolean;
 }): Promise<FetchResponse>;
 
 export function findRoot(args: {
@@ -568,6 +570,7 @@ export function pull(args: WorkDir & GitDir & {
   headers?: { [key: string]: string };
   emitter?: EventEmitter;
   emitterPrefix?: string;
+  autoTranslateSSH?: boolean;
   author?: {
     name?: string;
     email?: string;
@@ -601,6 +604,7 @@ export function push(args: GitDir & {
   headers?: { [key: string]: string };
   emitter?: EventEmitter;
   emitterPrefix?: string;
+  autoTranslateSSH?: boolean;
 }): Promise<PushResponse>;
 
 export function readObject(args: GitDir & {

--- a/src/managers/GitRemoteManager.js
+++ b/src/managers/GitRemoteManager.js
@@ -3,6 +3,13 @@ import { E, GitError } from '../models/GitError.js'
 import { GitRemoteHTTP } from './GitRemoteHTTP'
 
 function parseRemoteUrl ({ url }) {
+  // the stupid "shorter scp-like syntax"
+  if (url.startsWith('git@')) {
+    return {
+      transport: 'ssh',
+      address: url
+    }
+  }
   const matches = url.match(/(\w+)(:\/\/|::)(.*)/)
   if (matches === null) return
   /*

--- a/src/models/GitConfig.js
+++ b/src/models/GitConfig.js
@@ -26,6 +26,9 @@ const schema = {
     symlinks: bool,
     ignorecase: bool,
     bigFileThreshold: num
+  },
+  'isomorphic-git': {
+    autoTranslateSSH: bool
   }
 }
 

--- a/src/utils/translateSSHtoHTTP.js
+++ b/src/utils/translateSSHtoHTTP.js
@@ -1,0 +1,7 @@
+export function translateSSHtoHTTP (url) {
+  // handle "shorter scp-like syntax"
+  url = url.replace(/^git@([^:]+):/, 'https://$1/')
+  // handle proper SSH URLs
+  url = url.replace(/^ssh:\/\//, 'https://')
+  return url
+}


### PR DESCRIPTION

## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
