### PR TITLE
fix: throw a helpful error if `http` argument is missing

### DIFF
--- a/src/api/clone.js
+++ b/src/api/clone.js
@@ -72,6 +72,7 @@ export async function clone({
 }) {
   try {
     assertParameter('fs', fs)
+    assertParameter('http', http)
     assertParameter('gitdir', gitdir)
     if (!noCheckout) {
       assertParameter('dir', dir)

--- a/src/api/fastForward.js
+++ b/src/api/fastForward.js
@@ -60,6 +60,7 @@ export async function fastForward({
 }) {
   try {
     assertParameter('fs', fs)
+    assertParameter('http', http)
     assertParameter('gitdir', gitdir)
 
     const thisWillNotBeUsed = {

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -90,6 +90,7 @@ export async function fetch({
 }) {
   try {
     assertParameter('fs', fs)
+    assertParameter('http', http)
     assertParameter('gitdir', gitdir)
 
     return await _fetch({

--- a/src/api/getRemoteInfo.js
+++ b/src/api/getRemoteInfo.js
@@ -54,6 +54,7 @@ export async function getRemoteInfo({
   forPush = false,
 }) {
   try {
+    assertParameter('http', http)
     assertParameter('url', url)
 
     const remote = await GitRemoteHTTP.discover({

--- a/src/api/push.js
+++ b/src/api/push.js
@@ -73,6 +73,7 @@ export async function push({
 }) {
   try {
     assertParameter('fs', fs)
+    assertParameter('http', http)
     assertParameter('gitdir', gitdir)
 
     return await _push({


### PR DESCRIPTION
## I'm fixing a bug or typo

fixes #1088
