### PR TITLE
fix(fastCheckout): don't treat modified files as conflicted unless the file would actually change

### DIFF
--- a/src/commands/fastCheckout.js
+++ b/src/commands/fastCheckout.js
@@ -530,7 +530,7 @@ async function analyze ({
         /* eslint-disable no-fallthrough */
         // File missing from workdir
         case '110':
-        // Modified entries
+        // Possibly modified entries
         case '111': {
           /* eslint-enable no-fallthrough */
           switch (`${await stage.type()}-${await commit.type()}`) {
@@ -538,6 +538,16 @@ async function analyze ({
               return
             }
             case 'blob-blob': {
+              // If the file hasn't changed, there is no need to do anything.
+              // Existing file modifications in the workdir can be be left as is.
+              if (
+                (await stage.oid() === await commit.oid()) &&
+                (await stage.mode() === await commit.mode()) &&
+                !force
+              ) {
+                return
+              }
+
               // Check for local changes that would be lost
               if (workdir) {
                 // Note: canonical git only compares with the stage. But we're smart enough

--- a/src/commands/fastCheckout.js
+++ b/src/commands/fastCheckout.js
@@ -541,8 +541,8 @@ async function analyze ({
               // If the file hasn't changed, there is no need to do anything.
               // Existing file modifications in the workdir can be be left as is.
               if (
-                (await stage.oid() === await commit.oid()) &&
-                (await stage.mode() === await commit.mode()) &&
+                (await stage.oid()) === (await commit.oid()) &&
+                (await stage.mode()) === (await commit.mode()) &&
                 !force
               ) {
                 return


### PR DESCRIPTION
## I'm fixing a bug or typo

This fixes the over-zealous warnings about Git Pull in Studio, ie.

1. click Git Pull button
2. modify a file
3. click Git Pull button again
4. you get warnings even though literally nothing has changed since the last pull 🤦‍♂

