### PR TITLE
chore: remove automatic URL mangling and User-Agent setting

### DIFF
--- a/__tests__/__fixtures__/test-fetch-cors.git/config
+++ b/__tests__/__fixtures__/test-fetch-cors.git/config
@@ -5,7 +5,7 @@
 	symlinks = false
 	ignorecase = true
 [remote "origin"]
-	url = https://github.com/isomorphic-git/isomorphic-git
+	url = https://github.com/isomorphic-git/isomorphic-git.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "ssh"]
 	url = git@github.com:isomorphic-git/isomorphic-git.git

--- a/__tests__/__fixtures__/test-fetch.git/config
+++ b/__tests__/__fixtures__/test-fetch.git/config
@@ -5,5 +5,5 @@
 	symlinks = false
 	ignorecase = true
 [remote "origin"]
-	url = https://github.com/isomorphic-git/isomorphic-git
+	url = https://github.com/isomorphic-git/isomorphic-git.git
 	fetch = +refs/heads/*:refs/remotes/origin/*

--- a/__tests__/__fixtures__/test-hosting-providers.git/config
+++ b/__tests__/__fixtures__/test-hosting-providers.git/config
@@ -5,10 +5,10 @@
 	symlinks = false
 	ignorecase = true
 [remote "github"]
-	url = https://github.com/isomorphic-git/test.empty
+	url = https://github.com/isomorphic-git/test.empty.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "gitlab"]
-	url = https://gitlab.com/isomorphic-git/test.empty
+	url = https://gitlab.com/isomorphic-git/test.empty.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "awscc"]
 	url = https://git-codecommit.us-west-2.amazonaws.com/v1/repos/test.empty

--- a/__tests__/__fixtures__/test-issue-84.git/config
+++ b/__tests__/__fixtures__/test-issue-84.git/config
@@ -5,7 +5,7 @@
 	symlinks = false
 	ignorecase = true
 [remote "origin"]
-	url = https://github.com/isomorphic-git/isomorphic-git
+	url = https://github.com/isomorphic-git/isomorphic-git.git
 	#fetch = +refs/heads/*:refs/remotes/origin/*
 [http]
   corsProxy = http://localhost:9999

--- a/__tests__/test-clone.js
+++ b/__tests__/test-clone.js
@@ -23,7 +23,7 @@ describe('clone', () => {
       depth: 1,
       ref: 'test-branch',
       noTags: true,
-      url: 'https://github.com/isomorphic-git/isomorphic-git',
+      url: 'https://github.com/isomorphic-git/isomorphic-git.git',
       corsProxy: process.browser ? `http://${localhost}:9999` : undefined,
       noCheckout: true,
     })
@@ -55,7 +55,7 @@ describe('clone', () => {
       ref: 'test-branch',
       singleBranch: true,
       noCheckout: true,
-      url: 'https://github.com/isomorphic-git/isomorphic-git',
+      url: 'https://github.com/isomorphic-git/isomorphic-git.git',
       corsProxy: process.browser ? `http://${localhost}:9999` : undefined,
     })
     expect(await fs.exists(`${dir}`)).toBe(true)
@@ -76,7 +76,7 @@ describe('clone', () => {
       depth: 1,
       singleBranch: true,
       ref: 'test-tag',
-      url: 'https://github.com/isomorphic-git/isomorphic-git',
+      url: 'https://github.com/isomorphic-git/isomorphic-git.git',
       corsProxy: process.browser ? `http://${localhost}:9999` : undefined,
     })
     expect(await fs.exists(`${dir}`)).toBe(true)

--- a/__tests__/test-hosting-providers.js
+++ b/__tests__/test-hosting-providers.js
@@ -79,7 +79,6 @@ describe('Hosting Providers', () => {
       const res = await fetch({
         fs,
         http,
-        noGitSuffix: true,
         gitdir,
         // corsProxy: process.browser ? `http://${localhost}:9999` : undefined,
         username: 'isomorphicgittestpush',
@@ -104,7 +103,6 @@ describe('Hosting Providers', () => {
       const res = await push({
         fs,
         http,
-        noGitSuffix: true,
         gitdir,
         // corsProxy: process.browser ? `http://${localhost}:9999` : undefined,
         username: 'isomorphicgittestpush',

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -1,0 +1,18 @@
+---
+title: headers
+sidebar_label: headers
+---
+
+# The `User-Agent` header
+
+Regretably, some git hosting services have User-Agent specific behavior.
+For instance, GitHub will correctly interpret git HTTP requests made to a repository URL that is missing the `.git` suffix but _ONLY_ if the User-Agent starts with `git/`.
+And in fact, does not interpret git HTTP requests for _gists_ correctly _at all_ unless the User-Agent start with `git/` (bug [#259](https://github.com/isomorphic-git/isomorphic-git/issues/259)).
+
+Since 2015 the specs state that setting a custom User-Agent header in `fetch` should override the default. This works in Firefox (bug [#247](https://github.com/isomorphic-git/isomorphic-git/issues/247)), but Chrome has a bug so setting a custom User-Agent doesn't work at all (chrome bug [#571722](https://bugs.chromium.org/p/chromium/issues/detail?id=571722)).
+
+The [`@isomorphic-git/cors-proxy`](https://github.com/isomorphic-git/cors-proxy) solves some of this problem by checking if the User-Agent starts with `git/` and if it doesn't, it sets the User-Agent to `git/@isomorphic-git/cors-proxy`. So cloning gists using a proxy works.
+
+CORS also has a strange relationship with the User-Agent header. Setting a custom User-Agent header requires that 'User-Agent' be explicitly whitelisted in the CORS pre-flight request (bug [#555](https://github.com/isomorphic-git/isomorphic-git/issues/555)).
+
+As you can see, User-Agent is basically a mine field. Which is why as of version 1.0 this library doesn't touch it. There is no solution that works for everything (GitHub handling URLs without .git, cloning gists, setting it in Chrome, setting it in a proxy, CORS). This is your problem now, not mine. Go bug GitHub, Inc to stop using user-agent filtering.

--- a/src/api/clone.js
+++ b/src/api/clone.js
@@ -24,7 +24,6 @@ import { join } from '../utils/join.js'
  * @param {string} [args.ref] - Which branch to clone. By default this is the designated "main branch" of the repository.
  * @param {boolean} [args.singleBranch = false] - Instead of the default behavior of fetching all the branches, only fetch a single branch.
  * @param {boolean} [args.noCheckout = false] - If true, clone will only fetch the repo, not check out a branch. Skipping checkout can save a lot of time normally spent writing files to disk.
- * @param {boolean} [args.noGitSuffix = false] - If true, clone will not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**.)
  * @param {boolean} [args.noTags = false] - By default clone will fetch all tags. `noTags` disables that behavior.
  * @param {string} [args.remote = 'origin'] - What to name the remote that is created.
  * @param {number} [args.depth] - Integer. Determines how much of the git repository's history to retrieve
@@ -63,7 +62,6 @@ export async function clone({
   dir,
   gitdir = join(dir, '.git'),
   url,
-  noGitSuffix = false,
   corsProxy = undefined,
   ref = undefined,
   remote = 'origin',
@@ -99,7 +97,6 @@ export async function clone({
       dir,
       gitdir,
       url,
-      noGitSuffix,
       corsProxy,
       ref,
       remote,

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -43,7 +43,6 @@ import { join } from '../utils/join.js'
  * @param {string[]} [args.exclude = []] - A list of branches or tags. Instructs the remote server not to send us any commits reachable from these refs.
  * @param {boolean} [args.prune] - Delete local remote-tracking branches that are not present on the remote
  * @param {boolean} [args.pruneTags] - Prune local tags that don’t exist on the remote, and force-update those tags that differ
- * @param {boolean} [args.noGitSuffix = false] - If true, clone will not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**)
  * @param {string} [args.corsProxy] - Optional [CORS proxy](https://www.npmjs.com/%40isomorphic-git/cors-proxy). Overrides value in repo config.
  * @param {string} [args.username] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.password] - See the [Authentication](./authentication.html) documentation
@@ -83,7 +82,6 @@ export async function fetch({
   remote,
   remoteRef,
   url,
-  noGitSuffix = false,
   corsProxy,
   username,
   password,
@@ -126,7 +124,6 @@ export async function fetch({
       remote,
       remoteRef,
       url,
-      noGitSuffix,
       corsProxy,
       username,
       password,

--- a/src/api/getRemoteInfo.js
+++ b/src/api/getRemoteInfo.js
@@ -26,7 +26,6 @@ import { assertParameter } from '../utils/assertParameter.js'
  * @param {string} args.url - The URL of the remote repository. Will be gotten from gitconfig if absent.
  * @param {string} [args.corsProxy] - Optional [CORS proxy](https://www.npmjs.com/%40isomorphic-git/cors-proxy). Overrides value in repo config.
  * @param {boolean} [args.forPush = false] - By default, the command queries the 'fetch' capabilities. If true, it will ask for the 'push' capabilities.
- * @param {boolean} [args.noGitSuffix = false] - If true, clone will not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**)
  * @param {string} [args.username] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.password] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.token] - See the [Authentication](./authentication.html) documentation
@@ -49,7 +48,6 @@ export async function getRemoteInfo({
   http,
   corsProxy,
   url,
-  noGitSuffix = false,
   username,
   password,
   token,
@@ -66,7 +64,6 @@ export async function getRemoteInfo({
       corsProxy,
       service: forPush ? 'git-receive-pack' : 'git-upload-pack',
       url,
-      noGitSuffix,
       auth,
       headers,
     })

--- a/src/api/pull.js
+++ b/src/api/pull.js
@@ -26,7 +26,6 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  * @param {string} [args.corsProxy] - Optional [CORS proxy](https://www.npmjs.com/%40isomorphic-git/cors-proxy). Overrides value in repo config.
  * @param {boolean} [args.singleBranch = false] - Instead of the default behavior of fetching all the branches, only fetch a single branch.
  * @param {boolean} [args.fastForwardOnly = false] - Only perform simple fast-forward merges. (Don't create merge commits.)
- * @param {boolean} [args.noGitSuffix = false] - If true, do not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**)
  * @param {string} [args.username] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.password] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.token] - See the [Authentication](./authentication.html) documentation
@@ -71,7 +70,6 @@ export async function pull({
   gitdir = join(dir, '.git'),
   ref,
   fastForwardOnly = false,
-  noGitSuffix = false,
   corsProxy,
   username,
   password,
@@ -112,7 +110,6 @@ export async function pull({
       gitdir,
       ref,
       fastForwardOnly,
-      noGitSuffix,
       corsProxy,
       username,
       password,

--- a/src/api/push.js
+++ b/src/api/push.js
@@ -33,7 +33,6 @@ import { join } from '../utils/join.js'
  * @param {string} [args.remoteRef] - The name of the receiving branch on the remote. By default this is the configured remote tracking branch.
  * @param {boolean} [args.force = false] - If true, behaves the same as `git push --force`
  * @param {boolean} [args.delete = false] - If true, delete the remote ref
- * @param {boolean} [args.noGitSuffix = false] - If true, do not auto-append a `.git` suffix to the `url`. (**AWS CodeCommit needs this option**)
  * @param {string} [args.corsProxy] - Optional [CORS proxy](https://www.npmjs.com/%40isomorphic-git/cors-proxy). Overrides value in repo config.
  * @param {string} [args.username] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.password] - See the [Authentication](./authentication.html) documentation
@@ -73,7 +72,6 @@ export async function push({
   url,
   force = false,
   delete: _delete = false,
-  noGitSuffix = false,
   corsProxy,
   username,
   password,
@@ -100,7 +98,6 @@ export async function push({
       url,
       force,
       delete: _delete,
-      noGitSuffix,
       corsProxy,
       username,
       password,

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -24,7 +24,6 @@ import { addRemote } from './addRemote.js'
  * @param {string} args.ref
  * @param {boolean} args.singleBranch
  * @param {boolean} args.noCheckout
- * @param {boolean} args.noGitSuffix
  * @param {boolean} args.noTags
  * @param {string} args.remote
  * @param {number} args.depth
@@ -51,7 +50,6 @@ export async function clone({
   dir,
   gitdir,
   url,
-  noGitSuffix,
   corsProxy,
   ref,
   remote,
@@ -88,7 +86,6 @@ export async function clone({
     onAuthSuccess,
     onAuthFailure,
     gitdir,
-    noGitSuffix,
     ref,
     remote,
     username,

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -49,7 +49,6 @@ import { writeUploadPackRequest } from '../wire/writeUploadPackRequest.js'
  * @param {string} [args.remoteRef]
  * @param {string} [args.remote]
  * @param {boolean} [args.singleBranch = false]
- * @param {boolean} [args.noGitSuffix = false]
  * @param {boolean} [args.tags = false]
  * @param {number} [args.depth]
  * @param {Date} [args.since]
@@ -79,7 +78,6 @@ export async function fetch({
   remoteRef: _remoteRef,
   remote: _remote,
   url: _url,
-  noGitSuffix = false,
   corsProxy,
   username,
   password,
@@ -130,7 +128,6 @@ export async function fetch({
     corsProxy,
     service: 'git-upload-pack',
     url,
-    noGitSuffix,
     auth,
     headers,
   })
@@ -233,7 +230,6 @@ export async function fetch({
     corsProxy,
     service: 'git-upload-pack',
     url,
-    noGitSuffix,
     auth,
     body: [packbuffer],
     headers,

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -22,7 +22,6 @@ import { E, GitError } from '../models/GitError.js'
  * @param {string} [args.corsProxy] - Optional [CORS proxy](https://www.npmjs.com/%40isomorphic-git/cors-proxy). Overrides value in repo config.
  * @param {boolean} args.singleBranch
  * @param {boolean} args.fastForwardOnly
- * @param {boolean} args.noGitSuffix
  * @param {string} [args.username] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.password] - See the [Authentication](./authentication.html) documentation
  * @param {string} [args.token] - See the [Authentication](./authentication.html) documentation
@@ -55,7 +54,6 @@ export async function pull({
   gitdir,
   ref,
   fastForwardOnly,
-  noGitSuffix,
   corsProxy,
   username,
   password,
@@ -94,7 +92,6 @@ export async function pull({
       onAuthSuccess,
       onAuthFailure,
       gitdir,
-      noGitSuffix,
       corsProxy,
       ref,
       remote,

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -34,7 +34,6 @@ import { writeReceivePackRequest } from '../wire/writeReceivePackRequest.js'
  * @param {string} [args.remote]
  * @param {boolean} [args.force = false]
  * @param {boolean} [args.delete = false]
- * @param {boolean} [args.noGitSuffix = false]
  * @param {string} [args.url]
  * @param {string} [args.corsProxy]
  * @param {string} [args.username]
@@ -60,7 +59,6 @@ export async function push({
   url: _url,
   force = false,
   delete: _delete = false,
-  noGitSuffix = false,
   corsProxy,
   username,
   password,
@@ -118,7 +116,6 @@ export async function push({
     corsProxy,
     service: 'git-receive-pack',
     url,
-    noGitSuffix,
     auth,
     headers,
   })
@@ -209,7 +206,6 @@ export async function push({
     corsProxy,
     service: 'git-receive-pack',
     url,
-    noGitSuffix,
     auth,
     headers,
     body: [...packstream1, ...packstream2],

--- a/src/managers/GitRemoteHTTP.js
+++ b/src/managers/GitRemoteHTTP.js
@@ -5,7 +5,6 @@ import { calculateBasicAuthHeader } from '../utils/calculateBasicAuthHeader.js'
 import { calculateBasicAuthUsernamePasswordPair } from '../utils/calculateBasicAuthUsernamePasswordPair.js'
 import { collect } from '../utils/collect.js'
 import { extractAuthFromUrl } from '../utils/extractAuthFromUrl.js'
-import { pkg } from '../utils/pkg.js'
 import { parseRefsAdResponse } from '../wire/parseRefsAdResponse.js'
 
 // Try to accomodate known CORS proxy implementations:
@@ -31,7 +30,6 @@ export class GitRemoteHTTP {
    * @param {string} [args.corsProxy]
    * @param {string} args.service
    * @param {string} args.url
-   * @param {boolean} args.noGitSuffix
    * @param {GitAuth} [args.auth]
    * @param {Object<string, string>} [args.headers]
    */
@@ -44,13 +42,10 @@ export class GitRemoteHTTP {
     corsProxy,
     service,
     url,
-    noGitSuffix,
     auth,
     headers,
   }) {
     const _origUrl = url
-    // Auto-append the (necessary) .git if it's missing.
-    if (!url.endsWith('.git') && !noGitSuffix) url = url += '.git'
     const urlAuth = extractAuthFromUrl(url)
     if (urlAuth) {
       url = urlAuth.url
@@ -69,14 +64,6 @@ export class GitRemoteHTTP {
       url = corsProxify(corsProxy, url)
     }
     // headers['Accept'] = `application/x-${service}-advertisement`
-    // Only send a user agent in Node and to CORS proxies by default,
-    // because Gogs and others might not whitelist 'user-agent' in allowed headers.
-    // Solutions using 'process.browser' can't be used as they rely on bundler shims,
-    // ans solutions using 'process.versions.node' had to be discarded because the
-    // BrowserFS 'process' shim is too complete.
-    if (typeof window === 'undefined' || corsProxy) {
-      headers['user-agent'] = headers['user-agent'] || pkg.agent
-    }
     // If the username came from the URL, we want to allow the password to be missing.
     // This is because Github allows using the token as the username with an empty password
     // so that is a style of git clone URL we might encounter and we don't want to throw a "Missing password or token" error.
@@ -154,13 +141,10 @@ export class GitRemoteHTTP {
     corsProxy,
     service,
     url,
-    noGitSuffix,
     auth,
     body,
     headers,
   }) {
-    // Auto-append the (necessary) .git if it's missing.
-    if (!url.endsWith('.git') && !noGitSuffix) url = url += '.git'
     const urlAuth = extractAuthFromUrl(url)
     if (urlAuth) {
       url = urlAuth.url
@@ -175,14 +159,6 @@ export class GitRemoteHTTP {
     }
     headers['content-type'] = `application/x-${service}-request`
     headers.accept = `application/x-${service}-result`
-    // Only send a user agent in Node and to CORS proxies by default,
-    // because Gogs and others might not whitelist 'user-agent' in allowed headers.
-    // Solutions using 'process.browser' can't be used as they rely on bundler shims,
-    // ans solutions using 'process.versions.node' had to be discarded because the
-    // BrowserFS 'process' shim is too complete.
-    if (typeof window === 'undefined' || corsProxy) {
-      headers['user-agent'] = headers['user-agent'] || pkg.agent
-    }
     // If the username came from the URL, we want to allow the password to be missing.
     // This is because Github allows using the token as the username with an empty password
     // so that is a style of git clone URL we might encounter and we don't want to throw a "Missing password or token" error.


### PR DESCRIPTION
BREAKING CHANGE: The URL that's provided is now the URL that's used; no longer will they be "fixed" to end with `.git` since sometimes that actually makes things worse, and subverts user expectations. Accordingly, the `noGitSuffix` parameter has been removed since it's the default behavior. Furthermore, the `User-Agent` is now totally in the user's hands, because it is just a minefield, and I'm done trying to make sense of it. I added a Headers page to the docs documenting what I know about User-Agent + GitHub + CORS + Chrome bugs.