### PR TITLE
chore: remove the 'autoTranslateSSH' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ At the time of writing, the following breaking changes are planned:
   - [x] The `signing` function argument of `log` will be removed, and `log` will simply always return a payload. **Update: Actually, it now returns the same kind of objects as `readCommit` because that just makes a lot of sense.** (This change is to simplify the type signature of `log` so we don't need function overloading; it is the only thing blocking me from abandoning the hand-crafted `index.d.ts` file and generating the TypeScript definitions directly from the JSDoc tags that already power the website docs.)
 - [ ] Any functions that currently return `Buffer` objects will instead return `Uint8Array` so we can eventually drop the bloated Buffer browser polyfill.
 - [x] The `pattern` and globbing options will be removed from `statusMatrix` so we can drop the dependencies on `globalyzer` and `globrex`, but you'll be able to bring your own `filter` function instead.
-- [ ] The `autoTranslateSSH` feature will be removed, since it's trivial to implement using just the `UnknownTransportError.data.suggestion`
+- [x] The `autoTranslateSSH` feature will be removed, since it's trivial to implement using just the `UnknownTransportError.data.suggestion`
 
 ## Getting Started
 

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -81,7 +81,7 @@ describe('fetch', () => {
       value: `http://${localhost}:9999`
     })
     // Test
-    let err = null
+    let err
     try {
       await fetch({
         gitdir,
@@ -97,7 +97,7 @@ describe('fetch', () => {
     expect(err.code).toEqual(E.UnknownTransportError)
   })
 
-  it('shallow fetch using autoTranslateSSH param (from Github)', async () => {
+  it('the SSH -> HTTPS UnknownTransportError suggestion feature', async () => {
     const { fs, gitdir } = await makeFixture('test-fetch-cors')
     await config({
       gitdir,
@@ -105,42 +105,21 @@ describe('fetch', () => {
       value: `http://${localhost}:9999`
     })
     // Test
-    await fetch({
-      gitdir,
-      depth: 1,
-      singleBranch: true,
-      remote: 'ssh',
-      ref: 'test-branch-shallow-clone',
-      autoTranslateSSH: true
-    })
-    expect(await fs.exists(`${gitdir}/shallow`)).toBe(true)
-    const shallow = (await fs.read(`${gitdir}/shallow`)).toString('utf8')
-    expect(shallow === '92e7b4123fbf135f5ffa9b6fe2ec78d07bbc353e\n').toBe(true)
-  })
-
-  it('shallow fetch using autoTranslateSSH config (from Github)', async () => {
-    const { fs, gitdir } = await makeFixture('test-fetch-cors')
-    await config({
-      gitdir,
-      path: 'http.corsProxy',
-      value: `http://${localhost}:9999`
-    })
-    await config({
-      gitdir,
-      path: 'isomorphic-git.autoTranslateSSH',
-      value: true
-    })
-    // Test
-    await fetch({
-      gitdir,
-      depth: 1,
-      singleBranch: true,
-      remote: 'ssh',
-      ref: 'test-branch-shallow-clone'
-    })
-    expect(await fs.exists(`${gitdir}/shallow`)).toBe(true)
-    const shallow = (await fs.read(`${gitdir}/shallow`)).toString('utf8')
-    expect(shallow === '92e7b4123fbf135f5ffa9b6fe2ec78d07bbc353e\n').toBe(true)
+    let err
+    try {
+      await fetch({
+        gitdir,
+        depth: 1,
+        singleBranch: true,
+        remote: 'ssh',
+        ref: 'test-branch-shallow-clone'
+      })
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeDefined()
+    expect(err.code).toBe(E.UnknownTransportError)
+    expect(err.data.suggestion).toBe('https://github.com/isomorphic-git/isomorphic-git.git')
   })
 
   it('shallow fetch since (from Github)', async () => {

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -98,7 +98,7 @@ describe('fetch', () => {
   })
 
   it('the SSH -> HTTPS UnknownTransportError suggestion feature', async () => {
-    const { fs, gitdir } = await makeFixture('test-fetch-cors')
+    const { gitdir } = await makeFixture('test-fetch-cors')
     await config({
       gitdir,
       path: 'http.corsProxy',

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -119,7 +119,9 @@ describe('fetch', () => {
     }
     expect(err).toBeDefined()
     expect(err.code).toBe(E.UnknownTransportError)
-    expect(err.data.suggestion).toBe('https://github.com/isomorphic-git/isomorphic-git.git')
+    expect(err.data.suggestion).toBe(
+      'https://github.com/isomorphic-git/isomorphic-git.git'
+    )
   })
 
   it('shallow fetch since (from Github)', async () => {

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -39,7 +39,6 @@ import { init } from './init.js'
  * @param {object} [args.headers = {}] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
  * @param {import('events').EventEmitter} [args.emitter] - [deprecated] Overrides the emitter set via the ['emitter' plugin](./plugin_emitter.md)
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name
- * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  *
  * @returns {Promise<void>} Resolves successfully when clone completes
  *
@@ -84,7 +83,6 @@ export async function clone ({
   newSubmoduleBehavior = false,
   noTags = false,
   headers = {},
-  autoTranslateSSH = false,
   // @ts-ignore
   onprogress
 }) {
@@ -139,8 +137,7 @@ export async function clone ({
       relative,
       singleBranch,
       headers,
-      tags: !noTags,
-      autoTranslateSSH
+      tags: !noTags
     })
     if (fetchHead === null) return
     ref = ref || defaultBranch

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -17,7 +17,6 @@ import { join } from '../utils/join.js'
 import { pkg } from '../utils/pkg.js'
 import { cores } from '../utils/plugins.js'
 import { splitLines } from '../utils/splitLines.js'
-import { translateSSHtoHTTP } from '../utils/translateSSHtoHTTP.js'
 import { parseUploadPackResponse } from '../wire/parseUploadPackResponse.js'
 import { writeUploadPackRequest } from '../wire/writeUploadPackRequest.js'
 
@@ -64,7 +63,6 @@ import { config } from './config'
  * @param {object} [args.headers] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
  * @param {boolean} [args.prune] - Delete local remote-tracking branches that are not present on the remote
  * @param {boolean} [args.pruneTags] - Prune local tags that don’t exist on the remote, and force-update those tags that differ
- * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  * @param {import('events').EventEmitter} [args.emitter] - [deprecated] Overrides the emitter set via the ['emitter' plugin](./plugin_emitter.md).
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name.
  *
@@ -115,7 +113,6 @@ export async function fetch ({
   headers = {},
   prune = false,
   pruneTags = false,
-  autoTranslateSSH = false,
   // @ts-ignore
   onprogress // deprecated
 }) {
@@ -151,7 +148,6 @@ export async function fetch ({
       headers,
       prune,
       pruneTags,
-      autoTranslateSSH
     })
     if (response === null) {
       return {
@@ -242,8 +238,7 @@ async function fetchPackfile ({
   singleBranch,
   headers,
   prune,
-  pruneTags,
-  autoTranslateSSH
+  pruneTags
 }) {
   const fs = new FileSystem(_fs)
   // Sanity checks
@@ -261,14 +256,6 @@ async function fetchPackfile ({
       gitdir,
       path: `remote.${remote}.url`
     })
-  }
-
-  // Try to convert SSH URLs to HTTPS ones
-  if (
-    autoTranslateSSH ||
-    (await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` }))
-  ) {
-    url = translateSSHtoHTTP(url)
   }
 
   if (corsProxy === undefined) {

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -147,7 +147,7 @@ export async function fetch ({
       singleBranch,
       headers,
       prune,
-      pruneTags,
+      pruneTags
     })
     if (response === null) {
       return {

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -35,7 +35,6 @@ import { merge } from './merge'
  * @param {Object} [args.author] - passed to [commit](commit.md) when creating a merge commit
  * @param {Object} [args.committer] - passed to [commit](commit.md) when creating a merge commit
  * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
- * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  * @param {boolean} [args.noSubmodules = false] - If true, will not print out an error about missing submodules support. TODO: Skip checkout out submodules when supported instead.
  * @param {boolean} [args.newSubmoduleBehavior = false] - If true, will opt into a newer behavior that improves submodule non-support by at least not accidentally deleting them.
  *
@@ -74,7 +73,6 @@ export async function pull ({
   author,
   committer,
   signingKey,
-  autoTranslateSSH = false,
   noSubmodules = false,
   newSubmoduleBehavior = false
 }) {
@@ -105,8 +103,7 @@ export async function pull ({
       token,
       oauth2format,
       singleBranch,
-      headers,
-      autoTranslateSSH
+      headers
     })
     // Merge the remote tracking branch into the local one.
     await merge({

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -10,7 +10,6 @@ import { join } from '../utils/join.js'
 import { pkg } from '../utils/pkg.js'
 import { cores } from '../utils/plugins.js'
 import { splitLines } from '../utils/splitLines.js'
-import { translateSSHtoHTTP } from '../utils/translateSSHtoHTTP.js'
 import { parseReceivePackResponse } from '../wire/parseReceivePackResponse.js'
 import { writeReceivePackRequest } from '../wire/writeReceivePackRequest.js'
 
@@ -63,7 +62,6 @@ import { pack } from './pack.js'
  * @param {string} [args.token] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.oauth2format] - See the [Authentication](./authentication.html) documentation
  * @param {object} [args.headers] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
- * @param {boolean} [args.autoTranslateSSH] - Attempt to automatically translate SSH remotes into HTTP equivalents
  * @param {import('events').EventEmitter} [args.emitter] - [deprecated] Overrides the emitter set via the ['emitter' plugin](./plugin_emitter.md).
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name.
  *
@@ -103,22 +101,13 @@ export async function push ({
   password = authPassword,
   token,
   oauth2format,
-  headers = {},
-  autoTranslateSSH = false
+  headers = {}
 }) {
   try {
     const fs = new FileSystem(_fs)
     // TODO: Figure out how pushing tags works. (This only works for branches.)
     if (url === undefined) {
       url = await config({ fs, gitdir, path: `remote.${remote}.url` })
-    }
-
-    // Try to convert SSH URLs to HTTPS ones
-    if (
-      autoTranslateSSH ||
-      (await config({ fs, gitdir, path: `isomorphic-git.autoTranslateSSH` }))
-    ) {
-      url = translateSSHtoHTTP(url)
     }
 
     if (corsProxy === undefined) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -399,7 +399,6 @@ export function clone(args: WorkDir & GitDir & {
   noGitSuffix?: boolean;
   noTags?: boolean;
   headers?: { [key: string]: string };
-  autoTranslateSSH?: boolean;
 }): Promise<void>;
 
 export function commit(args: GitDir & {
@@ -501,7 +500,6 @@ export function fetch(args: GitDir & {
   prune?: boolean;
   pruneTags?: boolean;
   headers?: { [key: string]: string };
-  autoTranslateSSH?: boolean;
 }): Promise<FetchResponse>;
 
 export function findRoot(args: {
@@ -631,7 +629,6 @@ export function pull(args: WorkDir & GitDir & {
   headers?: { [key: string]: string };
   emitter?: EventEmitter;
   emitterPrefix?: string;
-  autoTranslateSSH?: boolean;
   author?: {
     name?: string;
     email?: string;
@@ -668,7 +665,6 @@ export function push(args: GitDir & {
   headers?: { [key: string]: string };
   emitter?: EventEmitter;
   emitterPrefix?: string;
-  autoTranslateSSH?: boolean;
 }): Promise<PushResponse>;
 
 export function readBlob(args: GitDir & {

--- a/src/models/GitConfig.js
+++ b/src/models/GitConfig.js
@@ -26,9 +26,6 @@ const schema = {
     symlinks: bool,
     ignorecase: bool,
     bigFileThreshold: num
-  },
-  'isomorphic-git': {
-    autoTranslateSSH: bool
   }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The `autoTranslateSSH` feature has been removed since it's kind of hacky, and it's trivial to implement your own version using the `data.suggestion` property of the `UnknownTransportError` when something fails.