### PR TITLE
Add noSubmodules to pull as well

### DIFF
--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -38,6 +38,7 @@ import { merge } from './merge'
  * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
  * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  * @param {boolean} [args.fast = false] - use fastCheckout instead of regular checkout
+ * @param {boolean} [args.noSubmodules = false] - If true, will not print out an error about missing submodules support. TODO: Skip checkout out submodules when supported instead.
  *
  * @returns {Promise<void>} Resolves successfully when pull operation completes
  *
@@ -75,7 +76,8 @@ export async function pull ({
   committer,
   signingKey,
   autoTranslateSSH = false,
-  fast = false
+  fast = false,
+  noSubmodules = false
 }) {
   try {
     const fs = new FileSystem(_fs)
@@ -135,7 +137,8 @@ export async function pull ({
         fs,
         ref,
         emitter,
-        emitterPrefix
+        emitterPrefix,
+        noSubmodules
       })
     }
   } catch (err) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -588,6 +588,7 @@ export function pull(args: WorkDir & GitDir & {
     timezoneOffset?: number;
   };
   signingKey?: string;
+  noSubmodules?: boolean;
 }): Promise<void>;
 
 export function push(args: GitDir & {


### PR DESCRIPTION
## I'm adding a parameter to an existing command:

- [x] add parameter to the function in `src/commands/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add parameter to the TypeScript library definition for X in `src/index.d.ts`
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] squash merge the PR with commit message "feat: Added 'bar' parameter to X command"
