### PR TITLE
chore: improve `readObject` and `writeObject` typings

### DIFF
--- a/__tests__/test-readObject.js
+++ b/__tests__/test-readObject.js
@@ -50,6 +50,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('content')
     expect(ref.type).toEqual('commit')
     expect(ref.source).toBe('objects/e1/0ebb90d03eaacca84de1af0a59b444232da99e')
+    if (ref.format !== 'content') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('wrapped', async () => {
@@ -62,8 +63,9 @@ describe('readObject', () => {
       format: 'wrapped'
     })
     expect(ref.format).toEqual('wrapped')
-    expect(ref.type).toEqual(undefined)
+    expect(ref.type).toEqual('wrapped')
     expect(ref.source).toBe('objects/e1/0ebb90d03eaacca84de1af0a59b444232da99e')
+    if (ref.format !== 'wrapped') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('deflated', async () => {
@@ -76,8 +78,9 @@ describe('readObject', () => {
       format: 'deflated'
     })
     expect(ref.format).toEqual('deflated')
-    expect(ref.type).toEqual(undefined)
+    expect(ref.type).toEqual('deflated')
     expect(ref.source).toBe('objects/e1/0ebb90d03eaacca84de1af0a59b444232da99e')
+    if (ref.format !== 'deflated') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('from packfile', async () => {
@@ -94,6 +97,7 @@ describe('readObject', () => {
     expect(ref.source).toBe(
       'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.pack'
     )
+    if (ref.format !== 'content') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('blob with encoding', async () => {
@@ -129,6 +133,7 @@ describe('readObject', () => {
       'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.pack'
     )
     expect(ref.oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
+    if (ref.type !== 'blob' || ref.format !== 'content') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('with deep filepath to blob', async () => {
@@ -144,6 +149,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('content')
     expect(ref.type).toEqual('blob')
     expect(ref.oid).toEqual('5264f23285d8be3ce45f95c102001ffa1d5391d3')
+    if (ref.type !== 'blob' || ref.format !== 'content') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('with simple filepath to tree', async () => {

--- a/__tests__/test-readObject.js
+++ b/__tests__/test-readObject.js
@@ -133,7 +133,7 @@ describe('readObject', () => {
       'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.pack'
     )
     expect(ref.oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
-    if (ref.type !== 'blob' || ref.format !== 'content') throw new Error('wrong type')
+    if (ref.format !== 'content') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('with deep filepath to blob', async () => {
@@ -149,7 +149,7 @@ describe('readObject', () => {
     expect(ref.format).toEqual('content')
     expect(ref.type).toEqual('blob')
     expect(ref.oid).toEqual('5264f23285d8be3ce45f95c102001ffa1d5391d3')
-    if (ref.type !== 'blob' || ref.format !== 'content') throw new Error('wrong type')
+    if (ref.format !== 'content') throw new Error('wrong type')
     expect(Buffer.from(ref.object).toString('hex')).toMatchSnapshot()
   })
   it('with simple filepath to tree', async () => {

--- a/__tests__/test-writeObject.js
+++ b/__tests__/test-writeObject.js
@@ -142,118 +142,116 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
       gitdir,
       type: 'tree',
       format: 'parsed',
-      object: {
-        entries: [
-          {
-            mode: '100644',
-            oid: '375f9392774e7a7c8a1ae23a6d13b5c133e42c45',
-            path: '.babelrc',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: 'bbf3e21f43fa4fe25eb925bfcb7c0434f7c2dc7d',
-            path: '.editorconfig',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '4a58bdcdef3eb91264dfca0279959d98c16568d5',
-            path: '.flowconfig',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '2b90c4a2353d2977e158c21f4315664063770212',
-            path: '.gitignore',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '63ed03aea9d828c86ebde989b336f5e978fdc3f1',
-            path: '.travis.yml',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: 'c675a17ccb1578bca836decf90205fdad743827d',
-            path: 'LICENSE.md',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '9761716146bbdb47f8a7de3d9df98777df9674f3',
-            path: 'README.md',
-            type: 'blob'
-          },
-          {
-            mode: '040000',
-            oid: '63a8130fa218d20b0009c1126375a105c1adba8a',
-            path: '__tests__',
-            type: 'tree'
-          },
-          {
-            mode: '100644',
-            oid: 'bdc76cc9d0da964db203f47333d05185a22d6a18',
-            path: 'ci.karma.conf.js',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '4551a1856279dde6ae9d65862a1dff59a5f199d8',
-            path: 'cli.js',
-            type: 'blob'
-          },
-          {
-            mode: '040000',
-            oid: '69be3467cb125fbc55eb5c7e50caa556fb0e34b4',
-            path: 'dist',
-            type: 'tree'
-          },
-          {
-            mode: '100644',
-            oid: 'af56d48cb8af9c5ba3547c12c4a4a61fc16ff971',
-            path: 'karma.conf.js',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '00b91c8b8ddfb43df70ef334088b7d840e5053db',
-            path: 'package-lock.json',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: '7b12188e7e351c1a761b76b38e36c13b5cba6c1f',
-            path: 'package-scripts.js',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: 'bfe174beb9bf440c1c49b6fba0094f16cf9c9490',
-            path: 'package.json',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            oid: 'a86d1a6c3997dc73e8bf8687edb15fc087892e9d',
-            path: 'rollup.config.js',
-            type: 'blob'
-          },
-          {
-            mode: '040000',
-            oid: 'ae7b4f3ac2c570dc3597124fc108ecb9d6c2b4fd',
-            path: 'src',
-            type: 'tree'
-          },
-          {
-            mode: '040000',
-            oid: '0a7ce5f20a8ccba18463a2ae990baf63ba1e3b43',
-            path: 'testling',
-            type: 'tree'
-          }
-        ]
-      }
+      object: [
+        {
+          mode: '100644',
+          oid: '375f9392774e7a7c8a1ae23a6d13b5c133e42c45',
+          path: '.babelrc',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: 'bbf3e21f43fa4fe25eb925bfcb7c0434f7c2dc7d',
+          path: '.editorconfig',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '4a58bdcdef3eb91264dfca0279959d98c16568d5',
+          path: '.flowconfig',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '2b90c4a2353d2977e158c21f4315664063770212',
+          path: '.gitignore',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '63ed03aea9d828c86ebde989b336f5e978fdc3f1',
+          path: '.travis.yml',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: 'c675a17ccb1578bca836decf90205fdad743827d',
+          path: 'LICENSE.md',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '9761716146bbdb47f8a7de3d9df98777df9674f3',
+          path: 'README.md',
+          type: 'blob'
+        },
+        {
+          mode: '040000',
+          oid: '63a8130fa218d20b0009c1126375a105c1adba8a',
+          path: '__tests__',
+          type: 'tree'
+        },
+        {
+          mode: '100644',
+          oid: 'bdc76cc9d0da964db203f47333d05185a22d6a18',
+          path: 'ci.karma.conf.js',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '4551a1856279dde6ae9d65862a1dff59a5f199d8',
+          path: 'cli.js',
+          type: 'blob'
+        },
+        {
+          mode: '040000',
+          oid: '69be3467cb125fbc55eb5c7e50caa556fb0e34b4',
+          path: 'dist',
+          type: 'tree'
+        },
+        {
+          mode: '100644',
+          oid: 'af56d48cb8af9c5ba3547c12c4a4a61fc16ff971',
+          path: 'karma.conf.js',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '00b91c8b8ddfb43df70ef334088b7d840e5053db',
+          path: 'package-lock.json',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: '7b12188e7e351c1a761b76b38e36c13b5cba6c1f',
+          path: 'package-scripts.js',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: 'bfe174beb9bf440c1c49b6fba0094f16cf9c9490',
+          path: 'package.json',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          oid: 'a86d1a6c3997dc73e8bf8687edb15fc087892e9d',
+          path: 'rollup.config.js',
+          type: 'blob'
+        },
+        {
+          mode: '040000',
+          oid: 'ae7b4f3ac2c570dc3597124fc108ecb9d6c2b4fd',
+          path: 'src',
+          type: 'tree'
+        },
+        {
+          mode: '040000',
+          oid: '0a7ce5f20a8ccba18463a2ae990baf63ba1e3b43',
+          path: 'testling',
+          type: 'tree'
+        }
+      ]
     })
     expect(oid).toEqual('6257985e3378ec42a03a57a7dc8eb952d69a5ff3')
   })
@@ -265,40 +263,38 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
       gitdir,
       type: 'tree',
       format: 'parsed',
-      object: {
-        entries: [
-          {
-            mode: '040000',
-            path: 'config',
-            oid: 'd564d0bc3dd917926892c55e3706cc116d5b165e',
-            type: 'tree'
-          },
-          {
-            mode: '100644',
-            path: 'config ',
-            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            path: 'config.',
-            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            path: 'config0',
-            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-            type: 'blob'
-          },
-          {
-            mode: '100644',
-            path: 'config~',
-            oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
-            type: 'blob'
-          }
-        ]
-      }
+      object: [
+        {
+          mode: '040000',
+          path: 'config',
+          oid: 'd564d0bc3dd917926892c55e3706cc116d5b165e',
+          type: 'tree'
+        },
+        {
+          mode: '100644',
+          path: 'config ',
+          oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          path: 'config.',
+          oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          path: 'config0',
+          oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+          type: 'blob'
+        },
+        {
+          mode: '100644',
+          path: 'config~',
+          oid: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+          type: 'blob'
+        }
+      ]
     })
     expect(oid).toEqual('c8a72f5bd8633663210490897b798ddc3ff9ca64')
   })

--- a/src/commands/readObject.js
+++ b/src/commands/readObject.js
@@ -81,51 +81,13 @@ import { resolveTree } from '../utils/resolveTree.js'
 
 /**
  *
- * @typedef {Object} RawBlobObject
+ * @typedef {Object} RawObject
  * @property {string} oid
- * @property {'blob'} type
+ * @property {'blob'|'commit'|'tree'|'tag'} type
  * @property {'content'} format
  * @property {Uint8Array} object
  * @property {string} [source]
  *
- */
-
-/**
- *
- * @typedef {Object} RawCommitObject
- * @property {string} oid
- * @property {'commit'} type
- * @property {'content'} format
- * @property {Uint8Array} object
- * @property {string} [source]
- *
- */
-
-/**
- *
- * @typedef {Object} RawTreeObject
- * @property {string} oid
- * @property {'tree'} type
- * @property {'content'} format
- * @property {Uint8Array} object
- * @property {string} [source]
- *
- */
-
-/**
- *
- * @typedef {Object} RawTagObject
- * @property {string} oid
- * @property {'tag'} type
- * @property {'content'} format
- * @property {Uint8Array} object
- * @property {string} [source]
- *
- */
-
-/**
- *
- * @typedef {RawBlobObject | RawCommitObject | RawTreeObject | RawTagObject} RawObject
  */
 
 /**
@@ -202,6 +164,41 @@ import { resolveTree } from '../utils/resolveTree.js'
  * | 'content'  | Return the object buffer without the git header.                                                                                                                                                          |
  * | 'parsed'   | Returns a parsed representation of the object.                                                                                                                                                            |
  *
+ * The result will be in one of the following schemas:
+ *
+ * ## `'deflated'` format
+ *
+ * {@link DeflatedObject typedef}
+ *
+ * ## `'wrapped'` format
+ *
+ * {@link WrappedObject typedef}
+ *
+ * ## `'content'` format
+ *
+ * {@link RawObject typedef}
+ *
+ * ## `'parsed'` format
+ *
+ * ### parsed `'blob'` type
+ *
+ * {@link ParsedBlobObject typedef}
+ *
+ * ### parsed `'commit'` type
+ *
+ * {@link ParsedCommitObject typedef}
+ * {@link CommitObject typedef}
+ *
+ * ### parsed `'tree'` type
+ *
+ * {@link ParsedTreeObject typedef}
+ * {@link TreeObject typedef}
+ *
+ * ### parsed `'tag'` type
+ *
+ * {@link ParsedTagObject typedef}
+ * {@link TagObject typedef}
+ *
  * @deprecated
  * > **Deprecated**
  * > This command is overly complicated.
@@ -241,7 +238,7 @@ import { resolveTree } from '../utils/resolveTree.js'
  *
  * const searchTree = async ({oid, prefix = ''}) => {
  *   let { object: tree } = await git.readObject({ dir: '$input((/))', oid })
- *   for (let entry of tree.entries) {
+ *   for (let entry of tree) {
  *     if (entry.type === 'tree') {
  *       await searchTree({oid: entry.oid, prefix: `${prefix}/${entry.path}`})
  *     } else if (entry.type === 'blob') {

--- a/src/commands/writeObject.js
+++ b/src/commands/writeObject.js
@@ -10,62 +10,50 @@ import { cores } from '../utils/plugins.js'
 
 /**
  *
- * @typedef {Object} CommitDescription
- * @property {string} oid - SHA-1 object id of this commit
- * @property {string} message - commit message
+ * @typedef {Object} CommitObject
+ * @property {string} message - Commit message
  * @property {string} tree - SHA-1 object id of corresponding file tree
  * @property {string[]} parent - an array of zero or more SHA-1 object ids
  * @property {Object} author
- * @property {string} author.name - the author's name
- * @property {string} author.email - the author's email
+ * @property {string} author.name - The author's name
+ * @property {string} author.email - The author's email
  * @property {number} author.timestamp - UTC Unix timestamp in seconds
- * @property {number} author.timezoneOffset - timezone difference from UTC in minutes
+ * @property {number} author.timezoneOffset - Timezone difference from UTC in minutes
  * @property {Object} committer
- * @property {string} committer.name - the committer's name
- * @property {string} committer.email - the committer's email
+ * @property {string} committer.name - The committer's name
+ * @property {string} committer.email - The committer's email
  * @property {number} committer.timestamp - UTC Unix timestamp in seconds
- * @property {number} committer.timezoneOffset - timezone difference from UTC in minutes
+ * @property {number} committer.timezoneOffset - Timezone difference from UTC in minutes
  * @property {string} [gpgsig] - PGP signature (if present)
  */
 
 /**
  *
+ * @typedef {TreeEntry[]} TreeObject
+ */
+
+/**
+ *
  * @typedef {Object} TreeEntry
- * @property {string} mode
- * @property {string} path
- * @property {string} oid
- * @property {string} [type]
+ * @property {string} mode - the 6 digit hexadecimal mode
+ * @property {string} path - the name of the file or directory
+ * @property {string} oid - the SHA-1 object id of the blob or tree
+ * @property {'commit'|'blob'|'tree'} type - the type of object
  */
 
 /**
  *
- * @typedef {Object} TreeDescription
- * @property {TreeEntry[]} entries
- */
-
-/**
- *
- * @typedef {Object} TagDescription
- * @property {string} object
- * @property {'blob' | 'tree' | 'commit' | 'tag'} type
- * @property {string} tag
+ * @typedef {Object} TagObject
+ * @property {string} object - SHA-1 object id of object being tagged
+ * @property {'blob' | 'tree' | 'commit' | 'tag'} type - the type of the object being tagged
+ * @property {string} tag - the tag name
  * @property {Object} tagger
  * @property {string} tagger.name - the tagger's name
  * @property {string} tagger.email - the tagger's email
  * @property {number} tagger.timestamp - UTC Unix timestamp in seconds
  * @property {number} tagger.timezoneOffset - timezone difference from UTC in minutes
- * @property {string} message
+ * @property {string} message - tag message
  * @property {string} [signature] - PGP signature (if present)
- */
-
-/**
- *
- * @typedef {Object} GitObjectDescription - The object returned has the following schema:
- * @property {string} oid
- * @property {'blob' | 'tree' | 'commit' | 'tag'} [type]
- * @property {'deflated' | 'wrapped' | 'content' | 'parsed'} format
- * @property {Uint8Array | String | CommitDescription | TreeDescription | TagDescription} object
- * @property {string} [source]
  */
 
 /**
@@ -80,8 +68,15 @@ import { cores } from '../utils/plugins.js'
  * | 'content'  | Treat `object` as the object buffer without the git header.                                                                                                      |
  * | 'parsed'   | Treat `object` as a parsed representation of the object.                                                                                                         |
  *
- * If `format` is `'parsed'`, then `object` must match one of the schemas for `CommitDescription`, `TreeDescription`, or `TagDescription` described in...
- * shucks I haven't written that page yet. :( Well, described in the [TypeScript definition](https://github.com/isomorphic-git/isomorphic-git/blob/master/src/index.d.ts) for now.
+ * If `format` is `'parsed'`, then `object` must match one of the schemas for `CommitObject`, `TreeObject`, `TagObject`, or a `string` (for blobs).
+ *
+ * {@link CommitObject typedef}
+ *
+ * {@link TreeObject typedef}
+ *
+ * {@link TagObject typedef}
+ *
+ * If `format` is `'content'`, `'wrapped'`, or `'deflated'`, `object` should be a `Uint8Array`.
  *
  * @deprecated
  * > **Deprecated**
@@ -93,11 +88,11 @@ import { cores } from '../utils/plugins.js'
  * @param {string} [args.core = 'default'] - The plugin core identifier to use for plugin injection
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
- * @param {string | Uint8Array | CommitDescription | TreeDescription | TagDescription} args.object - The object to write.
+ * @param {string | Uint8Array | CommitObject | TreeObject | TagObject} args.object - The object to write.
  * @param {'blob'|'tree'|'commit'|'tag'} [args.type] - The kind of object to write.
  * @param {'deflated' | 'wrapped' | 'content' | 'parsed'} [args.format = 'parsed'] - What format the object is in. The possible choices are listed below.
- * @param {string} args.oid - If `format` is `'deflated'` then this param is required. Otherwise it is calculated.
- * @param {string} [args.encoding] - If `type` is `'blob'` then `content` will be converted to a Uint8Array using `encoding`.
+ * @param {string} [args.oid] - If `format` is `'deflated'` then this param is required. Otherwise it is calculated.
+ * @param {string} [args.encoding] - If `type` is `'blob'` then `object` will be converted to a Uint8Array using `encoding`.
  *
  * @returns {Promise<string>} Resolves successfully with the SHA-1 object id of the newly written object.
  *
@@ -146,7 +141,7 @@ export async function writeObject ({
           object = GitCommit.from(object).toObject()
           break
         case 'tree':
-          object = GitTree.from(object.entries).toObject()
+          object = GitTree.from(object).toObject()
           break
         case 'blob':
           object = Buffer.from(object, encoding)
@@ -157,16 +152,16 @@ export async function writeObject ({
         default:
           throw new GitError(E.ObjectTypeUnknownFail, { type })
       }
+      // GitObjectManager does not know how to serialize content, so we tweak that parameter before passing it.
+      format = 'content'
     }
-    // GitObjectManager does not know how to parse content, so we tweak that parameter before passing it.
-    const _format = format === 'parsed' ? 'content' : format
     oid = await _writeObject({
       fs,
       gitdir,
       type,
       object,
       oid,
-      format: _format
+      format
     })
     return oid
   } catch (err) {

--- a/src/utils/AsyncIterator.js
+++ b/src/utils/AsyncIterator.js
@@ -38,7 +38,10 @@ export function fromValue (value) {
 // Convert a Node stream to an Async Iterator
 export function fromNodeStream (stream) {
   // Use native async iteration if it's available.
-  const asyncIterator = Object.getOwnPropertyDescriptor(stream, Symbol.asyncIterator)
+  const asyncIterator = Object.getOwnPropertyDescriptor(
+    stream,
+    Symbol.asyncIterator
+  )
   if (asyncIterator && asyncIterator.enumerable) {
     return stream
   }


### PR DESCRIPTION
BREAKING CHANGE: `readObject` and `writeObject` have been updated to use the same object schemas used in `readCommit`, `readTree`, and `readTag`. (The main change is trees are simply arrays now, rather than objects with a `.entries` property.) The types returned by `readObject` also form a proper discriminated union so TypeScript will infer the type of `.object` given `.format` and `.type`.