### PR TITLE
chore(website): Error: Failed to replace env in config: ${NPM_TOKEN}

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,3 +81,4 @@ jobs:
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     env:
       GITHUB_TOKEN: $(GITHUB_TOKEN)
+      NPM_TOKEN: $(Npm.Token)


### PR DESCRIPTION
## I'm fixing a bug or typo

```
Starting: Update website
==============================================================================
Task         : Command line
Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
Version      : 2.163.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
==============================================================================
Generating script.
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:7302) Warning: Use Cipheriv for counter mode of aes-256-ctr
Script contents:
npm run publish-website
========================== Starting Command Output ===========================
/bin/bash --noprofile --norc /home/vsts/work/_temp/a347b471-0c01-457e-88b3-ed7bba13c411.sh
Error: Failed to replace env in config: ${NPM_TOKEN}
    at /opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/config/core.js:415:13
    at String.replace (<anonymous>)
    at envReplace (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/config/core.js:411:12)
    at parseField (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/config/core.js:389:7)
    at /opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/config/core.js:330:24
    at Array.forEach (<anonymous>)
    at Conf.add (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/config/core.js:328:23)
    at ConfigChain.addString (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/node_modules/config-chain/index.js:244:8)
    at Conf.<anonymous> (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/config/core.js:316:10)
    at /opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:115:16
/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/npm.js:59
      throw new Error('npm.load() required')
      ^

Error: npm.load() required
    at Object.get (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/npm.js:59:13)
    at process.errorHandler (/opt/hostedtoolcache/node/8.17.0/x64/lib/node_modules/npm/lib/utils/error-handler.js:205:32)
    at emitOne (events.js:116:13)
    at process.emit (events.js:211:7)
    at process._fatalException (bootstrap_node.js:391:26)
##[error]Bash exited with code '7'.
Finishing: Update website
```

No idea what that's about, unless the `semantic-release` step is leaving some crap behind like an `.npmrc` file. Anyhow, should be safe to provide that variable even if I don't see why it's needed.