### PR TITLE
fix: cache per command rather than per 'fs' instance

### DIFF
--- a/src/api/add.js
+++ b/src/api/add.js
@@ -39,7 +39,8 @@ export async function add({
     assertParameter('filepath', filepath)
 
     const fs = new FileSystem(_fs)
-    await GitIndexManager.acquire({ fs, gitdir }, async function(index) {
+    const cache = {}
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index) {
       await addToIndex({ dir, gitdir, fs, filepath, index })
     })
   } catch (err) {

--- a/src/api/addNote.js
+++ b/src/api/addNote.js
@@ -58,6 +58,7 @@ export async function addNote({
       assertParameter('onSign', onSign)
     }
     const fs = new FileSystem(_fs)
+    const cache = {}
 
     const author = await normalizeAuthorObject({ fs, gitdir, author: _author })
     if (!author) throw new MissingNameError('author')
@@ -72,6 +73,7 @@ export async function addNote({
 
     return await _addNote({
       fs: new FileSystem(fs),
+      cache,
       onSign,
       gitdir,
       ref,

--- a/src/api/checkout.js
+++ b/src/api/checkout.js
@@ -78,6 +78,7 @@ export async function checkout({
     const ref = _ref || 'HEAD'
     return await _checkout({
       fs: new FileSystem(fs),
+      cache: {},
       onProgress,
       dir,
       gitdir,

--- a/src/api/clone.js
+++ b/src/api/clone.js
@@ -81,6 +81,7 @@ export async function clone({
 
     return await _clone({
       fs: new FileSystem(fs),
+      cache: {},
       http,
       onProgress,
       onMessage,

--- a/src/api/commit.js
+++ b/src/api/commit.js
@@ -72,6 +72,7 @@ export async function commit({
       assertParameter('onSign', onSign)
     }
     const fs = new FileSystem(_fs)
+    const cache = {}
 
     const author = await normalizeAuthorObject({ fs, gitdir, author: _author })
     if (!author) throw new MissingNameError('author')
@@ -86,6 +87,7 @@ export async function commit({
 
     return await _commit({
       fs,
+      cache,
       onSign,
       gitdir,
       message,

--- a/src/api/fastForward.js
+++ b/src/api/fastForward.js
@@ -72,6 +72,7 @@ export async function fastForward({
 
     return await _pull({
       fs: new FileSystem(fs),
+      cache: {},
       http,
       onProgress,
       onMessage,

--- a/src/api/listFiles.js
+++ b/src/api/listFiles.js
@@ -36,6 +36,7 @@ export async function listFiles({ fs, dir, gitdir = join(dir, '.git'), ref }) {
 
     return await _listFiles({
       fs: new FileSystem(fs),
+      cache: {},
       gitdir,
       ref,
     })

--- a/src/api/merge.js
+++ b/src/api/merge.js
@@ -89,6 +89,7 @@ export async function merge({
       assertParameter('onSign', onSign)
     }
     const fs = new FileSystem(_fs)
+    const cache = {}
 
     const author = await normalizeAuthorObject({ fs, gitdir, author: _author })
     if (!author && !fastForwardOnly) throw new MissingNameError('author')
@@ -105,6 +106,7 @@ export async function merge({
 
     return await _merge({
       fs,
+      cache,
       gitdir,
       ours,
       theirs,

--- a/src/api/pull.js
+++ b/src/api/pull.js
@@ -96,6 +96,7 @@ export async function pull({
 
     return await _pull({
       fs,
+      cache: {},
       http,
       onProgress,
       onMessage,

--- a/src/api/remove.js
+++ b/src/api/remove.js
@@ -35,8 +35,9 @@ export async function remove({
     assertParameter('gitdir', gitdir)
     assertParameter('filepath', filepath)
 
+    const cache = {}
     await GitIndexManager.acquire(
-      { fs: new FileSystem(_fs), gitdir },
+      { fs: new FileSystem(_fs), gitdir, cache },
       async function(index) {
         index.delete({ filepath })
       }

--- a/src/api/removeNote.js
+++ b/src/api/removeNote.js
@@ -51,6 +51,7 @@ export async function removeNote({
     assertParameter('oid', oid)
 
     const fs = new FileSystem(_fs)
+    const cache = {}
 
     const author = await normalizeAuthorObject({ fs, gitdir, author: _author })
     if (!author) throw new MissingNameError('author')
@@ -65,6 +66,7 @@ export async function removeNote({
 
     return await _removeNote({
       fs,
+      cache,
       onSign,
       gitdir,
       ref,

--- a/src/api/resetIndex.js
+++ b/src/api/resetIndex.js
@@ -40,6 +40,7 @@ export async function resetIndex({
     assertParameter('ref', ref)
 
     const fs = new FileSystem(_fs)
+    const cache = {}
     // Resolve commit
     let oid = await GitRefManager.resolve({ fs, gitdir, ref })
     let workdirOid
@@ -80,7 +81,7 @@ export async function resetIndex({
         stats = await fs.lstat(join(dir, filepath))
       }
     }
-    await GitIndexManager.acquire({ fs, gitdir }, async function(index) {
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index) {
       index.delete({ filepath })
       if (oid) {
         index.insert({ filepath, stats, oid })

--- a/src/api/status.js
+++ b/src/api/status.js
@@ -59,6 +59,7 @@ export async function status({
     assertParameter('filepath', filepath)
 
     const fs = new FileSystem(_fs)
+    const cache = {}
     const ignored = await GitIgnoreManager.isIgnored({
       fs,
       gitdir,
@@ -76,7 +77,7 @@ export async function status({
       path: filepath,
     })
     const indexEntry = await GitIndexManager.acquire(
-      { fs, gitdir },
+      { fs, gitdir, cache },
       async function(index) {
         for (const entry of index) {
           if (entry.path === filepath) return entry
@@ -107,7 +108,9 @@ export async function status({
           // (like the Karma webserver) because BrowserFS HTTP Backend uses HTTP HEAD requests to do fs.stat
           if (stats.size !== -1) {
             // We don't await this so we can return faster for one-off cases.
-            GitIndexManager.acquire({ fs, gitdir }, async function(index) {
+            GitIndexManager.acquire({ fs, gitdir, cache }, async function(
+              index
+            ) {
               index.insert({ filepath, stats, oid: workdirOid })
             })
           }

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -164,8 +164,10 @@ export async function statusMatrix({
     assertParameter('ref', ref)
 
     const fs = new FileSystem(_fs)
+    const cache = {}
     return await _walk({
       fs,
+      cache,
       dir,
       gitdir,
       trees: [TREE({ ref }), WORKDIR(), STAGE()],

--- a/src/api/walk.js
+++ b/src/api/walk.js
@@ -264,6 +264,7 @@ export async function walk({
 
     return await _walk({
       fs: new FileSystem(fs),
+      cache: {},
       dir,
       gitdir,
       trees,

--- a/src/commands/STAGE.js
+++ b/src/commands/STAGE.js
@@ -10,8 +10,8 @@ import { GitWalkSymbol } from '../utils/symbols.js'
 export function STAGE() {
   const o = Object.create(null)
   Object.defineProperty(o, GitWalkSymbol, {
-    value: function({ fs, gitdir }) {
-      return new GitWalkerIndex({ fs, gitdir })
+    value: function({ fs, gitdir, cache }) {
+      return new GitWalkerIndex({ fs, gitdir, cache })
     },
   })
   Object.freeze(o)

--- a/src/commands/WORKDIR.js
+++ b/src/commands/WORKDIR.js
@@ -10,8 +10,8 @@ import { GitWalkSymbol } from '../utils/symbols.js'
 export function WORKDIR() {
   const o = Object.create(null)
   Object.defineProperty(o, GitWalkSymbol, {
-    value: function({ fs, dir, gitdir }) {
-      return new GitWalkerFs({ fs, dir, gitdir })
+    value: function({ fs, dir, gitdir, cache }) {
+      return new GitWalkerFs({ fs, dir, gitdir, cache })
     },
   })
   Object.freeze(o)

--- a/src/commands/addNote.js
+++ b/src/commands/addNote.js
@@ -12,6 +12,7 @@ import { _writeObject as writeObject } from '../storage/writeObject.js'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {SignCallback} [args.onSign]
  * @param {string} args.gitdir
  * @param {string} args.ref
@@ -35,6 +36,7 @@ import { _writeObject as writeObject } from '../storage/writeObject.js'
 
 export async function _addNote({
   fs,
+  cache,
   onSign,
   gitdir,
   ref,
@@ -97,6 +99,7 @@ export async function _addNote({
   // Create the new note commit
   const commitOid = await _commit({
     fs,
+    cache,
     onSign,
     gitdir,
     ref,

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -10,6 +10,7 @@ import { GitConfigManager } from '../managers/GitConfigManager.js'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {HttpClient} args.http
  * @param {ProgressCallback} [args.onProgress]
  * @param {MessageCallback} [args.onMessage]
@@ -36,6 +37,7 @@ import { GitConfigManager } from '../managers/GitConfigManager.js'
  */
 export async function _clone({
   fs,
+  cache,
   http,
   onProgress,
   onMessage,
@@ -89,6 +91,7 @@ export async function _clone({
   // Checkout that branch
   await _checkout({
     fs,
+    cache,
     onProgress,
     dir,
     gitdir,

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -12,6 +12,7 @@ import { flatFileListToDirectoryStructure } from '../utils/flatFileListToDirecto
  *
  * @param {Object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {SignCallback} [args.onSign]
  * @param {string} args.gitdir
  * @param {string} args.message
@@ -36,6 +37,7 @@ import { flatFileListToDirectoryStructure } from '../utils/flatFileListToDirecto
  */
 export async function _commit({
   fs,
+  cache,
   onSign,
   gitdir,
   message,
@@ -57,7 +59,7 @@ export async function _commit({
     })
   }
 
-  return GitIndexManager.acquire({ fs, gitdir }, async function(index) {
+  return GitIndexManager.acquire({ fs, gitdir, cache }, async function(index) {
     const inodes = flatFileListToDirectoryStructure(index.entries)
     const inode = inodes.get('.')
     if (!tree) {

--- a/src/commands/listFiles.js
+++ b/src/commands/listFiles.js
@@ -7,19 +7,22 @@ import { join } from '../utils/join'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {string} args.gitdir
  * @param {string} [args.ref]
  *
  * @returns {Promise<Array<string>>}
  */
-export async function _listFiles({ fs, gitdir, ref }) {
+export async function _listFiles({ fs, gitdir, ref, cache }) {
   if (ref) {
     const oid = await GitRefManager.resolve({ gitdir, fs, ref })
     const filenames = []
     await accumulateFilesFromOid({ fs, gitdir, oid, filenames, prefix: '' })
     return filenames
   } else {
-    return GitIndexManager.acquire({ fs, gitdir }, async function(index) {
+    return GitIndexManager.acquire({ fs, gitdir, cache }, async function(
+      index
+    ) {
       return index.entries.map(x => x.path)
     })
   }

--- a/src/commands/merge.js
+++ b/src/commands/merge.js
@@ -25,6 +25,7 @@ import { mergeTree } from '../utils/mergeTree.js'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {string} args.gitdir
  * @param {string} [args.ours]
  * @param {string} args.theirs
@@ -54,6 +55,7 @@ import { mergeTree } from '../utils/mergeTree.js'
  */
 export async function _merge({
   fs,
+  cache,
   gitdir,
   ours,
   theirs,
@@ -137,6 +139,7 @@ export async function _merge({
     }
     const oid = await _commit({
       fs,
+      cache,
       gitdir,
       message,
       ref: ours,

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -9,6 +9,7 @@ import { MissingParameterError } from '../errors/MissingParameterError.js'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {HttpClient} args.http
  * @param {ProgressCallback} [args.onProgress]
  * @param {MessageCallback} [args.onMessage]
@@ -42,6 +43,7 @@ import { MissingParameterError } from '../errors/MissingParameterError.js'
  */
 export async function _pull({
   fs,
+  cache,
   http,
   onProgress,
   onMessage,
@@ -106,6 +108,7 @@ export async function _pull({
     })
     await _checkout({
       fs,
+      cache,
       onProgress,
       dir,
       gitdir,

--- a/src/commands/removeNote.js
+++ b/src/commands/removeNote.js
@@ -8,6 +8,7 @@ import { GitRefManager } from '../managers/GitRefManager.js'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {SignCallback} [args.onSign]
  * @param {string} [args.dir]
  * @param {string} [args.gitdir=join(dir,'.git')]
@@ -30,6 +31,7 @@ import { GitRefManager } from '../managers/GitRefManager.js'
 
 export async function _removeNote({
   fs,
+  cache,
   onSign,
   gitdir,
   ref = 'refs/notes/commits',
@@ -69,6 +71,7 @@ export async function _removeNote({
   // Create the new note commit
   const commitOid = await _commit({
     fs,
+    cache,
     onSign,
     gitdir,
     ref,

--- a/src/commands/walk.js
+++ b/src/commands/walk.js
@@ -9,6 +9,7 @@ import { unionOfIterators } from '../utils/unionOfIterators.js'
 /**
  * @param {object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
  * @param {string} [args.dir]
  * @param {string} [args.gitdir=join(dir,'.git')]
  * @param {Walker[]} args.trees
@@ -23,6 +24,7 @@ import { unionOfIterators } from '../utils/unionOfIterators.js'
  */
 export async function _walk({
   fs,
+  cache,
   dir,
   gitdir,
   trees,
@@ -37,7 +39,9 @@ export async function _walk({
   // The default iterate function walks all children concurrently
   iterate = (walk, children) => Promise.all([...children].map(walk)),
 }) {
-  const walkers = trees.map(proxy => proxy[GitWalkSymbol]({ fs, dir, gitdir }))
+  const walkers = trees.map(proxy =>
+    proxy[GitWalkSymbol]({ fs, dir, gitdir, cache })
+  )
 
   const root = new Array(walkers.length).fill('.')
   const range = arrayRange(0, walkers.length)

--- a/src/managers/GitIndexManager.js
+++ b/src/managers/GitIndexManager.js
@@ -2,32 +2,33 @@
 import AsyncLock from 'async-lock'
 
 import { GitIndex } from '../models/GitIndex.js'
-import { DeepMap } from '../utils/DeepMap.js'
 import { compareStats } from '../utils/compareStats.js'
 
 // import Lock from '../utils.js'
 
-// TODO: replace with an LRU cache?
-const map = new DeepMap()
-const stats = new DeepMap()
 // const lm = new LockManager()
 let lock = null
 
-async function updateCachedIndexFile(fs, filepath) {
+function createCache() {
+  return {
+    map: new Map(),
+    stats: new Map(),
+  }
+}
+
+async function updateCachedIndexFile(fs, filepath, cache) {
   const stat = await fs.lstat(filepath)
   const rawIndexFile = await fs.read(filepath)
   const index = await GitIndex.from(rawIndexFile)
-  // cache the GitIndex object so we don't need to re-read it
-  // every time.
-  map.set([fs, filepath], index)
-  // Save the stat data for the index so we know whether
-  // the cached file is stale (modified by an outside process).
-  stats.set([fs, filepath], stat)
+  // cache the GitIndex object so we don't need to re-read it every time.
+  cache.map.set(filepath, index)
+  // Save the stat data for the index so we know whether the cached file is stale (modified by an outside process).
+  cache.stats.set(filepath, stat)
 }
 
 // Determine whether our copy of the index file is stale
-async function isIndexStale(fs, filepath) {
-  const savedStats = stats.get([fs, filepath])
+async function isIndexStale(fs, filepath, cache) {
+  const savedStats = cache.stats.get(filepath)
   if (savedStats === undefined) return true
   const currStats = await fs.lstat(filepath)
   if (savedStats === null) return false
@@ -39,9 +40,14 @@ export class GitIndexManager {
   /**
    *
    * @param {object} opts
+   * @param {import('../models/FileSystem.js').FileSystem} opts.fs
+   * @param {string} opts.gitdir
+   * @param {object} opts.cache
    * @param {function(GitIndex): any} closure
    */
-  static async acquire({ fs, gitdir }, closure) {
+  static async acquire({ fs, gitdir, cache }, closure) {
+    if (!cache.index) cache.index = createCache()
+
     const filepath = `${gitdir}/index`
     if (lock === null) lock = new AsyncLock({ maxPending: Infinity })
     let result
@@ -50,10 +56,10 @@ export class GitIndexManager {
       // to make sure other processes aren't writing to it
       // simultaneously, which could result in a corrupted index.
       // const fileLock = await Lock(filepath)
-      if (await isIndexStale(fs, filepath)) {
-        await updateCachedIndexFile(fs, filepath)
+      if (await isIndexStale(fs, filepath, cache.index)) {
+        await updateCachedIndexFile(fs, filepath, cache.index)
       }
-      const index = map.get([fs, filepath])
+      const index = cache.index.map.get(filepath)
       result = await closure(index)
       if (index._dirty) {
         // Acquire a file lock while we're writing the index file
@@ -61,7 +67,7 @@ export class GitIndexManager {
         const buffer = await index.toObject()
         await fs.write(filepath, buffer)
         // Update cached stat value
-        stats.set([fs, filepath], await fs.lstat(filepath))
+        cache.index.stats.set(filepath, await fs.lstat(filepath))
         index._dirty = false
       }
     })

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -3,21 +3,11 @@ import pify from 'pify'
 import { compareStrings } from '../utils/compareStrings.js'
 import { dirname } from '../utils/dirname.js'
 
-const fsmap = new WeakMap()
 /**
  * This is just a collection of helper functions really. At least that's how it started.
  */
 export class FileSystem {
   constructor(fs) {
-    // This is sad... but preserving reference equality is now necessary
-    // to deal with cache invalidation in GitIndexManager.
-    if (fsmap.has(fs)) {
-      return fsmap.get(fs)
-    }
-    if (fsmap.has(fs._original_unwrapped_fs)) {
-      return fsmap.get(fs._original_unwrapped_fs)
-    }
-
     if (typeof fs._original_unwrapped_fs !== 'undefined') return fs
 
     const promises = Object.getOwnPropertyDescriptor(fs, 'promises')
@@ -45,7 +35,6 @@ export class FileSystem {
       this._symlink = pify(fs.symlink.bind(fs))
     }
     this._original_unwrapped_fs = fs
-    fsmap.set(fs, this)
   }
 
   /**

--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -7,8 +7,9 @@ import { shasum } from '../utils/shasum.js'
 import { GitObject } from './GitObject.js'
 
 export class GitWalkerFs {
-  constructor({ fs, dir, gitdir }) {
+  constructor({ fs, dir, gitdir, cache }) {
     this.fs = fs
+    this.cache = cache
     this.dir = dir
     this.gitdir = gitdir
     const walker = this
@@ -111,10 +112,12 @@ export class GitWalkerFs {
 
   async oid(entry) {
     if (entry._oid === false) {
-      const { fs, gitdir } = this
+      const { fs, gitdir, cache } = this
       let oid
       // See if we can use the SHA1 hash in the index.
-      await GitIndexManager.acquire({ fs, gitdir }, async function(index) {
+      await GitIndexManager.acquire({ fs, gitdir, cache }, async function(
+        index
+      ) {
         const stage = index.entriesMap.get(entry._fullpath)
         const stats = await entry.stat()
         if (!stage || compareStats(stats, stage)) {

--- a/src/models/GitWalkerIndex.js
+++ b/src/models/GitWalkerIndex.js
@@ -5,12 +5,13 @@ import { mode2type } from '../utils/mode2type'
 import { normalizeStats } from '../utils/normalizeStats'
 
 export class GitWalkerIndex {
-  constructor({ fs, gitdir }) {
-    this.treePromise = GitIndexManager.acquire({ fs, gitdir }, async function(
-      index
-    ) {
-      return flatFileListToDirectoryStructure(index.entries)
-    })
+  constructor({ fs, gitdir, cache }) {
+    this.treePromise = GitIndexManager.acquire(
+      { fs, gitdir, cache },
+      async function(index) {
+        return flatFileListToDirectoryStructure(index.entries)
+      }
+    )
     const walker = this
     this.ConstructEntry = class StageEntry {
       constructor(fullpath) {


### PR DESCRIPTION
TLDR: If you're doing a bunch of git commands in a loop, you might see a performance regression. File an issue letting me know what you're doing in a loop, and I'll figure out how to speed it up again.

Since some commit a while ago, we've been caching the parsed `.git/index` data since it's needed constantly during `walk`. But we were caching it keyed by `fs` and `filepath`. And... well, in situations where `fs` is in the browser or in memory, and you do funny things with it like wipe it or switch out the files for a different set of files, then `fs` isn't very reliable as a caching key. Because even though the `fs` object reference might be the same, it could be holding a very different file system.

To fix this, I'm relaxing the caching so we only hold onto the cached `.git/index` for the duration of the current command. If you're doing a bunch of `git` commands in a loop, you might see a performance regression. File an issue letting me know what you're doing in a loop, and I'll figure out how to speed it up again.