### PR TITLE
chore: return Uint8Arrays instead of Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ At the time of writing, the following breaking changes are planned:
   - [ ] The `fs` and `emitter` function arguments will be removed.
   - [x] The `fast` argument to `pull` will be removed since it will always use the `fastCheckout` implementation.
   - [x] The `signing` function argument of `log` will be removed, and `log` will simply always return a payload. **Update: Actually, it now returns the same kind of objects as `readCommit` because that just makes a lot of sense.** (This change is to simplify the type signature of `log` so we don't need function overloading; it is the only thing blocking me from abandoning the hand-crafted `index.d.ts` file and generating the TypeScript definitions directly from the JSDoc tags that already power the website docs.)
-- [ ] Any functions that currently return `Buffer` objects will instead return `Uint8Array` so we can eventually drop the bloated Buffer browser polyfill.
+- [x] Any functions that currently return `Buffer` objects will instead return `Uint8Array` so we can eventually drop the bloated Buffer browser polyfill.
 - [x] The `pattern` and globbing options will be removed from `statusMatrix` so we can drop the dependencies on `globalyzer` and `globrex`, but you'll be able to bring your own `filter` function instead.
 - [x] The `autoTranslateSSH` feature will be removed, since it's trivial to implement using just the `UnknownTransportError.data.suggestion`
 - [ ] The `internal-apis` will be excluded from `dist` before publishing. Because those are only exposed so I could unit test them and no one should be using them lol.

--- a/__tests__/test-addNote.js
+++ b/__tests__/test-addNote.js
@@ -27,7 +27,9 @@ describe('addNote', () => {
       oid: '3b4b7a6c2382ea60a0b4c7ff69920af9a2e6408d',
       filepath: 'f6d51b1f9a449079f6999be1fb249c359511f164'
     })
-    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a commit.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
+      'This is a note about a commit.'
+    )
   })
   it('to a tree', async () => {
     // Setup
@@ -52,7 +54,9 @@ describe('addNote', () => {
       oid: '4b52ff827d2b5fe1786bf52a1b78dd25517b6cdd',
       filepath: '199948939a0b95c6f27668689102496574b2c332'
     })
-    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a tree.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
+      'This is a note about a tree.'
+    )
   })
   it('to a blob', async () => {
     // Setup
@@ -77,7 +81,9 @@ describe('addNote', () => {
       oid: '6428616e2600d3cd4b66059d5c561a85ce4b33ff',
       filepath: '68aba62e560c0ebc3396e8ae9335232cd93a3f60'
     })
-    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a blob.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
+      'This is a note about a blob.'
+    )
   })
   it('consecutive notes accumulate', async () => {
     // Setup
@@ -153,7 +159,9 @@ describe('addNote', () => {
       oid: '6428616e2600d3cd4b66059d5c561a85ce4b33ff',
       filepath: '68aba62e560c0ebc3396e8ae9335232cd93a3f60'
     })
-    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a blob.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
+      'This is a note about a blob.'
+    )
   })
   it('throws if note already exists', async () => {
     // Setup

--- a/__tests__/test-addNote.js
+++ b/__tests__/test-addNote.js
@@ -27,7 +27,7 @@ describe('addNote', () => {
       oid: '3b4b7a6c2382ea60a0b4c7ff69920af9a2e6408d',
       filepath: 'f6d51b1f9a449079f6999be1fb249c359511f164'
     })
-    expect(blob.toString('utf8')).toEqual('This is a note about a commit.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a commit.')
   })
   it('to a tree', async () => {
     // Setup
@@ -52,7 +52,7 @@ describe('addNote', () => {
       oid: '4b52ff827d2b5fe1786bf52a1b78dd25517b6cdd',
       filepath: '199948939a0b95c6f27668689102496574b2c332'
     })
-    expect(blob.toString('utf8')).toEqual('This is a note about a tree.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a tree.')
   })
   it('to a blob', async () => {
     // Setup
@@ -77,7 +77,7 @@ describe('addNote', () => {
       oid: '6428616e2600d3cd4b66059d5c561a85ce4b33ff',
       filepath: '68aba62e560c0ebc3396e8ae9335232cd93a3f60'
     })
-    expect(blob.toString('utf8')).toEqual('This is a note about a blob.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a blob.')
   })
   it('consecutive notes accumulate', async () => {
     // Setup
@@ -153,7 +153,7 @@ describe('addNote', () => {
       oid: '6428616e2600d3cd4b66059d5c561a85ce4b33ff',
       filepath: '68aba62e560c0ebc3396e8ae9335232cd93a3f60'
     })
-    expect(blob.toString('utf8')).toEqual('This is a note about a blob.')
+    expect(Buffer.from(blob).toString('utf8')).toEqual('This is a note about a blob.')
   })
   it('throws if note already exists', async () => {
     // Setup
@@ -221,7 +221,7 @@ describe('addNote', () => {
       oid,
       filepath: 'f6d51b1f9a449079f6999be1fb249c359511f164'
     })
-    expect(blob.toString('utf8')).toEqual(
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
       'This is the newer note about a commit.'
     )
   })

--- a/__tests__/test-hashBlob.js
+++ b/__tests__/test-hashBlob.js
@@ -39,14 +39,14 @@ const wrapped = Buffer.concat([
 ])
 
 describe('hashBlob', () => {
-  it('object as Buffer', async () => {
+  it('object as Uint8Array', async () => {
     // Test
     const { oid, object, format } = await hashBlob({
       object: buffer
     })
     expect(oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
     expect(format).toEqual('wrapped')
-    expect(Buffer.compare(object, wrapped) === 0).toBe(true)
+    expect(Buffer.compare(Buffer.from(object), wrapped) === 0).toBe(true)
   })
 
   it('object as String', async () => {
@@ -56,6 +56,6 @@ describe('hashBlob', () => {
     })
     expect(oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
     expect(format).toEqual('wrapped')
-    expect(Buffer.compare(object, wrapped) === 0).toBe(true)
+    expect(Buffer.compare(Buffer.from(object), wrapped) === 0).toBe(true)
   })
 })

--- a/__tests__/test-packObjects.js
+++ b/__tests__/test-packObjects.js
@@ -32,6 +32,7 @@ describe('packObjects', () => {
     })
     expect(filename).toBe('pack-76178ca22ef818f971fca371d84bce571d474b1d.pack')
     expect(fixture.buffer).toEqual(packfile.buffer)
+    expect(Buffer.compare(Buffer.from(fixture), Buffer.from(packfile)) === 0).toBe(true)
     expect(await fs.exists(path.join(gitdir, `objects/pack/${filename}`))).toBe(
       false
     )
@@ -67,5 +68,6 @@ describe('packObjects', () => {
     expect(await fs.exists(filepath)).toBe(true)
     const packfile = await fs.read(filepath)
     expect(fixture.buffer).toEqual(packfile.buffer)
+    expect(Buffer.compare(Buffer.from(fixture), Buffer.from(packfile)) === 0).toBe(true)
   })
 })

--- a/__tests__/test-packObjects.js
+++ b/__tests__/test-packObjects.js
@@ -32,7 +32,9 @@ describe('packObjects', () => {
     })
     expect(filename).toBe('pack-76178ca22ef818f971fca371d84bce571d474b1d.pack')
     expect(fixture.buffer).toEqual(packfile.buffer)
-    expect(Buffer.compare(Buffer.from(fixture), Buffer.from(packfile)) === 0).toBe(true)
+    expect(
+      Buffer.compare(Buffer.from(fixture), Buffer.from(packfile)) === 0
+    ).toBe(true)
     expect(await fs.exists(path.join(gitdir, `objects/pack/${filename}`))).toBe(
       false
     )
@@ -68,6 +70,8 @@ describe('packObjects', () => {
     expect(await fs.exists(filepath)).toBe(true)
     const packfile = await fs.read(filepath)
     expect(fixture.buffer).toEqual(packfile.buffer)
-    expect(Buffer.compare(Buffer.from(fixture), Buffer.from(packfile)) === 0).toBe(true)
+    expect(
+      Buffer.compare(Buffer.from(fixture), Buffer.from(packfile)) === 0
+    ).toBe(true)
   })
 })

--- a/__tests__/test-readBlob.js
+++ b/__tests__/test-readBlob.js
@@ -34,7 +34,7 @@ describe('readBlob', () => {
       gitdir,
       oid: '4551a1856279dde6ae9d65862a1dff59a5f199d8'
     })
-    expect(blob.toString('utf8')).toMatchSnapshot()
+    expect(Buffer.from(blob).toString('utf8')).toMatchSnapshot()
   })
   it('peels tags', async () => {
     // Setup
@@ -56,7 +56,7 @@ describe('readBlob', () => {
       filepath: 'cli.js'
     })
     expect(oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
-    expect(blob.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(blob).toString('hex')).toMatchSnapshot()
   })
   it('with deep filepath to blob', async () => {
     // Setup
@@ -68,7 +68,7 @@ describe('readBlob', () => {
       filepath: 'src/commands/clone.js'
     })
     expect(oid).toEqual('5264f23285d8be3ce45f95c102001ffa1d5391d3')
-    expect(blob.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(blob).toString('hex')).toMatchSnapshot()
   })
   it('with simple filepath to tree', async () => {
     // Setup

--- a/__tests__/test-readNote.js
+++ b/__tests__/test-readNote.js
@@ -12,7 +12,7 @@ describe('readNote', () => {
       gitdir,
       oid: 'f6d51b1f9a449079f6999be1fb249c359511f164'
     })
-    expect(note.toString('utf8')).toEqual('This is a note about a commit.\n')
+    expect(Buffer.from(note).toString('utf8')).toEqual('This is a note about a commit.\n')
   })
   it('to a tree', async () => {
     // Setup
@@ -22,7 +22,7 @@ describe('readNote', () => {
       gitdir,
       oid: '199948939a0b95c6f27668689102496574b2c332'
     })
-    expect(note.toString('utf8')).toEqual('This is a note about a tree.\n')
+    expect(Buffer.from(note).toString('utf8')).toEqual('This is a note about a tree.\n')
   })
   it('to a blob', async () => {
     // Setup
@@ -32,7 +32,7 @@ describe('readNote', () => {
       gitdir,
       oid: '68aba62e560c0ebc3396e8ae9335232cd93a3f60'
     })
-    expect(note.toString('utf8')).toEqual('This is a note about a blob.\n')
+    expect(Buffer.from(note).toString('utf8')).toEqual('This is a note about a blob.\n')
   })
   it('from an alternate branch', async () => {
     // Setup
@@ -43,7 +43,7 @@ describe('readNote', () => {
       ref: 'refs/notes/alt',
       oid: 'f6d51b1f9a449079f6999be1fb249c359511f164'
     })
-    expect(note.toString('utf8')).toEqual(
+    expect(Buffer.from(note).toString('utf8')).toEqual(
       'This is alternate note about a commit.\n'
     )
   })

--- a/__tests__/test-readNote.js
+++ b/__tests__/test-readNote.js
@@ -12,7 +12,9 @@ describe('readNote', () => {
       gitdir,
       oid: 'f6d51b1f9a449079f6999be1fb249c359511f164'
     })
-    expect(Buffer.from(note).toString('utf8')).toEqual('This is a note about a commit.\n')
+    expect(Buffer.from(note).toString('utf8')).toEqual(
+      'This is a note about a commit.\n'
+    )
   })
   it('to a tree', async () => {
     // Setup
@@ -22,7 +24,9 @@ describe('readNote', () => {
       gitdir,
       oid: '199948939a0b95c6f27668689102496574b2c332'
     })
-    expect(Buffer.from(note).toString('utf8')).toEqual('This is a note about a tree.\n')
+    expect(Buffer.from(note).toString('utf8')).toEqual(
+      'This is a note about a tree.\n'
+    )
   })
   it('to a blob', async () => {
     // Setup
@@ -32,7 +36,9 @@ describe('readNote', () => {
       gitdir,
       oid: '68aba62e560c0ebc3396e8ae9335232cd93a3f60'
     })
-    expect(Buffer.from(note).toString('utf8')).toEqual('This is a note about a blob.\n')
+    expect(Buffer.from(note).toString('utf8')).toEqual(
+      'This is a note about a blob.\n'
+    )
   })
   it('from an alternate branch', async () => {
     // Setup

--- a/__tests__/test-readObject.js
+++ b/__tests__/test-readObject.js
@@ -50,7 +50,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('content')
     expect(ref.type).toEqual('commit')
     expect(ref.source).toBe('objects/e1/0ebb90d03eaacca84de1af0a59b444232da99e')
-    expect(ref.object.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('wrapped', async () => {
     // Setup
@@ -64,7 +64,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('wrapped')
     expect(ref.type).toEqual(undefined)
     expect(ref.source).toBe('objects/e1/0ebb90d03eaacca84de1af0a59b444232da99e')
-    expect(ref.object.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('deflated', async () => {
     // Setup
@@ -78,7 +78,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('deflated')
     expect(ref.type).toEqual(undefined)
     expect(ref.source).toBe('objects/e1/0ebb90d03eaacca84de1af0a59b444232da99e')
-    expect(ref.object.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('from packfile', async () => {
     // Setup
@@ -94,7 +94,7 @@ describe('readObject', () => {
     expect(ref.source).toBe(
       'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.pack'
     )
-    expect(ref.object.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('blob with encoding', async () => {
     // Setup
@@ -129,7 +129,7 @@ describe('readObject', () => {
       'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.pack'
     )
     expect(ref.oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
-    expect(ref.object.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('with deep filepath to blob', async () => {
     // Setup
@@ -144,7 +144,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('content')
     expect(ref.type).toEqual('blob')
     expect(ref.oid).toEqual('5264f23285d8be3ce45f95c102001ffa1d5391d3')
-    expect(ref.object.toString('hex')).toMatchSnapshot()
+    expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('with simple filepath to tree', async () => {
     // Setup

--- a/__tests__/test-walk.js
+++ b/__tests__/test-walk.js
@@ -55,7 +55,7 @@ describe('walk', () => {
           oid: await workdir.oid(),
           content:
             (await workdir.content()) &&
-            (await workdir.content()).toString('utf8'),
+            Buffer.from(await workdir.content()).toString('utf8'),
           hasStat: !!(await workdir.stat())
         },
         tree && {
@@ -63,7 +63,7 @@ describe('walk', () => {
           mode: await tree.mode(),
           oid: await tree.oid(),
           content:
-            (await tree.content()) && (await tree.content()).toString('utf8'),
+            (await tree.content()) && Buffer.from(await tree.content()).toString('utf8'),
           hasStat: !!(await tree.stat())
         },
         stage && {
@@ -71,7 +71,7 @@ describe('walk', () => {
           mode: await stage.mode(),
           oid: await stage.oid(),
           content:
-            (await stage.content()) && (await stage.content()).toString('utf8'),
+            (await stage.content()) && Buffer.from(await stage.content()).toString('utf8'),
           hasStat: !!(await stage.stat())
         }
       ]

--- a/__tests__/test-walk.js
+++ b/__tests__/test-walk.js
@@ -63,7 +63,8 @@ describe('walk', () => {
           mode: await tree.mode(),
           oid: await tree.oid(),
           content:
-            (await tree.content()) && Buffer.from(await tree.content()).toString('utf8'),
+            (await tree.content()) &&
+            Buffer.from(await tree.content()).toString('utf8'),
           hasStat: !!(await tree.stat())
         },
         stage && {
@@ -71,7 +72,8 @@ describe('walk', () => {
           mode: await stage.mode(),
           oid: await stage.oid(),
           content:
-            (await stage.content()) && Buffer.from(await stage.content()).toString('utf8'),
+            (await stage.content()) &&
+            Buffer.from(await stage.content()).toString('utf8'),
           hasStat: !!(await stage.stat())
         }
       ]

--- a/src/commands/hashBlob.js
+++ b/src/commands/hashBlob.js
@@ -6,7 +6,7 @@ import { hashObject } from '../storage/hashObject.js'
  * @typedef {object} HashBlobResult - The object returned has the following schema:
  * @property {string} oid - The SHA-1 object id
  * @property {'blob'} type - The type of the object
- * @property {Buffer} object - The wrapped git object (the thing that is hashed)
+ * @property {Uint8Array} object - The wrapped git object (the thing that is hashed)
  * @property {'wrapped'} format - The format of the object
  *
  */
@@ -16,9 +16,9 @@ import { hashObject } from '../storage/hashObject.js'
  *
  * @param {object} args
  * @param {string} [args.core = 'default'] - The plugin core identifier to use for plugin injection
- * @param {Buffer|string} args.object - The object to write. If `object` is a String then it will be converted to a Buffer using UTF-8 encoding.
+ * @param {Uint8Array|string} args.object - The object to write. If `object` is a String then it will be converted to a Uint8Array using UTF-8 encoding.
  *
- * @returns {Promise<{HashBlobResult}>} Resolves successfully with the SHA-1 object id and the wrapped object Buffer.
+ * @returns {Promise<{HashBlobResult}>} Resolves successfully with the SHA-1 object id and the wrapped object Uint8Array.
  * @see HashBlobResult
  *
  * @example
@@ -37,6 +37,8 @@ export async function hashBlob ({ core = 'default', object }) {
     // Convert object to buffer
     if (typeof object === 'string') {
       object = Buffer.from(object, 'utf8')
+    } else {
+      object = Buffer.from(object)
     }
 
     const type = 'blob'
@@ -45,7 +47,7 @@ export async function hashBlob ({ core = 'default', object }) {
       format: 'content',
       object
     })
-    return { oid, type, object: _object, format: 'wrapped' }
+    return { oid, type, object: new Uint8Array(_object), format: 'wrapped' }
   } catch (err) {
     err.caller = 'git.hashBlob'
     throw err

--- a/src/commands/packObjects.js
+++ b/src/commands/packObjects.js
@@ -10,7 +10,7 @@ import { pack } from './pack'
  *
  * @typedef {Object} PackObjectsResponse The packObjects command returns an object with two properties:
  * @property {string} filename - The suggested filename for the packfile if you want to save it to disk somewhere. It includes the packfile SHA.
- * @property {Buffer} [packfile] - The packfile contents. Not present if `write` parameter was true, in which case the packfile was written straight to disk.
+ * @property {Uint8Array} [packfile] - The packfile contents. Not present if `write` parameter was true, in which case the packfile was written straight to disk.
  */
 
 /**
@@ -56,7 +56,7 @@ export async function packObjects ({
     }
     return {
       filename,
-      packfile
+      packfile: new Uint8Array(packfile)
     }
   } catch (err) {
     err.caller = 'git.packObjects'

--- a/src/commands/readBlob.js
+++ b/src/commands/readBlob.js
@@ -9,7 +9,7 @@ import { resolveFilepath } from '../utils/resolveFilepath.js'
  *
  * @typedef {Object} ReadBlobResult - The object returned has the following schema:
  * @property {string} oid
- * @property {Buffer} blob
+ * @property {Uint8Array} blob
  *
  */
 

--- a/src/commands/readNote.js
+++ b/src/commands/readNote.js
@@ -17,7 +17,7 @@ import { readBlob } from './readBlob'
  * @param {string} [args.ref] - The notes ref to look under
  * @param {string} [args.oid] - The SHA-1 object id of the object to get the note for.
  *
- * @returns {Promise<Buffer>} Resolves successfully with note contents as a Buffer.
+ * @returns {Promise<Uint8Array>} Resolves successfully with note contents as a Buffer.
  */
 
 export async function readNote ({

--- a/src/commands/readObject.js
+++ b/src/commands/readObject.js
@@ -50,7 +50,7 @@ import { resolveTree } from '../utils/resolveTree.js'
  * @property {string} oid
  * @property {'blob' | 'tree' | 'commit' | 'tag'} [type]
  * @property {'deflated' | 'wrapped' | 'content' | 'parsed'} format
- * @property {Buffer | String | CommitDescription | TreeDescription} object
+ * @property {Uint8Array | String | CommitDescription | TreeDescription} object
  * @property {string} [source]
  *
  */
@@ -194,6 +194,7 @@ export async function readObject ({
           if (encoding) {
             result.object = result.object.toString(encoding)
           } else {
+            result.object = new Uint8Array(result.object)
             result.format = 'content'
           }
           break

--- a/src/commands/writeObject.js
+++ b/src/commands/writeObject.js
@@ -34,12 +34,12 @@ import { cores } from '../utils/plugins.js'
  * @param {FileSystem} [args.fs] - [deprecated] The filesystem containing the git repo. Overrides the fs provided by the [plugin system](./plugin_fs.md).
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
- * @param {Buffer|string|Object} args.object - The object to write.
+ * @param {Uint8Array|string|Object} args.object - The object to write.
  * @param {'blob'|'tree'|'commit'|'tag'} args.type - The kind of object to write.
  * @param {'deflated' | 'wrapped' | 'content' | 'parsed'} [args.format = 'parsed'] - What format the object is in. The possible choices are listed below.
  * @param {string} args.oid - If `format` is `'deflated'` then this param is required. Otherwise it is calculated.
  * @param {string} [args.filepath] - Don't return the object with `oid` itself, but resolve `oid` to a tree and then return the object at that filepath. To return the root directory of a tree set filepath to `''`
- * @param {string} [args.encoding] - If `type` is `'blob'` then `content` will be converted to a Buffer using `encoding`.
+ * @param {string} [args.encoding] - If `type` is `'blob'` then `content` will be converted to a Uint8Array using `encoding`.
  *
  * @returns {Promise<string>} Resolves successfully with the SHA-1 object id of the newly written object.
  *

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,7 +22,7 @@ export interface GitObjectDescription {
 
 export interface ReadBlobResult {
   oid: string;
-  blob: Buffer;
+  blob: Uint8Array;
 }
 
 export interface ReadCommitResult {
@@ -685,7 +685,7 @@ export function readNote(args: GitDir & {
   fs?: any;
   ref?: string;
   oid: string;
-}): Promise<Buffer>;
+}): Promise<Uint8Array>;
 
 export function readObject(args: GitDir & {
   core?: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -172,7 +172,7 @@ export interface WalkerEntry {
   type: () => Promise<'tree' | 'blob' | 'special'>;
   mode: () => Promise<number>;
   oid: () => Promise<string>;
-  content: () => Promise<Buffer|void>;
+  content: () => Promise<Uint8Array | void>;
   stat: () => Promise<{
     ctimeSeconds: number;
     mtimeSeconds: number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ export interface GitObjectDescription {
   oid: string;
   type?: 'blob' | 'tree' | 'commit' | 'tag';
   format: 'deflated' | 'wrapped' | 'content' | 'parsed';
-  object: Buffer | CommitDescription | TreeDescription | TagDescription;
+  object: Uint8Array | CommitDescription | TreeDescription | TagDescription;
   source?: string;
 }
 
@@ -124,7 +124,7 @@ export interface TreeEntry {
 
 export interface PackObjectsResponse {
   filename: string;
-  packfile?: Buffer;
+  packfile?: Uint8Array;
 }
 
 export interface PushResponse {
@@ -165,28 +165,7 @@ export interface RemoteDefinition {
 
 export interface Walker {}
 
-export interface WalkerTree {
-  fullpath: string;
-  basename: string;
-  exists: boolean;
-  populateStat: () => Promise<void>;
-  type?: 'tree' | 'blob' | 'special';
-  ctimeSeconds?: number;
-  mtimeSeconds?: number;
-  mtimeNanoseconds?: number;
-  dev?: number;
-  ino?: number;
-  mode?: number;
-  uid?: number;
-  gid?: number;
-  size?: number;
-  populateContent: () => Promise<void>;
-  content?: Buffer;
-  populateHash: () => Promise<void>;
-  oid?: string;
-}
-
-export interface WalkerEntry2 {
+export interface WalkerEntry {
   fullpath: string;
   basename: string;
   exists: boolean;
@@ -266,8 +245,6 @@ export type AnyGitPlugin = GitFsPlugin | GitFsPromisesPlugin | GitCredentialMana
 export type GitPluginCore = Map<GitPluginName, AnyGitPlugin>
 
 export type StatusMatrix = Array<[string, number, number, number]>;
-
-export type WalkerEntry = WalkerTree[];
 
 export const plugins: GitPluginCore
 
@@ -787,10 +764,10 @@ export function walk<T, Q>(args: WorkDir & GitDir & {
   core?: string;
   fs?: any;
   trees: Walker[];
-  filter?: (entries: WalkerEntry2[]) => Promise<boolean>;
-  map?: (entries: WalkerEntry2[]) => Promise<T | undefined>;
+  filter?: (entries: WalkerEntry[]) => Promise<boolean>;
+  map?: (entries: WalkerEntry[]) => Promise<T | undefined>;
   reduce?: (parent: T | undefined, children: Q[]) => Promise<Q>;
-  iterate?: (walk: (parent: WalkerEntry2[]) => Promise<Q>, children: Iterable<WalkerEntry2[]>) => Promise<Array<Q|undefined>>;
+  iterate?: (walk: (parent: WalkerEntry[]) => Promise<Q>, children: Iterable<WalkerEntry[]>) => Promise<Array<Q|undefined>>;
 }): Promise<Q|undefined>;
 
 export function writeBlob(args: GitDir & {
@@ -809,7 +786,7 @@ export function writeObject(args: GitDir & {
   core?: string;
   fs?: any;
   type?: 'blob' | 'tree' | 'commit' | 'tag';
-  object: string | Buffer | CommitDescription | TreeDescription | TagDescription;
+  object: string | Uint8Array | CommitDescription | TreeDescription | TagDescription;
   format?: 'deflated' | 'wrapped' | 'content' | 'parsed';
   oid?: string;
   encoding?: string;
@@ -830,13 +807,13 @@ export function writeTree(args: GitDir & {
 type HashBlobResult = {
   oid: string;
   type: 'blob';
-  object: Buffer;
+  object: Uint8Array;
   format: 'wrapped';
 }
 
 export function hashBlob(args: {
   core?: string;
-  object: string | Buffer | CommitDescription | TreeDescription | TagDescription;
+  object: string | Uint8Array;
 }): Promise<HashBlobResult>;
 
 export function writeRef(args: GitDir & {

--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -106,7 +106,7 @@ export class GitWalkerFs {
         if (entry._stat && entry._stat.size === -1) {
           entry._stat.size = entry._actualSize
         }
-        entry._content = content
+        entry._content = new Uint8Array(content)
       }
     }
     return entry._content

--- a/src/models/GitWalkerRepo.js
+++ b/src/models/GitWalkerRepo.js
@@ -121,7 +121,7 @@ export class GitWalkerRepo {
       if (type !== 'blob') {
         entry._content = void 0
       } else {
-        entry._content = object
+        entry._content = new Uint8Array(object)
       }
     }
     return entry._content

--- a/src/utils/mergeTree.js
+++ b/src/utils/mergeTree.js
@@ -222,9 +222,9 @@ async function mergeBlobs ({
   }
   // if both sides made changes do a merge
   const { mergedText, cleanMerge } = mergeFile({
-    ourContent: (await ours.content()).toString('utf8'),
-    baseContent: (await base.content()).toString('utf8'),
-    theirContent: (await theirs.content()).toString('utf8'),
+    ourContent: Buffer.from(await ours.content()).toString('utf8'),
+    baseContent: Buffer.from(await base.content()).toString('utf8'),
+    theirContent: Buffer.from(await theirs.content()).toString('utf8'),
     ourName,
     theirName,
     baseName,

--- a/src/utils/resolveBlob.js
+++ b/src/utils/resolveBlob.js
@@ -16,5 +16,5 @@ export async function resolveBlob ({ fs, gitdir, oid }) {
       expected: 'blob'
     })
   }
-  return { oid, blob: object }
+  return { oid, blob: new Uint8Array(object) }
 }


### PR DESCRIPTION
BREAKING CHANGE: Any functions that returned `Buffer` objects now instead return `Uint8Array` objects. This is so we can eventually drop the bloated `Buffer` browser polyfill.