### PR TITLE
fix: run docusaurus-version *before* docusaurus-build

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -76,15 +76,17 @@ module.exports = {
     },
     website: {
       default: series.nps(
-        'website.build',
+        'website.install',
         'website.version',
+        'website.build',
         'website.publish'
       ),
-      build: '(cd website && npm install && npm run build)',
+      install: `(cd website && npm install)`,
       version:
         pkg.version === '0.0.0-development'
           ? 'echo "Not a new version"'
           : `(cd website && npm run create-version ${pkg.version})`,
+      build: '(cd website && npm run build)',
       publish: '(cd website && node ./scripts/deploy-gh-pages.js)'
     },
     // ATTENTION:


### PR DESCRIPTION
## I'm fixing a bug or typo

Edit: Grr you know what, this won't work either. Because the versions need to be saved back to `website/versioned_docs` and `website/versioned_sidebars` and that'll need to be committed _back_ to the `master` branch........ ugh. Time to rethink / restructure this.