### PR TITLE
chore: deduplicate JSDoc types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ At the time of writing, the following breaking changes are planned:
 - [x] Make the 'message' event behave like 'rawmessage' and remove 'rawmessage'.
 - [x] Update the README to recommend LightningFS rather than BrowserFS.
 - [x] The `internal-apis` will be excluded from `dist` before publishing. Because those are only exposed so I could unit test them and no one should be using them lol.
-- [ ] I think I will change the `plugins` API. The current API (`plugins.set('fs', fs)`) uses a kinda-hacky run-time schema validation that just checks whether certain methods are defined. Static type checking would actually provide a better developer experience and better guarantees, but having `.set` be polymorphic is hard to accurately describe using JSDoc, so I might switch to an API like `plugins.fs(fs)`.
+- [x] I think I'll tweak `readObject` and `writeObject` so that `readObject` doesn't have a crazy polymorphic return type and they somehow "fit" with all the more specific `read/write Blob/Commit/Tag/Tree` commands.
+- [x] I think I will change the `plugins` API. The current API (`plugins.set('fs', fs)`) uses a kinda-hacky run-time schema validation that just checks whether certain methods are defined. Static type checking would actually provide a better developer experience and better guarantees, but having `.set` be polymorphic is hard to accurately describe using JSDoc, so I might switch to an API like `plugins.fs(fs)`.
   - this also means we can set `new FileSystem(_fs)` in the `plugins.fs(fs)` command, because _we don't have to expose a getter like `plugins.get()`!_
-
-- [ ] I think I'll tweak `readObject` and `writeObject` so that `readObject` doesn't have a crazy polymorphic return type and they somehow "fit" with all the more specific `read/write Blob/Commit/Tag/Tree` commands.
+- [ ] Actually, I'm thinking of eliminating the plugin system API and going back to function arguments. The plugin cores creates a mysterious "global state" that makes it easy to trip up (I've forgotten to unset plugins after running tests). The old style of passing `fs` as a function argument was less aesthetic but a much simpler model.
+- [ ] To go along with that, I'm experimenting with a way to make the API more aesthetic, eliminating the `emitter` plugin/argument and letting you chain event listeners onto running commands directly. NOTE: need to make sure there's no race condition between adding the event listeners and starting running the command.
+  - [ ] This also provides an aesthetic way to cancel / stop running commands.
 
 ## Getting Started
 

--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -254,24 +254,33 @@ async function gendoc (file, filepath) {
   const entries = tree.filter(
     entry => entry.type === 'blob' && !entry.path.startsWith('_')
   )
+
   const docs = []
-  await Promise.all(
-    entries.map(async entry => {
-      // Load file
-      const { blob } = await git.readBlob({
-        dir,
-        oid,
-        filepath: `src/commands/${entry.path}`
-      })
-      const filetext = Buffer.from(blob).toString('utf8')
-      const doctext = await gendoc(filetext, entry.path)
-      if (doctext !== '') {
-        const docfilename = entry.path.replace(/js$/, 'md')
-        fs.writeFileSync(path.join(docDir, docfilename), doctext)
-        docs.push(`docs/${docfilename}`)
-      }
+  const processEntry = async entry => {
+    // Load file
+    const { blob } = await git.readBlob({
+      dir,
+      oid,
+      filepath: `src/commands/${entry.path}`
     })
-  )
+    const filetext = Buffer.from(blob).toString('utf8')
+    const doctext = await gendoc(filetext, entry.path)
+    if (doctext !== '') {
+      const docfilename = entry.path.replace(/js$/, 'md')
+      fs.writeFileSync(path.join(docDir, docfilename), doctext)
+      docs.push(`docs/${docfilename}`)
+    }
+  }
+
+  // Generate the shared typedefs
+  const typedefsIndex = entries.findIndex(entry => entry.path.endsWith('typedefs.js'))
+  const typedefsEntry = entries[typedefsIndex]
+  entries.splice(typedefsIndex, 1)
+  await processEntry(typedefsEntry)
+
+  // Generate all the docs
+  await Promise.all(entries.map(processEntry))
+
   docs.sort()
   gitignoreContent += docs.join('\n') + '\n'
   fs.writeFileSync(gitignorePath, gitignoreContent, 'utf8')

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
         'build.docs',
         'build.size'
       ),
-      rollup: 'rollup -c',
+      rollup: 'rollup -c --no-treeshake',
       typings: 'tsc -p declaration.tsconfig.json',
       webpack: 'webpack',
       indexjson: `node __tests__/__helpers__/make_http_index.js`,

--- a/src/commands/STAGE.js
+++ b/src/commands/STAGE.js
@@ -1,12 +1,7 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { GitWalkerIndex } from '../models/GitWalkerIndex.js'
 import { GitWalkSymbol } from '../utils/symbols.js'
-
-/**
- *
- * @typedef Walker
- * @property {Symbol} Symbol('GitWalkerSymbol')
- */
 
 /**
  * Get a git index Walker

--- a/src/commands/TREE.js
+++ b/src/commands/TREE.js
@@ -1,12 +1,7 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { GitWalkerRepo } from '../models/GitWalkerRepo.js'
 import { GitWalkSymbol } from '../utils/symbols.js'
-
-/**
- *
- * @typedef Walker
- * @property {Symbol} Symbol('GitWalkerSymbol')
- */
 
 /**
  * Get a git commit `Walker`

--- a/src/commands/WORKDIR.js
+++ b/src/commands/WORKDIR.js
@@ -1,12 +1,7 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { GitWalkerFs } from '../models/GitWalkerFs.js'
 import { GitWalkSymbol } from '../utils/symbols.js'
-
-/**
- *
- * @typedef Walker
- * @property {Symbol} Symbol('GitWalkerSymbol')
- */
 
 /**
  * Get a working directory `Walker`

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -24,7 +24,7 @@ import { config } from './config'
 
 /**
  *
- * @typedef {object} FetchResponse - The object returned has the following schema:
+ * @typedef {object} FetchResult - The object returned has the following schema:
  * @property {string | null} defaultBranch - The branch that is cloned if no branch is specified (typically "master")
  * @property {string | null} fetchHead - The SHA-1 object id of the fetched head commit
  * @property {string | null} fetchHeadDescription - a textual description of the branch that was fetched
@@ -64,8 +64,8 @@ import { config } from './config'
  * @param {boolean} [args.pruneTags] - Prune local tags that don’t exist on the remote, and force-update those tags that differ
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name.
  *
- * @returns {Promise<FetchResponse>} Resolves successfully when fetch completes
- * @see FetchResponse
+ * @returns {Promise<FetchResult>} Resolves successfully when fetch completes
+ * @see FetchResult
  *
  * @example
  * await git.fetch({

--- a/src/commands/getRemoteInfo.js
+++ b/src/commands/getRemoteInfo.js
@@ -3,7 +3,7 @@ import { GitRemoteHTTP } from '../managers/GitRemoteHTTP.js'
 
 /**
  *
- * @typedef {Object} RemoteDescription - The object returned has the following schema:
+ * @typedef {Object} GetRemoteInfoResult - The object returned has the following schema:
  * @property {string[]} capabilities - The list of capabilities returned by the server (part of the Git protocol)
  * @property {Object} [refs]
  * @property {Object<string, string>} [refs.heads] - The branches on the remote
@@ -30,8 +30,8 @@ import { GitRemoteHTTP } from '../managers/GitRemoteHTTP.js'
  * @param {string} [args.oauth2format] - See the [Authentication](./authentication.html) documentation
  * @param {Object<string, string>} [args.headers] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
  *
- * @returns {Promise<RemoteDescription>} Resolves successfully with an object listing the branches, tags, and capabilities of the remote.
- * @see RemoteDescription
+ * @returns {Promise<GetRemoteInfoResult>} Resolves successfully with an object listing the branches, tags, and capabilities of the remote.
+ * @see GetRemoteInfoResult
  *
  * @example
  * let info = await git.getRemoteInfo({

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { readCommit } from '../commands/readCommit.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
 import { GitShallowManager } from '../managers/GitShallowManager.js'
@@ -6,33 +7,6 @@ import { FileSystem } from '../models/FileSystem.js'
 import { compareAge } from '../utils/compareAge.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
-
-/**
- *
- * @typedef {Object} ReadCommitResult
- * @property {string} oid - SHA-1 object id of this commit
- * @property {CommitObject} commit - the parsed commit object
- * @property {string} payload - PGP signing payload
- */
-
-/**
- *
- * @typedef {Object} CommitObject
- * @property {string} message - Commit message
- * @property {string} tree - SHA-1 object id of corresponding file tree
- * @property {string[]} parent - an array of zero or more SHA-1 object ids
- * @property {Object} author
- * @property {string} author.name - The author's name
- * @property {string} author.email - The author's email
- * @property {number} author.timestamp - UTC Unix timestamp in seconds
- * @property {number} author.timezoneOffset - Timezone difference from UTC in minutes
- * @property {Object} committer
- * @property {string} committer.name - The committer's name
- * @property {string} committer.email - The committer's email
- * @property {number} committer.timestamp - UTC Unix timestamp in seconds
- * @property {number} committer.timezoneOffset - Timezone difference from UTC in minutes
- * @property {string} [gpgsig] - PGP signature (if present)
- */
 
 /**
  * Get commit descriptions from the git history

--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -14,7 +14,7 @@ import { findMergeBase } from './findMergeBase.js'
 
 /**
  *
- * @typedef {Object} MergeReport - Returns an object with a schema like this:
+ * @typedef {Object} MergeResult - Returns an object with a schema like this:
  * @property {string} [oid] - The SHA-1 object id that is now at the head of the branch. Absent only if `dryRun` was specified and `mergeCommit` is true.
  * @property {boolean} [alreadyMerged] - True if the branch was already merged so no changes were made
  * @property {boolean} [fastForward] - True if it was a fast-forward merge
@@ -59,8 +59,8 @@ import { findMergeBase } from './findMergeBase.js'
  * @param {string} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
  *
- * @returns {Promise<MergeReport>} Resolves to a description of the merge operation
- * @see MergeReport
+ * @returns {Promise<MergeResult>} Resolves to a description of the merge operation
+ * @see MergeResult
  *
  * @example
  * let m = await git.merge({ dir: '$input((/))', ours: '$input((master))', theirs: '$input((remotes/origin/master))' })

--- a/src/commands/pack.js
+++ b/src/commands/pack.js
@@ -1,13 +1,12 @@
 import Hash from 'sha.js/sha1'
 
+import { types } from '../commands/types.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { readObject } from '../storage/readObject.js'
 import { deflate } from '../utils/deflate.js'
 import { join } from '../utils/join.js'
 import { padHex } from '../utils/padHex.js'
 import { cores } from '../utils/plugins.js'
-
-import { types } from './types'
 
 /**
  * @param {object} args

--- a/src/commands/packObjects.js
+++ b/src/commands/packObjects.js
@@ -8,7 +8,7 @@ import { pack } from './pack'
 
 /**
  *
- * @typedef {Object} PackObjectsResponse The packObjects command returns an object with two properties:
+ * @typedef {Object} PackObjectsResult The packObjects command returns an object with two properties:
  * @property {string} filename - The suggested filename for the packfile if you want to save it to disk somewhere. It includes the packfile SHA.
  * @property {Uint8Array} [packfile] - The packfile contents. Not present if `write` parameter was true, in which case the packfile was written straight to disk.
  */
@@ -23,8 +23,8 @@ import { pack } from './pack'
  * @param {string[]} args.oids - An array of SHA-1 object ids to be included in the packfile
  * @param {boolean} [args.write = false] - Whether to save the packfile to disk or not
  *
- * @returns {Promise<PackObjectsResponse>} Resolves successfully when the packfile is ready with the filename and buffer
- * @see PackObjectsResponse
+ * @returns {Promise<PackObjectsResult>} Resolves successfully when the packfile is ready with the filename and buffer
+ * @see PackObjectsResult
  *
  * @example
  * // Create a packfile containing only an empty tree

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -22,7 +22,7 @@ import { pack } from './pack.js'
 
 /**
  *
- * @typedef {Object} PushResponse - Returns an object with a schema like this:
+ * @typedef {Object} PushResult - Returns an object with a schema like this:
  * @property {string[]} [ok]
  * @property {string[]} [errors]
  * @property {object} [headers]
@@ -63,17 +63,17 @@ import { pack } from './pack.js'
  * @param {Object<string, string>} [args.headers] - Additional headers to include in HTTP requests, similar to git's `extraHeader` config
  * @param {string} [args.emitterPrefix = ''] - Scope emitted events by prepending `emitterPrefix` to the event name.
  *
- * @returns {Promise<PushResponse>} Resolves successfully when push completes with a detailed description of the operation from the server.
- * @see PushResponse
+ * @returns {Promise<PushResult>} Resolves successfully when push completes with a detailed description of the operation from the server.
+ * @see PushResult
  *
  * @example
- * let pushResponse = await git.push({
+ * let pushResult = await git.push({
  *   dir: '$input((/))',
  *   remote: '$input((origin))',
  *   ref: '$input((master))',
  *   token: $input((process.env.GITHUB_TOKEN)),
  * })
- * console.log(pushResponse)
+ * console.log(pushResult)
  *
  */
 export async function push ({

--- a/src/commands/readCommit.js
+++ b/src/commands/readCommit.js
@@ -1,35 +1,9 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
 import { resolveCommit } from '../utils/resolveCommit.js'
-
-/**
- *
- * @typedef {Object} ReadCommitResult - The object returned has the following schema:
- * @property {string} oid - SHA-1 object id of this commit
- * @property {CommitObject} commit - the parsed commit object
- * @property {string} payload - PGP signing payload
- */
-
-/**
- *
- * @typedef {Object} CommitObject
- * @property {string} message - Commit message
- * @property {string} tree - SHA-1 object id of corresponding file tree
- * @property {string[]} parent - an array of zero or more SHA-1 object ids
- * @property {Object} author
- * @property {string} author.name - The author's name
- * @property {string} author.email - The author's email
- * @property {number} author.timestamp - UTC Unix timestamp in seconds
- * @property {number} author.timezoneOffset - Timezone difference from UTC in minutes
- * @property {Object} committer
- * @property {string} committer.name - The committer's name
- * @property {string} committer.email - The committer's email
- * @property {number} committer.timestamp - UTC Unix timestamp in seconds
- * @property {number} committer.timezoneOffset - Timezone difference from UTC in minutes
- * @property {string} [gpgsig] - PGP signature (if present)
- */
 
 /**
  * Read a commit object directly

--- a/src/commands/readObject.js
+++ b/src/commands/readObject.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { GitCommit } from '../models/GitCommit.js'
@@ -8,54 +9,6 @@ import { readObject as _readObject } from '../storage/readObject.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
 import { resolveTree } from '../utils/resolveTree.js'
-
-/**
- *
- * @typedef {Object} CommitObject
- * @property {string} message - Commit message
- * @property {string} tree - SHA-1 object id of corresponding file tree
- * @property {string[]} parent - an array of zero or more SHA-1 object ids
- * @property {Object} author
- * @property {string} author.name - The author's name
- * @property {string} author.email - The author's email
- * @property {number} author.timestamp - UTC Unix timestamp in seconds
- * @property {number} author.timezoneOffset - Timezone difference from UTC in minutes
- * @property {Object} committer
- * @property {string} committer.name - The committer's name
- * @property {string} committer.email - The committer's email
- * @property {number} committer.timestamp - UTC Unix timestamp in seconds
- * @property {number} committer.timezoneOffset - Timezone difference from UTC in minutes
- * @property {string} [gpgsig] - PGP signature (if present)
- */
-
-/**
- *
- * @typedef {TreeEntry[]} TreeObject
- */
-
-/**
- *
- * @typedef {Object} TreeEntry
- * @property {string} mode - the 6 digit hexadecimal mode
- * @property {string} path - the name of the file or directory
- * @property {string} oid - the SHA-1 object id of the blob or tree
- * @property {'commit'|'blob'|'tree'} type - the type of object
- */
-
-/**
- *
- * @typedef {Object} TagObject
- * @property {string} object - SHA-1 object id of object being tagged
- * @property {'blob' | 'tree' | 'commit' | 'tag'} type - the type of the object being tagged
- * @property {string} tag - the tag name
- * @property {Object} tagger
- * @property {string} tagger.name - the tagger's name
- * @property {string} tagger.email - the tagger's email
- * @property {number} tagger.timestamp - UTC Unix timestamp in seconds
- * @property {number} tagger.timezoneOffset - timezone difference from UTC in minutes
- * @property {string} message - tag message
- * @property {string} [signature] - PGP signature (if present)
- */
 
 /**
  *

--- a/src/commands/readTag.js
+++ b/src/commands/readTag.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { E, GitError } from '../models/GitError.js'
@@ -12,21 +13,6 @@ import { cores } from '../utils/plugins.js'
  * @property {string} oid - SHA-1 object id of this tag
  * @property {TagObject} tag - the parsed tag object
  * @property {string} payload - PGP signing payload
- */
-
-/**
- *
- * @typedef {Object} TagObject
- * @property {string} object - SHA-1 object id of object being tagged
- * @property {'blob' | 'tree' | 'commit' | 'tag'} type - the type of the object being tagged
- * @property {string} tag - the tag name
- * @property {Object} tagger
- * @property {string} tagger.name - the tagger's name
- * @property {string} tagger.email - the tagger's email
- * @property {number} tagger.timestamp - UTC Unix timestamp in seconds
- * @property {number} tagger.timezoneOffset - timezone difference from UTC in minutes
- * @property {string} message - tag message
- * @property {string} [signature] - PGP signature (if present)
  */
 
 /**

--- a/src/commands/readTree.js
+++ b/src/commands/readTree.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
@@ -10,20 +11,6 @@ import { resolveTree } from '../utils/resolveTree.js'
  * @typedef {Object} ReadTreeResult - The object returned has the following schema:
  * @property {string} oid - SHA-1 object id of this tree
  * @property {TreeObject} tree - the parsed tree object
- */
-
-/**
- *
- * @typedef {TreeEntry[]} TreeObject
- */
-
-/**
- *
- * @typedef {Object} TreeEntry
- * @property {string} mode - the 6 digit hexadecimal mode
- * @property {string} path - the name of the file or directory
- * @property {string} oid - the SHA-1 object id of the blob or tree
- * @property {'commit'|'blob'|'tree'} type - the type of object
  */
 
 /**

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -17,19 +17,21 @@ import { cores } from '../utils/plugins.js'
  *
  * The possible resolve values are:
  *
- * | status          | description                                                              |
- * | --------------- | ------------------------------------------------------------------------ |
- * | `"ignored"`     | file ignored by a .gitignore rule                                        |
- * | `"unmodified"`  | file unchanged from HEAD commit                                          |
- * | `"*modified"`   | file has modifications, not yet staged                                   |
- * | `"*deleted"`    | file has been removed, but the removal is not yet staged                 |
- * | `"*added"`      | file is untracked, not yet staged                                        |
- * | `"absent"`      | file not present in HEAD commit, staging area, or working dir            |
- * | `"modified"`    | file has modifications, staged                                           |
- * | `"deleted"`     | file has been removed, staged                                            |
- * | `"added"`       | previously untracked file, staged                                        |
- * | `"*unmodified"` | working dir and HEAD commit match, but index differs                     |
- * | `"*absent"`     | file not present in working dir or HEAD commit, but present in the index |
+ * | status                | description                                                                           |
+ * | --------------------- | ------------------------------------------------------------------------------------- |
+ * | `"ignored"`           | file ignored by a .gitignore rule                                                     |
+ * | `"unmodified"`        | file unchanged from HEAD commit                                                       |
+ * | `"*modified"`         | file has modifications, not yet staged                                                |
+ * | `"*deleted"`          | file has been removed, but the removal is not yet staged                              |
+ * | `"*added"`            | file is untracked, not yet staged                                                     |
+ * | `"absent"`            | file not present in HEAD commit, staging area, or working dir                         |
+ * | `"modified"`          | file has modifications, staged                                                        |
+ * | `"deleted"`           | file has been removed, staged                                                         |
+ * | `"added"`             | previously untracked file, staged                                                     |
+ * | `"*unmodified"`       | working dir and HEAD commit match, but index differs                                  |
+ * | `"*absent"`           | file not present in working dir or HEAD commit, but present in the index              |
+ * | `"*undeleted"`        | file was deleted from the index, but is still in the working dir                      |
+ * | `"*undeletemodified"` | file was deleted from the index, but is present with modifications in the working dir |
  *
  * @param {object} args
  * @param {string} [args.core = 'default'] - The plugin core identifier to use for plugin injection
@@ -37,7 +39,7 @@ import { cores } from '../utils/plugins.js'
  * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string} args.filepath - The path to the file to query
  *
- * @returns {Promise<string>} Resolves successfully with the file's git status
+ * @returns {Promise<'ignored'|'unmodified'|'*modified'|'*deleted'|'*added'|'absent'|'modified'|'deleted'|'added'|'*unmodified'|'*absent'|'*undeleted'|'*undeletemodified'>} Resolves successfully with the file's git status
  *
  * @example
  * let status = await git.status({ dir: '$input((/))', filepath: '$input((README.md))' })

--- a/src/commands/typedefs.js
+++ b/src/commands/typedefs.js
@@ -63,3 +63,28 @@
  * @typedef Walker
  * @property {Symbol} Symbol('GitWalkerSymbol')
  */
+
+/**
+ *
+ * @typedef {Object} Stat Normalized subset of filesystem `stat` data:
+ * @property {number} ctimeSeconds
+ * @property {number} ctimeNanoseconds
+ * @property {number} mtimeSeconds
+ * @property {number} mtimeNanoseconds
+ * @property {number} dev
+ * @property {number} ino
+ * @property {number} mode
+ * @property {number} uid
+ * @property {number} gid
+ * @property {number} size
+ */
+
+/**
+ *
+ * @typedef {Object} WalkerEntry The `WalkerEntry` is an interface that abstracts computing many common tree / blob stats.
+ * @property {function(): Promise<'tree'|'blob'|'special'|'commit'>} type
+ * @property {function(): Promise<number>} mode
+ * @property {function(): Promise<string>} oid
+ * @property {function(): Promise<Uint8Array|void>} content
+ * @property {function(): Promise<Stat>} stat
+ */

--- a/src/commands/typedefs.js
+++ b/src/commands/typedefs.js
@@ -1,0 +1,65 @@
+/**
+ * A git commit object.
+ *
+ * @typedef {Object} CommitObject
+ * @property {string} message Commit message
+ * @property {string} tree SHA-1 object id of corresponding file tree
+ * @property {string[]} parent an array of zero or more SHA-1 object ids
+ * @property {Object} author
+ * @property {string} author.name The author's name
+ * @property {string} author.email The author's email
+ * @property {number} author.timestamp UTC Unix timestamp in seconds
+ * @property {number} author.timezoneOffset Timezone difference from UTC in minutes
+ * @property {Object} committer
+ * @property {string} committer.name The committer's name
+ * @property {string} committer.email The committer's email
+ * @property {number} committer.timestamp UTC Unix timestamp in seconds
+ * @property {number} committer.timezoneOffset Timezone difference from UTC in minutes
+ * @property {string} [gpgsig] PGP signature (if present)
+ */
+
+/**
+ * An entry from a git tree object. Files are called 'blobs' and directories are called 'trees'.
+ *
+ * @typedef {Object} TreeEntry
+ * @property {string} mode the 6 digit hexadecimal mode
+ * @property {string} path the name of the file or directory
+ * @property {string} oid the SHA-1 object id of the blob or tree
+ * @property {'commit'|'blob'|'tree'} type the type of object
+ */
+
+/**
+ * A git tree object. Trees represent a directory snapshot.
+ *
+ * @typedef {TreeEntry[]} TreeObject
+ */
+
+/**
+ * A git annotated tag object.
+ *
+ * @typedef {Object} TagObject
+ * @property {string} object SHA-1 object id of object being tagged
+ * @property {'blob' | 'tree' | 'commit' | 'tag'} type the type of the object being tagged
+ * @property {string} tag the tag name
+ * @property {Object} tagger
+ * @property {string} tagger.name the tagger's name
+ * @property {string} tagger.email the tagger's email
+ * @property {number} tagger.timestamp UTC Unix timestamp in seconds
+ * @property {number} tagger.timezoneOffset timezone difference from UTC in minutes
+ * @property {string} message tag message
+ * @property {string} [signature] PGP signature (if present)
+ */
+
+/**
+ *
+ * @typedef {Object} ReadCommitResult
+ * @property {string} oid - SHA-1 object id of this commit
+ * @property {CommitObject} commit - the parsed commit object
+ * @property {string} payload - PGP signing payload
+ */
+
+/**
+ *
+ * @typedef Walker
+ * @property {Symbol} Symbol('GitWalkerSymbol')
+ */

--- a/src/commands/types.js
+++ b/src/commands/types.js
@@ -1,3 +1,6 @@
+/**
+ * @enum {number}
+ */
 export const types = {
   commit: 0b0010000,
   tree: 0b0100000,

--- a/src/commands/walk.js
+++ b/src/commands/walk.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { arrayRange } from '../utils/arrayRange.js'
 import { flat } from '../utils/flat.js'
@@ -6,12 +7,6 @@ import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
 import { GitWalkSymbol } from '../utils/symbols.js'
 import { unionOfIterators } from '../utils/unionOfIterators.js'
-
-/**
- *
- * @typedef {Object} Walker
- * @property {Symbol} Symbol('GitWalkSymbol')
- */
 
 /**
  *

--- a/src/commands/walk.js
+++ b/src/commands/walk.js
@@ -9,31 +9,6 @@ import { GitWalkSymbol } from '../utils/symbols.js'
 import { unionOfIterators } from '../utils/unionOfIterators.js'
 
 /**
- *
- * @typedef {Object} Stat Normalized subset of filesystem `stat` data:
- * @property {number} ctimeSeconds
- * @property {number} ctimeNanoseconds
- * @property {number} mtimeSeconds
- * @property {number} mtimeNanoseconds
- * @property {number} dev
- * @property {number} ino
- * @property {number} mode
- * @property {number} uid
- * @property {number} gid
- * @property {number} size
- */
-
-/**
- *
- * @typedef {Object} WalkerEntry The `WalkerEntry` is an interface that abstracts computing many common tree / blob stats.
- * @property {function(): Promise<'tree'|'blob'|'special'|'commit'>} type
- * @property {function(): Promise<number>} mode
- * @property {function(): Promise<string>} oid
- * @property {function(): Promise<Uint8Array|void>} content
- * @property {function(): Promise<Stat>} stat
- */
-
-/**
  * @callback WalkerMap
  * @param {string} filename
  * @param {?WalkerEntry[]} entries

--- a/src/commands/writeCommit.js
+++ b/src/commands/writeCommit.js
@@ -1,28 +1,10 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { GitCommit } from '../models/GitCommit.js'
 import { writeObject } from '../storage/writeObject.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
-
-/**
- *
- * @typedef {Object} CommitObject
- * @property {string} message - Commit message
- * @property {string} tree - SHA-1 object id of corresponding file tree
- * @property {string[]} parent - an array of zero or more SHA-1 object ids
- * @property {Object} author
- * @property {string} author.name - The author's name
- * @property {string} author.email - The author's email
- * @property {number} author.timestamp - UTC Unix timestamp in seconds
- * @property {number} author.timezoneOffset - Timezone difference from UTC in minutes
- * @property {Object} committer
- * @property {string} committer.name - The committer's name
- * @property {string} committer.email - The committer's email
- * @property {number} committer.timestamp - UTC Unix timestamp in seconds
- * @property {number} committer.timezoneOffset - Timezone difference from UTC in minutes
- * @property {string} [gpgsig] - PGP signature (if present)
- */
 
 /**
  * Write a commit object directly

--- a/src/commands/writeObject.js
+++ b/src/commands/writeObject.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { GitCommit } from '../models/GitCommit.js'
@@ -7,54 +8,6 @@ import { GitTree } from '../models/GitTree.js'
 import { writeObject as _writeObject } from '../storage/writeObject.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
-
-/**
- *
- * @typedef {Object} CommitObject
- * @property {string} message - Commit message
- * @property {string} tree - SHA-1 object id of corresponding file tree
- * @property {string[]} parent - an array of zero or more SHA-1 object ids
- * @property {Object} author
- * @property {string} author.name - The author's name
- * @property {string} author.email - The author's email
- * @property {number} author.timestamp - UTC Unix timestamp in seconds
- * @property {number} author.timezoneOffset - Timezone difference from UTC in minutes
- * @property {Object} committer
- * @property {string} committer.name - The committer's name
- * @property {string} committer.email - The committer's email
- * @property {number} committer.timestamp - UTC Unix timestamp in seconds
- * @property {number} committer.timezoneOffset - Timezone difference from UTC in minutes
- * @property {string} [gpgsig] - PGP signature (if present)
- */
-
-/**
- *
- * @typedef {TreeEntry[]} TreeObject
- */
-
-/**
- *
- * @typedef {Object} TreeEntry
- * @property {string} mode - the 6 digit hexadecimal mode
- * @property {string} path - the name of the file or directory
- * @property {string} oid - the SHA-1 object id of the blob or tree
- * @property {'commit'|'blob'|'tree'} type - the type of object
- */
-
-/**
- *
- * @typedef {Object} TagObject
- * @property {string} object - SHA-1 object id of object being tagged
- * @property {'blob' | 'tree' | 'commit' | 'tag'} type - the type of the object being tagged
- * @property {string} tag - the tag name
- * @property {Object} tagger
- * @property {string} tagger.name - the tagger's name
- * @property {string} tagger.email - the tagger's email
- * @property {number} tagger.timestamp - UTC Unix timestamp in seconds
- * @property {number} tagger.timezoneOffset - timezone difference from UTC in minutes
- * @property {string} message - tag message
- * @property {string} [signature] - PGP signature (if present)
- */
 
 /**
  * Write a git object directly

--- a/src/commands/writeTag.js
+++ b/src/commands/writeTag.js
@@ -1,24 +1,10 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { writeObject } from '../storage/writeObject.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
-
-/**
- *
- * @typedef {Object} TagObject
- * @property {string} object - SHA-1 object id of object being tagged
- * @property {'blob' | 'tree' | 'commit' | 'tag'} type - the type of the object being tagged
- * @property {string} tag - the tag name
- * @property {Object} tagger
- * @property {string} tagger.name - the tagger's name
- * @property {string} tagger.email - the tagger's email
- * @property {number} tagger.timestamp - UTC Unix timestamp in seconds
- * @property {number} tagger.timezoneOffset - timezone difference from UTC in minutes
- * @property {string} message - tag message
- * @property {string} [signature] - PGP signature (if present)
- */
 
 /**
  * Write an annotated tag object directly

--- a/src/commands/writeTree.js
+++ b/src/commands/writeTree.js
@@ -1,23 +1,10 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { GitTree } from '../models/GitTree.js'
 import { writeObject } from '../storage/writeObject.js'
 import { join } from '../utils/join.js'
 import { cores } from '../utils/plugins.js'
-
-/**
- *
- * @typedef {TreeEntry[]} TreeObject
- */
-
-/**
- *
- * @typedef {Object} TreeEntry
- * @property {string} mode - the 6 digit hexadecimal mode
- * @property {string} path - the name of the file or directory
- * @property {string} oid - the SHA-1 object id of the blob or tree
- * @property {'commit'|'blob'|'tree'} type - the type of object
- */
 
 /**
  * Write a tree object directly

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import './commands/typedefs.js'
+
 export * from './commands/add.js'
 export * from './commands/addNote.js'
 export * from './commands/addRemote.js'

--- a/src/utils/mergeTree.js
+++ b/src/utils/mergeTree.js
@@ -1,4 +1,5 @@
 // @ts-check
+import '../commands/typedefs.js'
 import { TREE } from '../commands/TREE.js'
 import { walk } from '../commands/walk.js'
 import { FileSystem } from '../models/FileSystem.js'
@@ -10,11 +11,6 @@ import { basename } from './basename.js'
 import { join } from './join.js'
 import { mergeFile } from './mergeFile.js'
 import { cores } from './plugins.js'
-
-/**
- *
- * @typedef {import('../commands/readObject').TreeEntry} TreeEntry
- */
 
 /**
  * Create a merged tree
@@ -147,8 +143,8 @@ export async function mergeTree ({
 
 /**
  *
- * @param {import('../commands/walk.js').WalkerEntry} entry
- * @param {import('../commands/walk.js').WalkerEntry} base
+ * @param {WalkerEntry} entry
+ * @param {WalkerEntry} base
  *
  */
 async function modified (entry, base) {
@@ -174,9 +170,9 @@ async function modified (entry, base) {
  * @param {FileSystem} args.fs
  * @param {string} args.gitdir
  * @param {string} args.path
- * @param {import('../commands/walk.js').WalkerEntry} args.ours
- * @param {import('../commands/walk.js').WalkerEntry} args.base
- * @param {import('../commands/walk.js').WalkerEntry} args.theirs
+ * @param {WalkerEntry} args.ours
+ * @param {WalkerEntry} args.base
+ * @param {WalkerEntry} args.theirs
  * @param {string} [args.ourName]
  * @param {string} [args.baseName]
  * @param {string} [args.theirName]


### PR DESCRIPTION
- Moves all the shared types to `typedefs.js`
- Fixes the type (and documentation) of `status` to include `*undeleted* and `*undeletemodified`
- Renames some of the return types for consistency (`MergeReport` -> `MergeResult`, `FetchResponse` -> `FetchResult`, everything is a `Result` now)