### PR TITLE
chore: fix onAuth typings, add an http.d.ts

### DIFF
--- a/declaration.tsconfig.json
+++ b/declaration.tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["dist/index.js"],
+  "include": ["dist/index.js", "dist/http.js"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "strictNullChecks": true,

--- a/docs/onAuth.md
+++ b/docs/onAuth.md
@@ -13,14 +13,19 @@ Git does all its authentication using HTTPS Basic Authentication.
 An `onAuth` function is called with a `url` and should return a credential object:
 
 ```ts
-type AuthCallback = (url: string) => Promise<GitAuth>;
+/**
+ * @callback AuthCallback
+ * @param {string} url
+ * @returns {GitAuth | Promise<GitAuth>}
+ */
 
-type GitAuth = {
-  username?: string;
-  password?: string;
-  token?: string;
-  oauth2format?: string;
-}
+/**
+ * @typedef {Object} GitAuth
+ * @property {string} [username]
+ * @property {string} [password]
+ * @property {string} [token]
+ * @property {string} [oauth2format]
+ */
 ```
 
 ## Option 1: Username & Password

--- a/docs/onAuthFailure.md
+++ b/docs/onAuthFailure.md
@@ -5,16 +5,14 @@ sidebar_label: onAuthFailure
 
 The `onAuthFailure` callback is called when credentials fail. This is helpful to know if say, you have saved password and want to offer to delete ones that fail.
 
-An `onAuthFailure` function is called with a `{ url, auth }` object.
+An `onAuthFailure` function is called with a `url` and an `auth` object.
 
 ```js
 /**
  * @callback AuthFailureCallback
- * @param {object} args.
- * @param {string} args.url
- * @param {GitAuth} args.auth
- *
- * @returns {Promise<void>}
+ * @param {string} url
+ * @param {GitAuth} auth
+ * @returns {void | Promise<void>}
  */
 
 /**
@@ -32,7 +30,7 @@ An `onAuthFailure` function is called with a `{ url, auth }` object.
 const git = require('isomorphic-git')
 git.clone({
   ...,
-  onAuthFailure: ({ url, auth }) => {
+  onAuthFailure: (url, auth) => {
     if (confirm('Access was denied. Delete saved password?')) {
       forgetSavedPassword(url)
     }

--- a/docs/onAuthSuccess.md
+++ b/docs/onAuthSuccess.md
@@ -5,16 +5,14 @@ sidebar_label: onAuthSuccess
 
 The `onAuthSuccess` callback is called when credentials fail. This is helpful to know if say, you want to offer to save a password but only after it succeeds.
 
-An `onAuthSuccess` function is called with a `{ url, auth }` object.
+An `onAuthSuccess` function is called with a `url` and an `auth` object.
 
 ```js
 /**
  * @callback AuthSuccessCallback
- * @param {object} args.
- * @param {string} args.url
- * @param {GitAuth} args.auth
- *
- * @returns {Promise<void>}
+ * @param {string} url
+ * @param {GitAuth} auth
+ * @returns {void | Promise<void>}
  */
 
 /**
@@ -32,7 +30,7 @@ An `onAuthSuccess` function is called with a `{ url, auth }` object.
 const git = require('isomorphic-git')
 git.clone({
   ...,
-  onAuthSuccess: ({ url, auth }) => {
+  onAuthSuccess: (url, auth) => {
     if (confirm('Remember password?')) {
       savedPassword(url, auth)
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0-development",
   "description": "A pure JavaScript reimplementation of git for node and browsers",
   "typings": "./dist/index.d.ts",
-  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
@@ -54,6 +53,7 @@
     "dist/bundle.umd.min.js",
     "dist/bundle.umd.min.js.map",
     "dist/http.cjs",
+    "dist/http.d.ts",
     "dist/http.js",
     "dist/http.umd.min.js",
     "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.0.0-development",
   "description": "A pure JavaScript reimplementation of git for node and browsers",
   "typings": "./dist/index.d.ts",
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": "./dist/index.cjs",
+    "./dist/index.cjs": "./dist/index.cjs",
     "./dist/index.js": "./dist/index.js",
     "./dist/http.cjs": "./dist/http.cjs",
     "./dist/http.js": "./dist/http.js"

--- a/src/builtin-browser/http.js
+++ b/src/builtin-browser/http.js
@@ -2,6 +2,36 @@
 import { collect } from '../utils/collect.js'
 import { fromStream } from '../utils/fromStream'
 
+// Sorry for the copy & paste from typedefs.js but if we import typedefs.js we'll get a whole bunch of extra comments
+// in the rollup output
+
+/**
+ * @typedef {Object} GitHttpRequest
+ * @property {string} url - The URL to request
+ * @property {string} [method='GET'] - The HTTP method to use
+ * @property {Object<string, string>} [headers={}] - Headers to include in the HTTP request
+ * @property {AsyncIterableIterator<Uint8Array>} [body] - An async iterator of Uint8Arrays that make up the body of POST requests
+ * @property {string} [core] - If your `http` plugin needs access to other plugins, it can do so via `git.cores.get(core)`
+ * @property {GitEmitterPlugin} [emitter] - If your `http` plugin emits events, it can do so via `emitter.emit()`
+ * @property {string} [emitterPrefix] - The `emitterPrefix` passed by the user when calling a function. If your plugin emits events, prefix the event name with this.
+ */
+
+/**
+ * @typedef {Object} GitHttpResponse
+ * @property {string} url - The final URL that was fetched after any redirects
+ * @property {string} [method] - The HTTP method that was used
+ * @property {Object<string, string>} [headers] - HTTP response headers
+ * @property {AsyncIterableIterator<Uint8Array>} [body] - An async iterator of Uint8Arrays that make up the body of the response
+ * @property {number} statusCode - The HTTP status code
+ * @property {string} statusMessage - The HTTP status message
+ */
+
+/**
+ * HttpClient
+ *
+ * @param {GitHttpRequest} request
+ * @returns {Promise<GitHttpResponse>}
+ */
 export default async function http({
   onProgress,
   url,

--- a/src/builtin-node/http.js
+++ b/src/builtin-node/http.js
@@ -2,6 +2,36 @@ import { asyncIteratorToStream } from '../utils/asyncIteratorToStream.js'
 import { collect } from '../utils/collect.js'
 import { fromNodeStream } from '../utils/fromNodeStream.js'
 
+// Sorry for the copy & paste from typedefs.js but if we import typedefs.js we'll get a whole bunch of extra comments
+// in the rollup output
+
+/**
+ * @typedef {Object} GitHttpRequest
+ * @property {string} url - The URL to request
+ * @property {string} [method='GET'] - The HTTP method to use
+ * @property {Object<string, string>} [headers={}] - Headers to include in the HTTP request
+ * @property {AsyncIterableIterator<Uint8Array>} [body] - An async iterator of Uint8Arrays that make up the body of POST requests
+ * @property {string} [core] - If your `http` plugin needs access to other plugins, it can do so via `git.cores.get(core)`
+ * @property {GitEmitterPlugin} [emitter] - If your `http` plugin emits events, it can do so via `emitter.emit()`
+ * @property {string} [emitterPrefix] - The `emitterPrefix` passed by the user when calling a function. If your plugin emits events, prefix the event name with this.
+ */
+
+/**
+ * @typedef {Object} GitHttpResponse
+ * @property {string} url - The final URL that was fetched after any redirects
+ * @property {string} [method] - The HTTP method that was used
+ * @property {Object<string, string>} [headers] - HTTP response headers
+ * @property {AsyncIterableIterator<Uint8Array>} [body] - An async iterator of Uint8Arrays that make up the body of the response
+ * @property {number} statusCode - The HTTP status code
+ * @property {string} statusMessage - The HTTP status message
+ */
+
+/**
+ * HttpClient
+ *
+ * @param {GitHttpRequest} request
+ * @returns {Promise<GitHttpResponse>}
+ */
 export default async function http({
   onProgress,
   url,

--- a/src/managers/GitRemoteHTTP.js
+++ b/src/managers/GitRemoteHTTP.js
@@ -83,7 +83,7 @@ export class GitRemoteHTTP {
     // apparently doesn't realize this is a git request and is returning the HTML for the "Azure DevOps Services | Sign In" page.
     if ((res.statusCode === 401 || res.statusCode === 203) && onAuth) {
       // Acquire credentials and try again
-      // TODO: read `useHttpPath` value from git config and pass as 2nd argument
+      // TODO: read `useHttpPath` value from git config and pass as 2nd argument?
       auth = await onAuth(_origUrl)
       const _auth = calculateBasicAuthUsernamePasswordPair(auth)
       if (_auth) {
@@ -97,9 +97,9 @@ export class GitRemoteHTTP {
       })
       // Tell credential manager if the credentials were no good
       if (res.statusCode === 401 && onAuthFailure) {
-        await onAuthFailure({ url: _origUrl, auth })
+        await onAuthFailure(_origUrl, auth)
       } else if (res.statusCode === 200 && onAuthSuccess) {
-        await onAuthSuccess({ url: _origUrl, auth })
+        await onAuthSuccess(_origUrl, auth)
       }
     }
     if (res.statusCode !== 200) {

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -156,38 +156,22 @@
  */
 
 /**
- * @typedef {Object} FillParams
- * @property {string} url
- * @property {boolean} useHttpPath
- */
-
-/**
  * @callback AuthCallback
- * @param {FillParams} args
+ * @param {string} url
  * @returns {GitAuth | Promise<GitAuth>}
  */
 
 /**
- * @typedef {Object} ApprovedParams
- * @property {string} url
- * @property {IAuthJSON} auth
- */
-
-/**
  * @callback AuthSuccessCallback
- * @param {ApprovedParams} args
+ * @param {string} url
+ * @param {GitAuth} auth
  * @returns {void | Promise<void>}
  */
 
 /**
- * @typedef {Object} RejectededParams
- * @property {string} url
- * @property {IAuthJSON} auth
- */
-
-/**
  * @callback AuthFailureCallback
- * @param {RejectededParams} args
+ * @param {string} url
+ * @param {GitAuth} auth
  * @returns {void | Promise<void>}
  */
 

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -51,7 +51,6 @@
  */
 
 /**
- *
  * @typedef {Object} ReadCommitResult
  * @property {string} oid - SHA-1 object id of this commit
  * @property {CommitObject} commit - the parsed commit object
@@ -59,14 +58,14 @@
  */
 
 /**
- *
  * @typedef Walker
  * @property {Symbol} Symbol('GitWalkerSymbol')
  */
 
 /**
+ * Normalized subset of filesystem `stat` data:
  *
- * @typedef {Object} Stat Normalized subset of filesystem `stat` data:
+ * @typedef {Object} Stat
  * @property {number} ctimeSeconds
  * @property {number} ctimeNanoseconds
  * @property {number} mtimeSeconds
@@ -80,8 +79,9 @@
  */
 
 /**
+ * The `WalkerEntry` is an interface that abstracts computing many common tree / blob stats.
  *
- * @typedef {Object} WalkerEntry The `WalkerEntry` is an interface that abstracts computing many common tree / blob stats.
+ * @typedef {Object} WalkerEntry
  * @property {function(): Promise<'tree'|'blob'|'special'|'commit'>} type
  * @property {function(): Promise<number>} mode
  * @property {function(): Promise<string>} oid
@@ -90,7 +90,6 @@
  */
 
 /**
- *
  * @typedef {Object} GitAuth
  * @property {string} [username]
  * @property {string} [password]
@@ -99,7 +98,6 @@
  */
 
 /**
- *
  * @typedef {Object} GitProgressEvent
  * @property {string} phase
  * @property {number} loaded
@@ -107,8 +105,7 @@
  */
 
 /**
- *
- * @typedef {Object} GitFsPlugin
+ * @typedef {Object} CallbackFsClient
  * @property {function} readFile - https://nodejs.org/api/fs.html#fs_fs_readfile_path_options_callback
  * @property {function} writeFile - https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback
  * @property {function} unlink - https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback
@@ -123,8 +120,7 @@
  */
 
 /**
- *
- * @typedef {Object} GitFsPromisesPlugin
+ * @typedef {Object} PromiseFsClient
  * @property {Object} promises
  * @property {function} promises.readFile - https://nodejs.org/api/fs.html#fs_fspromises_readfile_path_options
  * @property {function} promises.writeFile - https://nodejs.org/api/fs.html#fs_fspromises_writefile_file_data_options
@@ -140,7 +136,7 @@
  */
 
 /**
- * @typedef {GitFsPlugin|GitFsPromisesPlugin} FsClient
+ * @typedef {CallbackFsClient | PromiseFsClient} FsClient
  */
 
 /**
@@ -182,14 +178,12 @@
  */
 
 /**
- *
  * @callback SignCallback
  * @param {SignParams} args
  * @return {{signature: string} | Promise<{signature: string}>} - an 'ASCII armor' encoded "detached" signature
  */
 
 /**
- *
  * @typedef {Object} GitHttpRequest
  * @property {string} url - The URL to request
  * @property {string} [method='GET'] - The HTTP method to use
@@ -201,7 +195,6 @@
  */
 
 /**
- *
  * @typedef {Object} GitHttpResponse
  * @property {string} url - The final URL that was fetched after any redirects
  * @property {string} [method] - The HTTP method that was used
@@ -212,7 +205,6 @@
  */
 
 /**
- *
  * @callback HttpClient
  * @param {GitHttpRequest} request
  * @returns {Promise<GitHttpResponse>}
@@ -246,29 +238,27 @@
  */
 
 /**
- *
  * @typedef {Object} RefUpdateStatus
  * @property {boolean} ok
  * @property {string} error
- *
  */
 
 /**
- *
  * @typedef {Object} PushResult
  * @property {boolean} ok
  * @property {?string} error
  * @property {Object<string, RefUpdateStatus>} refs
  * @property {Object<string, string>} [headers]
- *
  */
 
 /**
  * @typedef {0|1} HeadStatus
  */
+
 /**
  * @typedef {0|1|2} WorkdirStatus
  */
+
 /**
  * @typedef {0|1|2|3} StageStatus
  */


### PR DESCRIPTION
The typings for `onAuth` were not what I thought they were 🤦‍♂ . I should consider typechecking all the `.md` files, even the ones that aren't auto-generated. That wouldn't have caught this though, since the page for `onAuth` doesn't actually use `git.clone({ onAuth })` anywhere. :/

And, while I was at it, I went ahead and changed the typings for `onAuthSuccess` and `onAuthFailure` to match (plain arguments instead of an argument object).

Aaaand I generate a `dist/http.d.ts` :eyeroll: oh typescript.