### PR TITLE
perf: use native browser 'deflate' if available

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -111,6 +111,10 @@ module.exports = function (config) {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox']
+      },
+      ChromeCanaryHeadlessNoSandbox: {
+        base: 'ChromeCanaryHeadless',
+        flags: ['--no-sandbox']
       }
     },
     sauceLabs: {
@@ -218,6 +222,7 @@ module.exports = function (config) {
     options.browsers.push('ChromeHeadlessNoSandbox')
     options.browsers.push('FirefoxHeadless')
     // options.browsers.push('Edge')
+    // options.browsers.push('ChromeCanaryHeadlessNoSandbox')
   }
 
   if (!process.env.TEST_NO_BROWSERS) {

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -4,8 +4,8 @@ import * as marky from 'marky'
 
 import { E, GitError } from '../models/GitError.js'
 import { BufferCursor } from '../utils/BufferCursor.js'
-import { inflate } from '../utils/inflate.js'
 import { listpack } from '../utils/git-list-pack.js'
+import { inflate } from '../utils/inflate.js'
 import { log } from '../utils/log.js'
 import { shasum } from '../utils/shasum.js'
 

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -1,10 +1,10 @@
 import crc32 from 'crc-32'
 import applyDelta from 'git-apply-delta'
 import * as marky from 'marky'
-import pako from 'pako'
 
 import { E, GitError } from '../models/GitError.js'
 import { BufferCursor } from '../utils/BufferCursor.js'
+import { inflate } from '../utils/inflate.js'
 import { listpack } from '../utils/git-list-pack.js'
 import { log } from '../utils/log.js'
 import { shasum } from '../utils/shasum.js'
@@ -434,7 +434,7 @@ export class GitPackIndex {
     }
     // Handle undeltified objects
     const buffer = raw.slice(reader.tell())
-    object = Buffer.from(pako.inflate(buffer))
+    object = Buffer.from(await inflate(buffer))
     // Assert that the object length is as expected.
     if (object.byteLength !== length) {
       throw new GitError(E.InternalFail, {

--- a/src/storage/readObject.js
+++ b/src/storage/readObject.js
@@ -1,10 +1,9 @@
-import pako from 'pako'
-
 import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { GitObject } from '../models/GitObject.js'
 import { readObjectLoose } from '../storage/readObjectLoose.js'
 import { readObjectPacked } from '../storage/readObjectPacked.js'
+import { inflate } from '../utils/inflate.js'
 import { shasum } from '../utils/shasum.js'
 
 export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) {
@@ -42,7 +41,7 @@ export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) 
   /* eslint-disable no-fallthrough */
   switch (result.format) {
     case 'deflated':
-      result.object = Buffer.from(pako.inflate(result.object))
+      result.object = Buffer.from(await inflate(result.object))
       result.format = 'wrapped'
     case 'wrapped':
       if (format === 'wrapped' && result.format === 'wrapped') {

--- a/src/storage/writeObject.js
+++ b/src/storage/writeObject.js
@@ -1,8 +1,7 @@
-import pako from 'pako'
-
 import { FileSystem } from '../models/FileSystem.js'
 import { GitObject } from '../models/GitObject.js'
 import { writeObjectLoose } from '../storage/writeObjectLoose.js'
+import { deflate } from '../utils/deflate.js'
 import { shasum } from '../utils/shasum.js'
 
 export async function writeObject ({
@@ -19,7 +18,7 @@ export async function writeObject ({
       object = GitObject.wrap({ type, object })
     }
     oid = await shasum(object)
-    object = Buffer.from(pako.deflate(object))
+    object = Buffer.from(await deflate(object))
   }
   if (!dryRun) {
     const fs = new FileSystem(_fs)

--- a/src/utils/deflate.js
+++ b/src/utils/deflate.js
@@ -1,0 +1,28 @@
+/* eslint-env node, browser */
+/* global CompressionStream */
+import pako from 'pako'
+
+let supportsCompressionStream = null
+
+export async function deflate (buffer) {
+  if (supportsCompressionStream === null) {
+    supportsCompressionStream = testCompressionStream()
+  }
+  return supportsCompressionStream ? browserDeflate(buffer) : pako.deflate(buffer)
+}
+
+async function browserDeflate (buffer) {
+  const cs = new CompressionStream('deflate')
+  const c = new Blob([buffer]).stream().pipeThrough(cs)
+  return new Uint8Array(await new Response(c).arrayBuffer())
+}
+
+function testCompressionStream () {
+  try {
+    const cs = new CompressionStream('deflate')
+    if (cs) return true
+  } catch (_) {
+    // no bother
+  }
+  return false
+}

--- a/src/utils/deflate.js
+++ b/src/utils/deflate.js
@@ -8,7 +8,9 @@ export async function deflate (buffer) {
   if (supportsCompressionStream === null) {
     supportsCompressionStream = testCompressionStream()
   }
-  return supportsCompressionStream ? browserDeflate(buffer) : pako.deflate(buffer)
+  return supportsCompressionStream
+    ? browserDeflate(buffer)
+    : pako.deflate(buffer)
 }
 
 async function browserDeflate (buffer) {

--- a/src/utils/inflate.js
+++ b/src/utils/inflate.js
@@ -1,0 +1,28 @@
+/* eslint-env node, browser */
+/* global DecompressionStream */
+import pako from 'pako'
+
+let supportsDecompressionStream = false
+
+export async function inflate (buffer) {
+  if (supportsDecompressionStream === null) {
+    supportsDecompressionStream = testDecompressionStream()
+  }
+  return supportsDecompressionStream ? browserInflate(buffer) : pako.inflate(buffer)
+}
+
+async function browserInflate (buffer) {
+  const ds = new DecompressionStream('deflate')
+  const d = new Blob([buffer]).stream().pipeThrough(ds)
+  return new Uint8Array(await new Response(d).arrayBuffer())
+}
+
+function testDecompressionStream () {
+  try {
+    const ds = new DecompressionStream('deflate')
+    if (ds) return true
+  } catch (_) {
+    // no bother
+  }
+  return false
+}

--- a/src/utils/inflate.js
+++ b/src/utils/inflate.js
@@ -8,7 +8,9 @@ export async function inflate (buffer) {
   if (supportsDecompressionStream === null) {
     supportsDecompressionStream = testDecompressionStream()
   }
-  return supportsDecompressionStream ? browserInflate(buffer) : pako.inflate(buffer)
+  return supportsDecompressionStream
+    ? browserInflate(buffer)
+    : pako.inflate(buffer)
 }
 
 async function browserInflate (buffer) {


### PR DESCRIPTION
A progressive enhancement to use `new DecompressionStream('deflate')` and `new CompressionStream('deflate')` if is available instead of the pure JS implementation in pako.

Chrome 80 has signaled an [intent to ship](https://groups.google.com/a/chromium.org/forum/m/#!topic/blink-dev/JmwpHPTu3XM) with them.

I have not bothered to measure if there is a performance difference. The simple fact that the compression/decompression happens in a separate thread pretty much guarantees it'll be a win for browser users.

`pako` is still needed to index packfiles, because so far only `pako`'s direct port of zlib's streaming implementation has the quirky ability to detect the end of `deflate` data in the middle of a stream.