### PR TITLE
fix(checkout): files that don't match filepaths/pattern should be left alone

### DIFF
--- a/__tests__/test-checkout.js
+++ b/__tests__/test-checkout.js
@@ -187,4 +187,22 @@ describe('checkout', () => {
     const index = await listFiles({ dir, gitdir })
     expect(index).toMatchSnapshot()
   })
+
+  it('checkout files should not delete other files', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    await checkout({
+      dir,
+      gitdir,
+      ref: 'test-branch'
+    })
+    await checkout({
+      dir,
+      gitdir,
+      ref: 'test-branch',
+      filepaths: ['src/utils', 'test']
+    })
+    const files = await fs.readdir(dir)
+    expect(files).toContain('README.md')
+  })
 })

--- a/__tests__/test-fastCheckout.js
+++ b/__tests__/test-fastCheckout.js
@@ -252,4 +252,22 @@ describe('fastCheckout', () => {
     expect(error).toBeNull()
     expect(await fs.read(`${dir}/README.md`, 'utf8')).not.toBe('Hello world')
   })
+
+  it('checkout files should not delete other files', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    await fastCheckout({
+      dir,
+      gitdir,
+      ref: 'test-branch'
+    })
+    await fastCheckout({
+      dir,
+      gitdir,
+      ref: 'test-branch',
+      filepaths: ['src/utils', 'test']
+    })
+    const files = await fs.readdir(dir)
+    expect(files).toContain('README.md')
+  })
 })

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -121,6 +121,24 @@ export async function checkout ({
         // that are not present in the new branch, and only write files that
         // are not in the index or are in the index but have the wrong SHA.
         for (const entry of index) {
+          // match against base paths
+          if (!bases.some(base => worthWalking(entry.path, base))) {
+            continue
+          }
+
+          // filter against file names
+          if (patternGlobrex) {
+            let match = false
+            for (const base of bases) {
+              const partToMatch = entry.path.replace(base + '/', '')
+              if (patternGlobrex.regex.test(partToMatch)) {
+                match = true
+                break
+              }
+            }
+            if (!match) continue
+          }
+
           try {
             await fs.rm(join(dir, entry.path))
             if (emitter) {


### PR DESCRIPTION
fixes #952

## I'm fixing a bug or typo

- [ ] squash merge the PR with commit message "fix: [Description of fix]"
