### PR TITLE
feat: include data.response on all HttpErrors (not just on SmartHttpErrors)

### DIFF
--- a/__tests__/test-push.js
+++ b/__tests__/test-push.js
@@ -377,6 +377,7 @@ describe('push', () => {
     }
     expect(err).toBeDefined()
     expect(err.code).toBe(Errors.HttpError.code)
+    expect(err.data.response).toBeTruthy()
     expect(onAuthArgs).toEqual([
       [
         `http://${localhost}:8888/test-push-server-auth.git`,

--- a/src/errors/HttpError.js
+++ b/src/errors/HttpError.js
@@ -4,11 +4,12 @@ export class HttpError extends BaseError {
   /**
    * @param {number} statusCode
    * @param {string} statusMessage
+   * @param {string} response
    */
-  constructor(statusCode, statusMessage) {
+  constructor(statusCode, statusMessage, response) {
     super(`HTTP Error: ${statusCode} ${statusMessage}`)
     this.code = this.name = HttpError.code
-    this.data = { statusCode, statusMessage }
+    this.data = { statusCode, statusMessage, response }
   }
 }
 /** @type {'HttpError'} */


### PR DESCRIPTION
## I'm adding additional data to the `data` returned by an custom Error

- [x] add parameter to the function in `src/errors/X.js`
- [x] document the parameter in the JSDoc comment above the function
- [x] add or update a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat(X): Added 'bar' parameter"
