### PR TITLE
fix: trim multi-line commit messages when tweeting about release

### DIFF
--- a/__tests__/__helpers__/tweet.js
+++ b/__tests__/__helpers__/tweet.js
@@ -12,7 +12,7 @@ var tweet = TweetTweet({
 })
 
 let commitMessage = process.env.BUILD_SOURCEVERSIONMESSAGE
-commitMessage = commitMessage ? '\n\n' + commitMessage : ''
+commitMessage = commitMessage ? '\n\n' + commitMessage.split('\n')[0] : ''
 
 tweet(message + commitMessage, function (err, response) {
   if (err) return console.log(err)


### PR DESCRIPTION
This bug has been driving me nuts.