### PR TITLE
chore: fix the website to use the new import paths

### DIFF
--- a/__tests__/__helpers__/copy-to-website.js
+++ b/__tests__/__helpers__/copy-to-website.js
@@ -1,0 +1,17 @@
+const join = require('path').join
+
+const decompress = require('decompress')
+const rmrf = require('rimraf')
+
+const dest = 'website/static/js/isomorphic-git'
+
+rmrf(join(__dirname, '..', '..', dest), async () => {
+  await decompress(
+    join(__dirname, '..', '..', 'isomorphic-git-0.0.0-development.tgz'),
+    join(__dirname, '..', '..', dest),
+    {
+      strip: 1,
+    }
+  )
+  console.log(`extracted tarball to ${dest}`)
+})

--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -8,7 +8,7 @@ const git = require('../..')
 const { E } = require('../..')
 
 const dir = path.join(__dirname, '..', '..')
-const thisFile = path.relative(dir, __filename)
+const thisFile = path.relative(dir, __filename).replace(/\\/g, '/')
 const ref = process.argv[2] || 'HEAD'
 
 function cleanType(type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3930,6 +3930,42 @@
         }
       }
     },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -5997,12 +6033,161 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "dev": true,
+      "requires": {
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "dev": true
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "dev": true,
+      "requires": {
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
+      },
+      "dependencies": {
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+          "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
+          }
+        }
       }
     },
     "deep-eql": {
@@ -9490,6 +9675,12 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -10402,6 +10593,12 @@
         "jsonpointer": "^4.0.0",
         "xtend": "^4.0.0"
       }
+    },
+    "is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -20005,6 +20202,26 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "dev": true,
+      "requires": {
+        "commander": "~2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
+      }
+    },
     "select-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/select-case/-/select-case-1.0.0.tgz",
@@ -22047,6 +22264,15 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "dev": true,
+      "requires": {
+        "is-natural-number": "^4.0.1"
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -22194,6 +22420,47 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "temp-dir": {
       "version": "1.0.0",
@@ -22713,6 +22980,12 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -22974,6 +23247,16 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
+    },
+    "unbzip2-stream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
     },
     "underscore": {
       "version": "1.4.4",

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -88,7 +88,7 @@ module.exports = {
       codemirrorify:
         '(cd website/packages/codemirrorify && npm install && npm run build)',
       cpstatic:
-        'cp index.umd.min.* website/static/js && cp http/web.cjs website/static/js && cp website/packages/codemirrorify/dist/main.js website/static/js/codemirrorify.js',
+        'cp website/packages/codemirrorify/dist/main.js website/static/js/codemirrorify.js && node __tests__/__helpers__/copy-to-website.js',
       build: '(cd website && npm install && npm run build)',
       dev: '(cd website && npm start)',
       publish: '(cd website && node ./scripts/deploy-gh-pages.js)',

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "browserfs": "2.0.0",
     "bundlewatch": "0.2.5",
     "cross-env": "6.0.0",
+    "decompress": "^4.2.0",
     "diff-lines": "1.1.1",
     "duplicate-package-checker-webpack-plugin": "3.0.0",
     "envify": "4.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = [
         analyzerMode: 'static',
         reportFilename: 'size_report.html',
         defaultSizes: 'gzip',
-        excludeAssets: 'internal\\.umd\\.min\\.js',
+        excludeAssets: 'internal-apis\\.umd\\.min\\.js',
       }),
       new DuplicatePackageCheckerPlugin({
         strict: true,

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -62,7 +62,7 @@ class Footer extends React.Component {
 
         {/* Correct sidebar nav scroll position */}
         <script type="text/javascript" dangerouslySetInnerHTML={{
-          __html: `document.querySelector('.navListItemActive').scrollIntoView({ block: 'nearest' })`
+          __html: `let el = document.querySelector('.navListItemActive'); if (el) el.scrollIntoView({ block: 'nearest' })`
         }}></script>
         {/* External scripts */}
         {this.props.config.footerscripts &&

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -13,6 +13,7 @@ const GoSettings = require("react-icons/lib/go/settings");
 const GoFileBinary = require("react-icons/lib/go/file-binary");
 const GoDiffModified = require("react-icons/lib/go/diff-modified");
 const GoGitBranch = require("react-icons/lib/go/git-branch");
+const GoGitMerge = require("react-icons/lib/go/git-merge");
 const GoGitCommit = require("react-icons/lib/go/git-commit");
 const GoRepo = require("react-icons/lib/go/repo");
 const GoRepoClone = require("react-icons/lib/go/repo-clone");
@@ -94,7 +95,7 @@ class HomeSplash extends React.Component {
             <Button href={docUrl("browser.html", language)}>
               Getting Started
             </Button>
-            <Button href={docUrl("init.html", language)}>
+            <Button href={docUrl("alphabetic.html", language)}>
               Interactive Docs
             </Button>
             <Button href="https://github.com/isomorphic-git/isomorphic-git/releases">
@@ -192,7 +193,7 @@ const Features = props => (
   </Container>
 );
 
-const FeatureCallout = props => (
+const FeatureCallout = ({ language }) => (
   <div
     className="productShowcaseSection paddingBottom"
     style={{ textAlign: "center" }}
@@ -200,77 +201,106 @@ const FeatureCallout = props => (
     <h2>Features</h2>
     <ul className="isomorphic-git-feature-list">
       <li>
-        <GoRepoClone size="3em" /> clone repos
+        <a href={docUrl("clone.html", language)} >
+          <GoRepoClone size="3.5em" style={{paddingRight: '10px'}} />clone repos
+        </a>
       </li>
       <li>
-        <GoRepo size="3em" /> init new repos
+        <a href={docUrl("init.html", language)} >
+          <GoRepo size="3.5em" style={{paddingRight: '10px'}} />init new repos
+        </a>
       </li>
       <li>
-        <GoGitBranch size="3em" /> list branches and tags
+        <a href={docUrl("listBranches.html", language)} >
+          <GoGitBranch size="3.5em" style={{paddingRight: '10px'}} />list branches and tags
+        </a>
       </li>
       <li>
-        <GoHistory size="3em" /> list commit history
+        <a href={docUrl("log.html", language)} >
+          <GoHistory size="3.5em" style={{paddingRight: '10px'}} />list commit history
+        </a>
       </li>
       <li>
-        <GoRepoPull size="3em" />
-        checkout branches
+        <a href={docUrl("checkout.html", language)} >
+          <GoRepoPull size="3.5em" style={{paddingRight: '10px'}} />checkout branches
+        </a>
       </li>
       <li>
-        <GoRepoPush size="3em" /> push branches to remotes
-        <a title="via a proxy server">*</a>
+        <a href={docUrl("push.html", language)} >
+          <GoRepoPush size="3.5em" style={{paddingRight: '10px'}} />push branches to remotes
+        </a>
       </li>
       <li>
-        <GoGitCommit size="3em" /> create new commits
+        <a href={docUrl("commit.html", language)} >
+          <GoGitCommit size="3.5em" style={{paddingRight: '10px'}} />create new commits
+        </a>
       </li>
       <li>
-        <GoSettings size="3em" /> read & write to .git/config
+        <a href={docUrl("getConfig.html", language)} >
+          <GoSettings size="3.5em" style={{paddingRight: '10px'}} />git config
+        </a>
       </li>
       <li>
-        <GoFileBinary size="3em" /> read & write raw git objects
+        <a href={docUrl("readCommit.html", language)} >
+          <GoFileBinary size="3.5em" style={{paddingRight: '10px'}} />read & write raw git objects
+        </a>
       </li>
       <li>
-        <GoLock size="3em" /> sign commits
+        <a href={docUrl("onSign.html", language)} >
+          <GoKey size="3.5em" style={{paddingRight: '10px'}} />PGP signing
+        </a>
       </li>
       <li>
-        <GoKey size="3em" /> verify signed commits
+        <a href={docUrl("statusMatrix.html", language)} >
+          <GoDiffModified size="3.5em" style={{paddingRight: '10px'}} />file status
+        </a>
       </li>
       <li>
-        <GoDiffModified size="3em" /> working file status
+        <a href={docUrl("merge.html", language)} >
+          <GoGitMerge size="3.5em" style={{paddingRight: '10px'}} />merge branches
+        </a>
       </li>
     </ul>
   </div>
 );
 
 const TryGitRemoteInfo = props => (
-  <div className="try-it-out">
-    <h2>Try it out</h2>
-    <label htmlFor="giturl">Enter a git URL:</label>
-    <div>
-      <input
-        id="giturl_input"
-        name="giturl"
-        type="text"
-        className="input"
-        defaultValue="https://github.com/facebook/react"
-        size="50"
-        style={{ maxWidth: "80%" }}
-      />
-      <button
-        id="giturl_button"
-        type="button"
-        className="button"
-        value="Fetch Info"
-      >
-        Fetch Info
-      </button>
+  <Container padding={["bottom", "top"]} id={props.id} background="light">
+    <div className="try-it-out">
+      <h2>Try it out!</h2>
+      <label htmlFor="giturl">Enter in the URL of a git repository, and we'll retrive the list of branches and tags using the git HTTP protocol.</label>
       <div>
-        <b>Branches:</b> <span id="giturl_branches"></span>
-      </div>
-      <div>
-        <b>Tags:</b> <span id="giturl_tags"></span>
+        <input
+          id="giturl_input"
+          name="giturl"
+          type="text"
+          className="input"
+          defaultValue="https://github.com/facebook/react"
+          size="50"
+          style={{ maxWidth: "80%" }}
+        />
+        <button
+          id="giturl_button"
+          type="button"
+          className="button"
+          value="Fetch Info"
+        >
+          Fetch Info
+        </button>
+        <div id="try-it-output">
+          <div>
+            <b>Branches:</b> <span id="giturl_branches"></span>
+          </div>
+          <div>
+            <b>Tags:</b> <span id="giturl_tags"></span>
+          </div>
+          <p className="more">
+            <em>Cool, huh?</em> There are a whole bunch more live examples in the <a href={docUrl("alphabetic.html", props.language)}>docs</a>!
+          </p>
+        </div>
       </div>
     </div>
-  </div>
+  </Container>
 );
 
 const LearnHow = props => (
@@ -289,9 +319,6 @@ const LearnHow = props => (
   The API has been designed with modern tools like Rollup and Webpack in mind.
   By providing functionality as individual functions, code bundlers can produce smaller bundles by including only the functions your application uses.
       `}</MarkdownBlock>
-      </div>
-      <div className="blockElement fourByGridBlock">
-        <TryGitRemoteInfo />
       </div>
     </div>
   </Container>
@@ -352,11 +379,29 @@ class Index extends React.Component {
         <HomeSplash language={language} />
         <div className="mainContainer">
           <Features />
-          <FeatureCallout />
+          <FeatureCallout language={language} />
           <LearnHow />
+          <TryGitRemoteInfo language={language} />
           <Praise />
           <Showcase language={language} />
         </div>
+        {this.props.config.homepagescripts &&
+          this.props.config.homepagescripts.map(function (source, idx) {
+            if (typeof source === 'string') {
+              return (
+                <script
+                  defer
+                  type="text/javascript"
+                  key={'script' + idx}
+                  src={source}
+                />
+              );
+            } else {
+              return (
+                <script defer key={'script' + idx} {...source} />
+              );
+            }
+          })}
       </div>
     );
   }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -56,20 +56,26 @@ const siteConfig = {
   scripts: [
     '/js/announcement.js',
   ],
-  footerscripts: [
+  homepagescripts: [
     'https://platform.twitter.com/widgets.js',
+  ],
+  footerscripts: [
     '/js/gitter.js',
     '/js/sidecar.v1.js',
+    // Used to transform the code blocks into editable examples
+    '/js/codemirrorify.js',
+    // isomorphic-git itself
     'https://unpkg.com/@isomorphic-git/lightning-fs',
-    '/js/bundle.umd.min.js',
-    'https://unpkg.com/openpgp@2.6.2/dist/openpgp.min.js',
+    '/js/isomorphic-git/index.umd.min.js',
+    // the tutorial
+    { type: 'module', src: '/js/tutorial.js' },
+    // the button on the home page
+    { type: 'module', src: '/js/try-it-out-giturl.js' },
+    // The object inspector - only appears after users run examples
     'https://unpkg.com/@webcomponents/shadydom',
     '/js/object-inspector.min.js',
-    '/js/codemirrorify.js',
-    { type: 'module', src: '/js/tutorial.js' },
-    { type: 'module', src: '/js/try-it-out-giturl.js' },
-    '//static.getclicky.com/js',
-    '/js/analytics.js',
+    // minimal analytics
+    { 'data-domain': 'isomorphic-git.org', src: 'https://plausible.io/js/plausible.js' }
   ],
   // stylesheets: ['./css/tutorial.css'],
   // You may provide arbitrary config keys to be used as needed by your template.

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -61,6 +61,10 @@ footer img[src="/img/isomorphic-git-logo.svg"] {
   margin-left: auto;
   margin-right: auto;
 }
+.isomorphic-git-feature-list li a {
+  color: black;
+  text-decoration: underline;
+}
 
 .isomorphic-git-browser-list {
   display: block;
@@ -111,9 +115,20 @@ footer img[src="/img/isomorphic-git-logo.svg"] {
 
 .try-it-out {
   line-height: 2em;
+  text-align: center;
 }
 .try-it-out h2 {
   margin-top: 0;
+}
+#try-it-output {
+  text-align: left;
+  display: none;
+}
+#try-it-output .more {
+  text-align: center;
+}
+#try-it-output.show {
+  display: block;
 }
 
 #giturl_branches,

--- a/website/static/js/.gitignore
+++ b/website/static/js/.gitignore
@@ -1,4 +1,2 @@
-bundle.umd.min.js
-bundle.umd.min.js.map
-codemirrorify.js
-http.js
+/isomorphic-git
+/codemirrorify.js

--- a/website/static/js/try-it-out-giturl.js
+++ b/website/static/js/try-it-out-giturl.js
@@ -1,7 +1,8 @@
-import http from './http.js'
+import http from './isomorphic-git/http/web/index.js'
 
 document.addEventListener('DOMContentLoaded', function listener () {
   document.removeEventListener('DOMContentLoaded', listener)
+  let $output = document.getElementById('try-it-output')
   let $input = document.getElementById('giturl_input')
   let $button = document.getElementById('giturl_button')
   const change = async function change (event) {
@@ -13,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function listener () {
       url: value,
       corsProxy: 'https://cors.isomorphic-git.org'
     })
-    const limit = 100;
+    const limit = 1000;
     if (info.refs.tags) {
       let $tags = document.getElementById('giturl_tags')
       let tagstext = Object.keys(info.refs.tags).join(', ')
@@ -24,6 +25,7 @@ document.addEventListener('DOMContentLoaded', function listener () {
       let branchestext = Object.keys(info.refs.heads).join(', ')
       $branches.innerText = branchestext.slice(0, limit)
     }
+    $output.classList.add('show')
   }
   if ($input && $button) {
     $input.addEventListener('change', change)

--- a/website/static/js/tutorial.js
+++ b/website/static/js/tutorial.js
@@ -1,4 +1,4 @@
-import http from './http.js'
+import http from './isomorphic-git/http/web/index.js'
 
 // Initialize isomorphic-git with a file system
 window.fs = new LightningFS('fs')


### PR DESCRIPTION
- just dump entire package tarball into the `website/js/isomorphic-git` folder.
- tweaks to homepage
  - make Features link to docs
  - don't throw error in console about the scrollIntoView thing
  - make Try It Out thing a little nicer looking
- tweaks to other pages
  - don't load the twitter JavaScript on regular docs pages because Firefox proudly announces it blocked a social tracker on the page!!! Sheesh. I just wanted to embed a tweet, not destroy users privacy 🤕.
- ditch clicky.com analytics since I wasn't using it anyway. And Firefox blocks it.
- try a new analytics called Plausible.io which sounds privacy-conscious and collects way less data. I really just want to know a couple things:
  - referers (how did people hear about isomorphic-git? aka Hacker News, blog posts)
  - what pages are they looking at? which gives me some vague idea of what functions people are interested in
  - what language do they speak? So I can prioritize language translation if I ever get around to it
and honestly I may cancel after it's 30 day trial but I figure some analytics on the page for the 1.0 launch is smart. After the 1.0 launch it may not matter as much.