### PR TITLE
chore: remove extra FileSystem casts

### DIFF
--- a/src/commands/listCommitsAndTags.js
+++ b/src/commands/listCommitsAndTags.js
@@ -1,6 +1,5 @@
 import { GitRefManager } from '../managers/GitRefManager.js'
 import { GitShallowManager } from '../managers/GitShallowManager.js'
-import { FileSystem } from '../models/FileSystem.js'
 import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { GitCommit } from '../models/GitCommit.js'
 import { E, GitError } from '../models/GitError.js'
@@ -8,13 +7,12 @@ import { readObject } from '../storage/readObject.js'
 import { join } from '../utils/join.js'
 
 export async function listCommitsAndTags ({
-  fs: _fs,
+  fs,
   dir,
   gitdir = join(dir, '.git'),
   start,
   finish
 }) {
-  const fs = new FileSystem(_fs)
   const shallows = await GitShallowManager.read({ fs, gitdir })
   const startingSet = new Set()
   const finishingSet = new Set()

--- a/src/commands/listObjects.js
+++ b/src/commands/listObjects.js
@@ -1,4 +1,3 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { GitCommit } from '../models/GitCommit.js'
 import { GitTree } from '../models/GitTree.js'
@@ -6,12 +5,11 @@ import { readObject } from '../storage/readObject.js'
 import { join } from '../utils/join.js'
 
 export async function listObjects ({
-  fs: _fs,
+  fs,
   dir,
   gitdir = join(dir, '.git'),
   oids
 }) {
-  const fs = new FileSystem(_fs)
   const visited = new Set()
   // We don't do the purest simplest recursion, because we can
   // avoid reading Blob objects entirely since the Tree objects

--- a/src/commands/pack.js
+++ b/src/commands/pack.js
@@ -1,7 +1,6 @@
 import Hash from 'sha.js/sha1.js'
 
 import { types } from '../commands/types.js'
-import { FileSystem } from '../models/FileSystem.js'
 import { readObject } from '../storage/readObject.js'
 import { deflate } from '../utils/deflate.js'
 import { join } from '../utils/join.js'
@@ -14,8 +13,7 @@ import { padHex } from '../utils/padHex.js'
  * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string[]} args.oids
  */
-export async function pack ({ fs: _fs, dir, gitdir = join(dir, '.git'), oids }) {
-  const fs = new FileSystem(_fs)
+export async function pack ({ fs, dir, gitdir = join(dir, '.git'), oids }) {
   const hash = new Hash()
   const outputStream = []
   function write (chunk, enc) {

--- a/src/commands/uploadPack.js
+++ b/src/commands/uploadPack.js
@@ -1,15 +1,13 @@
 import { GitRefManager } from '../managers/GitRefManager.js'
-import { FileSystem } from '../models/FileSystem.js'
 import { join } from '../utils/join.js'
 import { writeRefsAdResponse } from '../wire/writeRefsAdResponse.js'
 
 export async function uploadPack ({
-  fs: _fs,
+  fs,
   dir,
   gitdir = join(dir, '.git'),
   advertiseRefs = false
 }) {
-  const fs = new FileSystem(_fs)
   try {
     if (advertiseRefs) {
       // Send a refs advertisement

--- a/src/managers/GitConfigManager.js
+++ b/src/managers/GitConfigManager.js
@@ -1,17 +1,14 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { GitConfig } from '../models/GitConfig.js'
 
 export class GitConfigManager {
-  static async get ({ fs: _fs, gitdir }) {
-    const fs = new FileSystem(_fs)
+  static async get ({ fs, gitdir }) {
     // We can improve efficiency later if needed.
     // TODO: read from full list of git config files
     const text = await fs.read(`${gitdir}/config`, { encoding: 'utf8' })
     return GitConfig.from(text)
   }
 
-  static async save ({ fs: _fs, gitdir, config }) {
-    const fs = new FileSystem(_fs)
+  static async save ({ fs, gitdir, config }) {
     // We can improve efficiency later if needed.
     // TODO: handle saving to the correct global/user/repo location
     await fs.write(`${gitdir}/config`, config.toString(), {

--- a/src/managers/GitIgnoreManager.js
+++ b/src/managers/GitIgnoreManager.js
@@ -1,6 +1,5 @@
 import ignore from 'ignore'
 
-import { FileSystem } from '../models/FileSystem.js'
 import { basename } from '../utils/basename.js'
 import { dirname } from '../utils/dirname.js'
 import { join } from '../utils/join.js'
@@ -12,12 +11,11 @@ import { join } from '../utils/join.js'
 
 export class GitIgnoreManager {
   static async isIgnored ({
-    fs: _fs,
+    fs,
     dir,
     gitdir = join(dir, '.git'),
     filepath
   }) {
-    const fs = new FileSystem(_fs)
     // ALWAYS ignore ".git" folders.
     if (basename(filepath) === '.git') return true
     // '.' is not a valid gitignore entry, so '.' is never ignored

--- a/src/managers/GitIgnoreManager.js
+++ b/src/managers/GitIgnoreManager.js
@@ -10,12 +10,7 @@ import { join } from '../utils/join.js'
 // TODO: Implement .git/info/exclude
 
 export class GitIgnoreManager {
-  static async isIgnored ({
-    fs,
-    dir,
-    gitdir = join(dir, '.git'),
-    filepath
-  }) {
+  static async isIgnored ({ fs, dir, gitdir = join(dir, '.git'), filepath }) {
     // ALWAYS ignore ".git" folders.
     if (basename(filepath) === '.git') return true
     // '.' is not a valid gitignore entry, so '.' is never ignored

--- a/src/managers/GitIndexManager.js
+++ b/src/managers/GitIndexManager.js
@@ -1,7 +1,6 @@
 // import LockManager from 'travix-lock-manager'
 import AsyncLock from 'async-lock'
 
-import { FileSystem } from '../models/FileSystem.js'
 import { GitIndex } from '../models/GitIndex.js'
 import { DeepMap } from '../utils/DeepMap.js'
 import { compareStats } from '../utils/compareStats.js'
@@ -42,8 +41,7 @@ export class GitIndexManager {
    * @param {object} opts
    * @param {function(GitIndex): any} closure
    */
-  static async acquire ({ fs: _fs, gitdir }, closure) {
-    const fs = new FileSystem(_fs)
+  static async acquire ({ fs, gitdir }, closure) {
     const filepath = `${gitdir}/index`
     if (lock === null) lock = new AsyncLock({ maxPending: Infinity })
     let result

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -1,5 +1,4 @@
 // This is a convenience wrapper for reading and writing files in the 'refs' directory.
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { GitPackedRefs } from '../models/GitPackedRefs.js'
 import { GitRefSpecSet } from '../models/GitRefSpecSet.js'
@@ -23,7 +22,7 @@ const GIT_FILES = ['config', 'description', 'index', 'shallow', 'commondir']
 
 export class GitRefManager {
   static async updateRemoteRefs ({
-    fs: _fs,
+    fs,
     gitdir,
     remote,
     refs,
@@ -33,7 +32,6 @@ export class GitRefManager {
     prune = false,
     pruneTags = false
   }) {
-    const fs = new FileSystem(_fs)
     // Validate input
     for (const value of refs.values()) {
       if (!value.match(/[0-9a-f]{40}/)) {
@@ -132,8 +130,7 @@ export class GitRefManager {
   }
 
   // TODO: make this less crude?
-  static async writeRef ({ fs: _fs, gitdir, ref, value }) {
-    const fs = new FileSystem(_fs)
+  static async writeRef ({ fs, gitdir, ref, value }) {
     // Validate input
     if (!value.match(/[0-9a-f]{40}/)) {
       throw new GitError(E.NotAnOidFail, { value })
@@ -141,8 +138,7 @@ export class GitRefManager {
     await fs.write(join(gitdir, ref), `${value.trim()}\n`, 'utf8')
   }
 
-  static async writeSymbolicRef ({ fs: _fs, gitdir, ref, value }) {
-    const fs = new FileSystem(_fs)
+  static async writeSymbolicRef ({ fs, gitdir, ref, value }) {
     await fs.write(join(gitdir, ref), 'ref: ' + `${value.trim()}\n`, 'utf8')
   }
 
@@ -150,8 +146,7 @@ export class GitRefManager {
     return GitRefManager.deleteRefs({ fs, gitdir, refs: [ref] })
   }
 
-  static async deleteRefs ({ fs: _fs, gitdir, refs }) {
-    const fs = new FileSystem(_fs)
+  static async deleteRefs ({ fs, gitdir, refs }) {
     // Delete regular ref
     await Promise.all(refs.map(ref => fs.rm(join(gitdir, ref))))
     // Delete any packed ref
@@ -169,8 +164,7 @@ export class GitRefManager {
     }
   }
 
-  static async resolve ({ fs: _fs, gitdir, ref, depth = undefined }) {
-    const fs = new FileSystem(_fs)
+  static async resolve ({ fs, gitdir, ref, depth = undefined }) {
     if (depth !== undefined) {
       depth--
       if (depth === -1) {
@@ -213,8 +207,7 @@ export class GitRefManager {
     }
   }
 
-  static async expand ({ fs: _fs, gitdir, ref }) {
-    const fs = new FileSystem(_fs)
+  static async expand ({ fs, gitdir, ref }) {
     // Is it a complete and valid SHA?
     if (ref.length === 40 && /[0-9a-f]{40}/.test(ref)) {
       return ref
@@ -274,16 +267,14 @@ export class GitRefManager {
     throw new GitError(E.ResolveRefError, { ref })
   }
 
-  static async packedRefs ({ fs: _fs, gitdir }) {
-    const fs = new FileSystem(_fs)
+  static async packedRefs ({ fs, gitdir }) {
     const text = await fs.read(`${gitdir}/packed-refs`, { encoding: 'utf8' })
     const packed = GitPackedRefs.from(text)
     return packed.refs
   }
 
   // List all the refs that match the `filepath` prefix
-  static async listRefs ({ fs: _fs, gitdir, filepath }) {
-    const fs = new FileSystem(_fs)
+  static async listRefs ({ fs, gitdir, filepath }) {
     const packedMap = GitRefManager.packedRefs({ fs, gitdir })
     let files = null
     try {
@@ -309,8 +300,7 @@ export class GitRefManager {
     return files
   }
 
-  static async listBranches ({ fs: _fs, gitdir, remote }) {
-    const fs = new FileSystem(_fs)
+  static async listBranches ({ fs, gitdir, remote }) {
     if (remote) {
       return GitRefManager.listRefs({
         fs,
@@ -322,8 +312,7 @@ export class GitRefManager {
     }
   }
 
-  static async listTags ({ fs: _fs, gitdir }) {
-    const fs = new FileSystem(_fs)
+  static async listTags ({ fs, gitdir }) {
     const tags = await GitRefManager.listRefs({
       fs,
       gitdir,

--- a/src/managers/GitShallowManager.js
+++ b/src/managers/GitShallowManager.js
@@ -1,13 +1,11 @@
 import AsyncLock from 'async-lock'
 
-import { FileSystem } from '../models/FileSystem.js'
 import { join } from '../utils/join.js'
 
 let lock = null
 
 export class GitShallowManager {
-  static async read ({ fs: _fs, gitdir }) {
-    const fs = new FileSystem(_fs)
+  static async read ({ fs, gitdir }) {
     if (lock === null) lock = new AsyncLock()
     const filepath = join(gitdir, 'shallow')
     const oids = new Set()
@@ -23,8 +21,7 @@ export class GitShallowManager {
     return oids
   }
 
-  static async write ({ fs: _fs, gitdir, oids }) {
-    const fs = new FileSystem(_fs)
+  static async write ({ fs, gitdir, oids }) {
     if (lock === null) lock = new AsyncLock()
     const filepath = join(gitdir, 'shallow')
     if (oids.size > 0) {

--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -4,12 +4,10 @@ import { join } from '../utils/join'
 import { normalizeStats } from '../utils/normalizeStats.js'
 import { shasum } from '../utils/shasum.js'
 
-import { FileSystem } from './FileSystem.js'
 import { GitObject } from './GitObject.js'
 
 export class GitWalkerFs {
-  constructor ({ fs: _fs, dir, gitdir }) {
-    const fs = new FileSystem(_fs)
+  constructor ({ fs, dir, gitdir }) {
     this.fs = fs
     this.dir = dir
     this.gitdir = gitdir

--- a/src/models/GitWalkerIndex.js
+++ b/src/models/GitWalkerIndex.js
@@ -4,11 +4,8 @@ import { flatFileListToDirectoryStructure } from '../utils/flatFileListToDirecto
 import { mode2type } from '../utils/mode2type'
 import { normalizeStats } from '../utils/normalizeStats'
 
-import { FileSystem } from './FileSystem.js'
-
 export class GitWalkerIndex {
-  constructor ({ fs: _fs, gitdir }) {
-    const fs = new FileSystem(_fs)
+  constructor ({ fs, gitdir }) {
     this.treePromise = GitIndexManager.acquire({ fs, gitdir }, async function (
       index
     ) {

--- a/src/models/GitWalkerRepo.js
+++ b/src/models/GitWalkerRepo.js
@@ -5,12 +5,10 @@ import { join } from '../utils/join'
 import { normalizeMode } from '../utils/normalizeMode.js'
 import { resolveTree } from '../utils/resolveTree.js'
 
-import { FileSystem } from './FileSystem.js'
 import { GitTree } from './GitTree.js'
 
 export class GitWalkerRepo {
-  constructor ({ fs: _fs, gitdir, ref }) {
-    const fs = new FileSystem(_fs)
+  constructor ({ fs, gitdir, ref }) {
     this.fs = fs
     this.gitdir = gitdir
     this.mapPromise = (async () => {

--- a/src/storage/expandOid.js
+++ b/src/storage/expandOid.js
@@ -1,14 +1,12 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { expandOidLoose } from '../storage/expandOidLoose.js'
 import { expandOidPacked } from '../storage/expandOidPacked.js'
 import { readObject } from '../storage/readObject.js'
 
-export async function expandOid ({ fs: _fs, gitdir, oid: short }) {
-  const fs = new FileSystem(_fs)
+export async function expandOid ({ fs, gitdir, oid: short }) {
   // Curry the current read method so that the packfile un-deltification
   // process can acquire external ref-deltas.
-  const getExternalRefDelta = oid => readObject({ fs: _fs, gitdir, oid })
+  const getExternalRefDelta = oid => readObject({ fs, gitdir, oid })
 
   const results1 = await expandOidLoose({ fs, gitdir, oid: short })
   const results2 = await expandOidPacked({

--- a/src/storage/expandOidLoose.js
+++ b/src/storage/expandOidLoose.js
@@ -1,7 +1,4 @@
-import { FileSystem } from '../models/FileSystem.js'
-
-export async function expandOidLoose ({ fs: _fs, gitdir, oid: short }) {
-  const fs = new FileSystem(_fs)
+export async function expandOidLoose ({ fs, gitdir, oid: short }) {
   const prefix = short.slice(0, 2)
   const objectsSuffixes = await fs.readdir(`${gitdir}/objects/${prefix}`)
   return objectsSuffixes

--- a/src/storage/expandOidPacked.js
+++ b/src/storage/expandOidPacked.js
@@ -1,15 +1,13 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { readPackIndex } from '../storage/readPackIndex.js'
 import { join } from '../utils/join.js'
 
 export async function expandOidPacked ({
-  fs: _fs,
+  fs,
   gitdir,
   oid: short,
   getExternalRefDelta
 }) {
-  const fs = new FileSystem(_fs)
   // Iterate through all the .pack files
   const results = []
   let list = await fs.readdir(join(gitdir, 'objects/pack'))

--- a/src/storage/hasObject.js
+++ b/src/storage/hasObject.js
@@ -1,10 +1,8 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { hasObjectLoose } from '../storage/hasObjectLoose.js'
 import { hasObjectPacked } from '../storage/hasObjectPacked.js'
 import { readObject } from '../storage/readObject.js'
 
-export async function hasObject ({ fs: _fs, gitdir, oid, format = 'content' }) {
-  const fs = new FileSystem(_fs)
+export async function hasObject ({ fs, gitdir, oid, format = 'content' }) {
   // Curry the current read method so that the packfile un-deltification
   // process can acquire external ref-deltas.
   const getExternalRefDelta = oid => readObject({ fs, gitdir, oid })

--- a/src/storage/hasObjectLoose.js
+++ b/src/storage/hasObjectLoose.js
@@ -1,7 +1,4 @@
-import { FileSystem } from '../models/FileSystem.js'
-
-export async function hasObjectLoose ({ fs: _fs, gitdir, oid }) {
-  const fs = new FileSystem(_fs)
+export async function hasObjectLoose ({ fs, gitdir, oid }) {
   const source = `objects/${oid.slice(0, 2)}/${oid.slice(2)}`
   return fs.exists(`${gitdir}/${source}`)
 }

--- a/src/storage/hasObjectPacked.js
+++ b/src/storage/hasObjectPacked.js
@@ -1,15 +1,13 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { readPackIndex } from '../storage/readPackIndex.js'
 import { join } from '../utils/join.js'
 
 export async function hasObjectPacked ({
-  fs: _fs,
+  fs,
   gitdir,
   oid,
   getExternalRefDelta
 }) {
-  const fs = new FileSystem(_fs)
   // Check to see if it's in a packfile.
   // Iterate through all the .idx files
   let list = await fs.readdir(join(gitdir, 'objects/pack'))

--- a/src/storage/readObject.js
+++ b/src/storage/readObject.js
@@ -1,4 +1,3 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { GitObject } from '../models/GitObject.js'
 import { readObjectLoose } from '../storage/readObjectLoose.js'
@@ -6,8 +5,7 @@ import { readObjectPacked } from '../storage/readObjectPacked.js'
 import { inflate } from '../utils/inflate.js'
 import { shasum } from '../utils/shasum.js'
 
-export async function readObject ({ fs: _fs, gitdir, oid, format = 'content' }) {
-  const fs = new FileSystem(_fs)
+export async function readObject ({ fs, gitdir, oid, format = 'content' }) {
   // Curry the current read method so that the packfile un-deltification
   // process can acquire external ref-deltas.
   const getExternalRefDelta = oid => readObject({ fs, gitdir, oid })

--- a/src/storage/readObjectLoose.js
+++ b/src/storage/readObjectLoose.js
@@ -1,7 +1,4 @@
-import { FileSystem } from '../models/FileSystem.js'
-
-export async function readObjectLoose ({ fs: _fs, gitdir, oid }) {
-  const fs = new FileSystem(_fs)
+export async function readObjectLoose ({ fs, gitdir, oid }) {
   const source = `objects/${oid.slice(0, 2)}/${oid.slice(2)}`
   const file = await fs.read(`${gitdir}/${source}`)
   if (!file) {

--- a/src/storage/readObjectPacked.js
+++ b/src/storage/readObjectPacked.js
@@ -1,16 +1,14 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { readPackIndex } from '../storage/readPackIndex.js'
 import { join } from '../utils/join.js'
 
 export async function readObjectPacked ({
-  fs: _fs,
+  fs,
   gitdir,
   oid,
   format = 'content',
   getExternalRefDelta
 }) {
-  const fs = new FileSystem(_fs)
   // Check to see if it's in a packfile.
   // Iterate through all the .idx files
   let list = await fs.readdir(join(gitdir, 'objects/pack'))

--- a/src/storage/writeObject.js
+++ b/src/storage/writeObject.js
@@ -1,11 +1,10 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { GitObject } from '../models/GitObject.js'
 import { writeObjectLoose } from '../storage/writeObjectLoose.js'
 import { deflate } from '../utils/deflate.js'
 import { shasum } from '../utils/shasum.js'
 
 export async function writeObject ({
-  fs: _fs,
+  fs,
   gitdir,
   type,
   object,
@@ -21,7 +20,6 @@ export async function writeObject ({
     object = Buffer.from(await deflate(object))
   }
   if (!dryRun) {
-    const fs = new FileSystem(_fs)
     await writeObjectLoose({ fs, gitdir, object, format: 'deflated', oid })
   }
   return oid

--- a/src/storage/writeObjectLoose.js
+++ b/src/storage/writeObjectLoose.js
@@ -1,14 +1,12 @@
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 
 export async function writeObjectLoose ({
-  fs: _fs,
+  fs,
   gitdir,
   object,
   format,
   oid
 }) {
-  const fs = new FileSystem(_fs)
   if (format !== 'deflated') {
     throw new GitError(E.InternalFail, {
       message:

--- a/src/storage/writeObjectLoose.js
+++ b/src/storage/writeObjectLoose.js
@@ -1,12 +1,6 @@
 import { E, GitError } from '../models/GitError.js'
 
-export async function writeObjectLoose ({
-  fs,
-  gitdir,
-  object,
-  format,
-  oid
-}) {
+export async function writeObjectLoose ({ fs, gitdir, object, format, oid }) {
   if (format !== 'deflated') {
     throw new GitError(E.InternalFail, {
       message:

--- a/src/utils/mergeTree.js
+++ b/src/utils/mergeTree.js
@@ -3,7 +3,6 @@ import '../commands/typedefs.js'
 
 import { TREE } from '../commands/TREE.js'
 import { walk } from '../commands/walk.js'
-import { FileSystem } from '../models/FileSystem.js'
 import { E, GitError } from '../models/GitError.js'
 import { GitTree } from '../models/GitTree.js'
 import { writeObject } from '../storage/writeObject.js'
@@ -16,7 +15,7 @@ import { mergeFile } from './mergeFile.js'
  * Create a merged tree
  *
  * @param {Object} args
- * @param {FsClient} args.fs - a file system client
+ * @param {import('../models/FileSystem.js').FileSystem} args.fs
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string} args.ourOid - The SHA-1 object id of our tree
@@ -31,7 +30,7 @@ import { mergeFile } from './mergeFile.js'
  *
  */
 export async function mergeTree ({
-  fs: _fs,
+  fs,
   dir,
   gitdir = join(dir, '.git'),
   ourOid,
@@ -42,13 +41,12 @@ export async function mergeTree ({
   theirName = 'theirs',
   dryRun = false
 }) {
-  const fs = new FileSystem(_fs)
   const ourTree = TREE({ ref: ourOid })
   const baseTree = TREE({ ref: baseOid })
   const theirTree = TREE({ ref: theirOid })
 
   const results = await walk({
-    fs: _fs,
+    fs,
     dir,
     gitdir,
     trees: [ourTree, baseTree, theirTree],


### PR DESCRIPTION
one of the reasons for the new `src/api` directory is to _always_ cast the input to a `FileSystem` there. So we can be certain that everywhere else it's a `FileSystem` not an `FsClient`