### PR TITLE
chore: cleanup 'dist' directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ You can install it from npm.
 npm install --save isomorphic-git
 ```
 
-In the package.json you'll see there are actually 4 different versions:
+In the package.json you'll see there are actually 3 different versions:
 
 ```json
-  "main": "dist/for-node/isomorphic-git/index.js",
-  "module": "dist/for-future/isomorphic-git/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "unpkg": "dist/bundle.umd.min.js",
 ```
 
@@ -234,7 +234,7 @@ The main difference is the ridiculous amount of hacks involved in the tests.
 We use Facebook's [Jest](https://jestjs.io) for testing, which make doing TDD fast and fun,
 but we also used custom hacks so that the same
 tests will also run in the browser using [Jasmine](https://jasmine.github.io/) via [Karma](https://karma-runner.github.io).
-We even have our own [karma plugin](https://github.com/isomorphic-git/karma-git-http-server-middleware) for serving
+We even have our own [mock server](https://github.com/isomorphic-git/git-http-mock-server) for serving
 git repository test fixtures!
 
 You'll need [Node.js](https://nodejs.org) installed, but everything else is a devDependency.

--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -2,7 +2,7 @@ const jsdoc = require('jsdoc-api')
 const fs = require('fs')
 const path = require('path')
 const table = require('markdown-table')
-const git = require('../../dist/for-node/isomorphic-git/index.js')
+const git = require('../..')
 
 git.plugins.set('fs', fs)
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -141,12 +141,6 @@ module.exports = function (config) {
     junitReporter: {
       outputDir: './junit'
     },
-    browserify: {
-      transform: [
-        // Replace process.env.CI
-        'envify'
-      ]
-    },
     webpack: {
       mode: 'development',
       devtool: 'inline-source-map',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10848,38 +10848,6 @@
         "handlebars": "^4.1.2"
       }
     },
-    "jasmine": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
-      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.4",
-        "jasmine-core": "~3.5.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "jasmine-core": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-          "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
-          "dev": true
-        }
-      }
-    },
     "jasmine-core": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0-development",
   "description": "A pure JavaScript reimplementation of git for node and browsers",
   "typings": "./src/index.d.ts",
-  "main": "dist/for-node/isomorphic-git/index.js",
+  "main": "dist/index.cjs",
   "browser": {
     "isomorphic-git": "./dist/bundle.umd.min.js",
     "isomorphic-git/internal-apis": "./dist/internal.umd.min.js",
     "./src/utils/http.js": "./src/utils/http-browser.js"
   },
-  "module": "dist/for-future/isomorphic-git/index.js",
+  "module": "dist/index.js",
   "unpkg": "dist/bundle.umd.min.js",
   "bin": {
     "isogit": "./cli.js"
@@ -43,7 +43,12 @@
   },
   "homepage": "https://isomorphic-git.org/",
   "files": [
-    "dist",
+    "dist/index.js",
+    "dist/index.cjs",
+    "dist/browser-tests.json",
+    "dist/bundle.umd.min.js",
+    "dist/bundle.umd.min.js.map",
+    "dist/size_report.html",
     "cli.js",
     "src/errors.d.ts",
     "src/index.d.ts"
@@ -87,7 +92,6 @@
     "git-http-mock-server": "1.2.0",
     "github-comment": "1.0.1",
     "inquirer": "^7.0.0",
-    "jasmine": "3.5.0",
     "jasmine-core": "3.4.0",
     "jest": "24.9.0",
     "jest-fixtures": "wmhilton-contrib/jest-fixtures#win32",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
-import resolve from 'rollup-plugin-node-resolve'
 import path from 'path'
+import resolve from 'rollup-plugin-node-resolve'
+
 import pkg from './package.json'
 
 const external = [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import resolve from 'rollup-plugin-node-resolve'
-
+import path from 'path'
 import pkg from './package.json'
 
 const external = [
@@ -7,9 +7,7 @@ const external = [
   'path',
   'crypto',
   'stream',
-  'openpgp/dist/openpgp.min.js',
   'crc/lib/crc32.js',
-  'stream-source/index.node.js',
   'sha.js/sha1',
   ...Object.keys(pkg.dependencies)
 ]
@@ -22,7 +20,7 @@ const moduleConfig = input => ({
     {
       format: 'es',
       name: 'git',
-      file: `dist/for-future/isomorphic-git/${input}`
+      file: `dist/${input}`
     }
   ],
   plugins: [resolve({ browser: true })]
@@ -36,7 +34,7 @@ const nodeConfig = input => ({
     {
       format: 'cjs',
       name: 'git',
-      file: `dist/for-node/isomorphic-git/${input}`
+      file: `dist/${path.basename(input, '.js')}.cjs`
     }
   ]
 })


### PR DESCRIPTION
BREAKING CHANGE: The `internal-apis` are no longer included in the npm package. I never really intended that; they were just for running unit tests. Also, I renamed `dist/for-future/isomorphic-git/index.js` to `dist/index.js` and `dist/for-node/isomorphic-git/index.js` to `dist/index.cjs`.

And I removed the `jasmine` fallback. I'm sorry `jest` uses native modules, but it's just _too good_ not to use and maintaining a fallback test runner is an added complication.