### PR TITLE
fix(checkout): don't treat modified files as conflicted unless the file would actually change

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ At the time of writing, the following breaking changes are planned:
 - [x] Update the README to recommend LightningFS rather than BrowserFS.
 - [x] The `internal-apis` will be excluded from `dist` before publishing. Because those are only exposed so I could unit test them and no one should be using them lol.
 - [ ] I think I will change the `plugins` API. The current API (`plugins.set('fs', fs)`) uses a kinda-hacky run-time schema validation that just checks whether certain methods are defined. Static type checking would actually provide a better developer experience and better guarantees, but having `.set` be polymorphic is hard to accurately describe using JSDoc, so I might switch to an API like `plugins.fs(fs)`.
+  - this also means we can set `new FileSystem(_fs)` in the `plugins.fs(fs)` command, because _we don't have to expose a getter like `plugins.get()`!_
+
 - [ ] I think I'll tweak `readObject` and `writeObject` so that `readObject` doesn't have a crazy polymorphic return type and they somehow "fit" with all the more specific `read/write Blob/Commit/Tag/Tree` commands.
 
 ## Getting Started

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -523,7 +523,7 @@ async function analyze ({
         /* eslint-disable no-fallthrough */
         // File missing from workdir
         case '110':
-        // Modified entries
+        // Possibly modified entries
         case '111': {
           /* eslint-enable no-fallthrough */
           switch (`${await stage.type()}-${await commit.type()}`) {
@@ -531,6 +531,16 @@ async function analyze ({
               return
             }
             case 'blob-blob': {
+              // If the file hasn't changed, there is no need to do anything.
+              // Existing file modifications in the workdir can be be left as is.
+              if (
+                (await stage.oid() === await commit.oid()) &&
+                (await stage.mode() === await commit.mode()) &&
+                !force
+              ) {
+                return
+              }
+
               // Check for local changes that would be lost
               if (workdir) {
                 // Note: canonical git only compares with the stage. But we're smart enough

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -534,8 +534,8 @@ async function analyze ({
               // If the file hasn't changed, there is no need to do anything.
               // Existing file modifications in the workdir can be be left as is.
               if (
-                (await stage.oid() === await commit.oid()) &&
-                (await stage.mode() === await commit.mode()) &&
+                (await stage.oid()) === (await commit.oid()) &&
+                (await stage.mode()) === (await commit.mode()) &&
                 !force
               ) {
                 return


### PR DESCRIPTION
corresponds to #1017. Since `fastCheckout` gets deleted that won't merge very well.

## I'm fixing a bug or typo

- [ ] squash merge the PR with commit message "fix: [Description of fix]"
