### PR TITLE
chore: remove date option from author/committer/tagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ The following environments are tested in CI and will continue to be supported un
 
 ## 1.0 Breaking Changes
 
-TODO:
-- [ ] I should probably normalize on timestamps and get rid of the `date` options.
-
 ### Big changes
 - [x] The supported node & browser versions have been bumped. (See beautiful table above.)
 - [x] The plugin system has been eliminated and we're back to plain old dependency injection via function arguments! The plugin cores created a mysterious "global state" that makes it easy to trip up (I myself sometimes forgot to unset plugins after running tests). The old style of passing `fs` as a function argument was less aesthetic and more verbose, but it is a much simpler model than the plugin core model, and much safer because it makes it impossible for dependencies to accidentally share the default plugin core.
@@ -64,6 +61,7 @@ TODO:
   - [x] The `autoTranslateSSH` feature was removed, since it is trivial to implement your own version using just the `UnknownTransportError.data.suggestion`
   - [x] The `writeObject` function when used to write a tree now expects a plain array rather than an object with a property called `entries` which is the array. (This is so that argument to `writeObject` has the same shame as the arguments to `writeBlob`/`writeCommit`/`writeTag`/`writeTree`.)
   - [x] The `noOverwrite` parameter was removed from `init` and is the new behavior.
+  - [x] The `author.date`, `committer.date`, `tagger.date` parameters were removed in favor of `author.timestamp`, `comitter.timestamp`, `tagger.timestamp` in order to be clear about what is actually written and better reflect the return types in `readCommit`, `log`, and `readTag`.
 
 ### The return types of some functions have changed:
   - [x] Functions that used to return `Buffer` objects now return `Uint8Array` objects. (This is so we can eventually remove all internal dependencies on the Buffer browser polyfill, which is quite heavy!)

--- a/src/api/addNote.js
+++ b/src/api/addNote.js
@@ -24,14 +24,12 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  * @param {Object} [args.author] - The details about the author.
  * @param {string} [args.author.name] - Default is `user.name` config.
  * @param {string} [args.author.email] - Default is `user.email` config.
- * @param {Date} [args.author.date] - Set the author timestamp field. Default is the current date.
- * @param {number} [args.author.timestamp] - Set the author timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.author.timestamp=Math.floor(Date.now()/1000)] - Set the author timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.author.timezoneOffset] - Set the author timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {Object} [args.committer = author] - The details about the note committer, in the same format as the author parameter. If not specified, the author details are used.
  * @param {string} [args.committer.name] - Default is `user.name` config.
  * @param {string} [args.committer.email] - Default is `user.email` config.
- * @param {Date} [args.committer.date] - Set the committer timestamp field. Default is the current date.
- * @param {number} [args.committer.timestamp] - Set the committer timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.committer.timestamp=Math.floor(Date.now()/1000)] - Set the committer timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.signingKey] - Sign the note commit using this private PGP key.
  *

--- a/src/api/annotatedTag.js
+++ b/src/api/annotatedTag.js
@@ -22,8 +22,7 @@ import { normalizeAuthorObject } from '../utils/normalizeAuthorObject.js'
  * @param {object} [args.tagger] - The details about the tagger.
  * @param {string} [args.tagger.name] - Default is `user.name` config.
  * @param {string} [args.tagger.email] - Default is `user.email` config.
- * @param {Date} [args.tagger.date] - Set the tagger timestamp field. Default is the current date.
- * @param {number} [args.tagger.timestamp] - Set the tagger timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.tagger.timestamp=Math.floor(Date.now()/1000)] - Set the tagger timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.tagger.timezoneOffset] - Set the tagger timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.gpgsig] - The gpgsig attatched to the tag object. (Mutually exclusive with the `signingKey` option.)
  * @param {string} [args.signingKey] - Sign the tag object using this private PGP key. (Mutually exclusive with the `gpgsig` option.)

--- a/src/api/commit.js
+++ b/src/api/commit.js
@@ -21,14 +21,12 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  * @param {Object} [args.author] - The details about the author.
  * @param {string} [args.author.name] - Default is `user.name` config.
  * @param {string} [args.author.email] - Default is `user.email` config.
- * @param {Date} [args.author.date] - Set the author timestamp field. Default is the current date.
- * @param {number} [args.author.timestamp] - Set the author timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.author.timestamp=Math.floor(Date.now()/1000)] - Set the author timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.author.timezoneOffset] - Set the author timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {Object} [args.committer = author] - The details about the commit committer, in the same format as the author parameter. If not specified, the author details are used.
  * @param {string} [args.committer.name] - Default is `user.name` config.
  * @param {string} [args.committer.email] - Default is `user.email` config.
- * @param {Date} [args.committer.date] - Set the committer timestamp field. Default is the current date.
- * @param {number} [args.committer.timestamp] - Set the committer timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.committer.timestamp=Math.floor(Date.now()/1000)] - Set the committer timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.signingKey] - Sign the tag object using this private PGP key.
  * @param {boolean} [args.dryRun = false] - If true, simulates making a commit so you can test whether it would succeed. Implies `noUpdateBranch`.
@@ -45,7 +43,7 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  *   dir: '/tutorial',
  *   author: {
  *     name: 'Mr. Test',
- *     email: 'mrtest@example.com'
+ *     email: 'mrtest@example.com',
  *   },
  *   message: 'Added the a.txt file'
  * })

--- a/src/api/merge.js
+++ b/src/api/merge.js
@@ -46,14 +46,12 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  * @param {Object} [args.author] - passed to [commit](commit.md) when creating a merge commit
  * @param {string} [args.author.name] - Default is `user.name` config.
  * @param {string} [args.author.email] - Default is `user.email` config.
- * @param {Date} [args.author.date] - Set the author timestamp field. Default is the current date.
- * @param {number} [args.author.timestamp] - Set the author timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.author.timestamp=Math.floor(Date.now()/1000)] - Set the author timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.author.timezoneOffset] - Set the author timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {Object} [args.committer] - passed to [commit](commit.md) when creating a merge commit
  * @param {string} [args.committer.name] - Default is `user.name` config.
  * @param {string} [args.committer.email] - Default is `user.email` config.
- * @param {Date} [args.committer.date] - Set the committer timestamp field. Default is the current date.
- * @param {number} [args.committer.timestamp] - Set the committer timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.committer.timestamp=Math.floor(Date.now()/1000)] - Set the committer timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
  *

--- a/src/api/pull.js
+++ b/src/api/pull.js
@@ -30,14 +30,12 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  * @param {Object} [args.author] - The details about the author.
  * @param {string} [args.author.name] - Default is `user.name` config.
  * @param {string} [args.author.email] - Default is `user.email` config.
- * @param {Date} [args.author.date] - Set the author timestamp field. Default is the current date.
- * @param {number} [args.author.timestamp] - Set the author timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.author.timestamp=Math.floor(Date.now()/1000)] - Set the author timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.author.timezoneOffset] - Set the author timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {Object} [args.committer = author] - The details about the commit committer, in the same format as the author parameter. If not specified, the author details are used.
  * @param {string} [args.committer.name] - Default is `user.name` config.
  * @param {string} [args.committer.email] - Default is `user.email` config.
- * @param {Date} [args.committer.date] - Set the committer timestamp field. Default is the current date.
- * @param {number} [args.committer.timestamp] - Set the committer timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.committer.timestamp=Math.floor(Date.now()/1000)] - Set the committer timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
  *

--- a/src/api/removeNote.js
+++ b/src/api/removeNote.js
@@ -22,14 +22,12 @@ import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
  * @param {Object} [args.author] - The details about the author.
  * @param {string} [args.author.name] - Default is `user.name` config.
  * @param {string} [args.author.email] - Default is `user.email` config.
- * @param {Date} [args.author.date] - Set the author timestamp field. Default is the current date.
- * @param {number} [args.author.timestamp] - Set the author timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.author.timestamp=Math.floor(Date.now()/1000)] - Set the author timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.author.timezoneOffset] - Set the author timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {Object} [args.committer = author] - The details about the note committer, in the same format as the author parameter. If not specified, the author details are used.
  * @param {string} [args.committer.name] - Default is `user.name` config.
  * @param {string} [args.committer.email] - Default is `user.email` config.
- * @param {Date} [args.committer.date] - Set the committer timestamp field. Default is the current date.
- * @param {number} [args.committer.timestamp] - Set the committer timestamp field. This is an alternative to using `date` using an integer number of seconds since the Unix epoch instead of a JavaScript date object.
+ * @param {number} [args.committer.timestamp=Math.floor(Date.now()/1000)] - Set the committer timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
  * @param {number} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
  * @param {string} [args.signingKey] - Sign the tag object using this private PGP key.
  *

--- a/src/commands/addNote.js
+++ b/src/commands/addNote.js
@@ -20,13 +20,11 @@ import { E, GitError } from '../models/GitError.js'
  * @param {Object} args.author
  * @param {string} args.author.name
  * @param {string} args.author.email
- * @param {Date} args.author.date
  * @param {number} args.author.timestamp
  * @param {number} args.author.timezoneOffset
  * @param {Object} args.committer
  * @param {string} args.committer.name
  * @param {string} args.committer.email
- * @param {Date} args.committer.date
  * @param {number} args.committer.timestamp
  * @param {number} args.committer.timezoneOffset
  * @param {string} [args.signingKey]

--- a/src/commands/annotatedTag.js
+++ b/src/commands/annotatedTag.js
@@ -20,7 +20,6 @@ import { writeObject } from '../storage/writeObject.js'
  * @param {object} [args.tagger]
  * @param {string} args.tagger.name
  * @param {string} args.tagger.email
- * @param {Date} args.tagger.date
  * @param {number} args.tagger.timestamp
  * @param {number} args.tagger.timezoneOffset
  * @param {string} [args.gpgsig]

--- a/src/utils/normalizeAuthorObject.js
+++ b/src/utils/normalizeAuthorObject.js
@@ -5,7 +5,7 @@ import { getConfig } from '../commands/getConfig'
  * @returns {Promise<void | {name: string, email: string, date: Date, timestamp: number, timezoneOffset: number }>}
  */
 export async function normalizeAuthorObject({ fs, gitdir, author = {} }) {
-  let { name, email, date, timestamp, timezoneOffset } = author
+  let { name, email, timestamp, timezoneOffset } = author
   name = name || (await getConfig({ fs, gitdir, path: 'user.name' }))
   email = email || (await getConfig({ fs, gitdir, path: 'user.email' }))
 
@@ -13,10 +13,11 @@ export async function normalizeAuthorObject({ fs, gitdir, author = {} }) {
     return undefined
   }
 
-  date = date || new Date()
-  timestamp = timestamp != null ? timestamp : Math.floor(date.valueOf() / 1000)
+  timestamp = timestamp != null ? timestamp : Math.floor(Date.now() / 1000)
   timezoneOffset =
-    timezoneOffset != null ? timezoneOffset : date.getTimezoneOffset()
+    timezoneOffset != null
+      ? timezoneOffset
+      : new Date(timestamp * 1000).getTimezoneOffset()
 
-  return { name, email, date, timestamp, timezoneOffset }
+  return { name, email, timestamp, timezoneOffset }
 }

--- a/src/utils/normalizeCommitterObject.js
+++ b/src/utils/normalizeCommitterObject.js
@@ -2,7 +2,7 @@ import { normalizeAuthorObject } from '../utils/normalizeAuthorObject.js'
 
 /**
  *
- * @returns {Promise<void | {name: string, email: string, date: Date, timestamp: number, timezoneOffset: number }>}
+ * @returns {Promise<void | {name: string, email: string, timestamp: number, timezoneOffset: number }>}
  */
 export async function normalizeCommitterObject({
   fs,
@@ -13,7 +13,6 @@ export async function normalizeCommitterObject({
   committer = Object.assign({}, committer || author)
   // Match committer's date to author's one, if omitted
   if (author) {
-    committer.date = committer.date || author.date
     committer.timestamp = committer.timestamp || author.timestamp
     committer.timezoneOffset = committer.timezoneOffset || author.timezoneOffset
   }


### PR DESCRIPTION
BREAKING CHANGE: The `author.date`, `committer.date`, `tagger.date` parameters were removed in favor of `author.timestamp`, `comitter.timestamp`, `tagger.timestamp` in order to be clear about what is actually written and better reflect the return types in `readCommit`, `log`, and `readTag`.