### PR TITLE
chore(dev-deps): upgrade to agadoo 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,29 +2290,21 @@
       "dev": true
     },
     "agadoo": {
-      "version": "git+https://github.com/wmhilton-contrib/agadoo.git#ff6f9b269c75a09d12a5266a036b86871a018a8f",
-      "from": "git+https://github.com/wmhilton-contrib/agadoo.git#external-imports",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/agadoo/-/agadoo-2.0.0.tgz",
+      "integrity": "sha512-68aFhseH51ZBKYKkQNxwDi1hJwTnywBjHWg068qFnMkpXShhOazNzJUPRvaLQjrqhT3EOUth5G9mt1A0/dGhOw==",
       "dev": true,
       "requires": {
-        "rollup": "^0.64.1",
+        "acorn": "^7.1.0",
+        "rollup": "^1",
         "rollup-plugin-virtual": "^1.0.1"
       },
       "dependencies": {
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
           "dev": true
-        },
-        "rollup": {
-          "version": "0.64.1",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.64.1.tgz",
-          "integrity": "sha512-+ThdVXrvonJdOTzyybMBipP0uz605Z8AnzWVY3rf+cSGnLO7uNkJBlN+9jXqWOomkvumXfm/esmBpA5d53qm7g==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "0.0.39",
-            "@types/node": "*"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@semantic-release/exec": "3.3.6",
     "@types/jest": "24.0.18",
     "@types/node": "12.7.2",
-    "agadoo": "git+https://github.com/wmhilton-contrib/agadoo.git#external-imports",
+    "agadoo": "2.0.0",
     "all-contributors-cli": "6.9.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.6",


### PR DESCRIPTION
Oh hey look, we can get rid of our `agadoo` fork! https://github.com/Rich-Harris/agadoo/pull/7#issuecomment-570266090