### PR TITLE
chore: 'message' events are no longer trimmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ At the time of writing, the following breaking changes are planned:
 - [x] Any functions that currently return `Buffer` objects will instead return `Uint8Array` so we can eventually drop the bloated Buffer browser polyfill.
 - [x] The `pattern` and globbing options will be removed from `statusMatrix` so we can drop the dependencies on `globalyzer` and `globrex`, but you'll be able to bring your own `filter` function instead.
 - [x] The `autoTranslateSSH` feature will be removed, since it's trivial to implement using just the `UnknownTransportError.data.suggestion`
+- [x] Make the 'message' event behave like 'rawmessage' and remove 'rawmessage'.
+- [ ] Update the README to recommend LightningFS rather than BrowserFS.
 - [ ] The `internal-apis` will be excluded from `dist` before publishing. Because those are only exposed so I could unit test them and no one should be using them lol.
 
 ## Getting Started

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -159,11 +159,7 @@ export async function fetch ({
     if (emitter) {
       const lines = splitLines(response.progress)
       forAwait(lines, line => {
-        // As a historical accident, 'message' events were trimmed removing valuable information,
-        // such as \r by itself which was a single to update the existing line instead of appending a new one.
-        // TODO NEXT BREAKING RELEASE: make 'message' behave like 'rawmessage' and remove 'rawmessage'.
-        emitter.emit(`${emitterPrefix}message`, line.trim())
-        emitter.emit(`${emitterPrefix}rawmessage`, line)
+        emitter.emit(`${emitterPrefix}message`, line)
         const matches = line.match(/([^:]*).*\((\d+?)\/(\d+?)\)/)
         if (matches) {
           emitter.emit(`${emitterPrefix}progress`, {


### PR DESCRIPTION
BREAKING CHANGE: As a historical accident, `message` events were trimmed. This was lossy and removed valuable information, such as an `'\r'` by itself, which is a signal to update the existing line instead of appending a new one. The `rawmessage` event was added as a temporary workaround to expose the untrimmed data. The `rawmessage` event has been removed and from now on, `message` events emit the full untrimmed data.