### PR TITLE
remove 'sha.js' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20785,6 +20785,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "pako": "^1.0.10",
     "pify": "^4.0.1",
     "readable-stream": "^3.4.0",
-    "sha.js": "^2.4.9",
     "simple-get": "^3.0.2"
   },
   "devDependencies": {

--- a/src/commands/pack.js
+++ b/src/commands/pack.js
@@ -1,10 +1,9 @@
-import Hash from 'sha.js/sha1.js'
-
 import { types } from '../commands/types.js'
 import { _readObject as readObject } from '../storage/readObject.js'
 import { deflate } from '../utils/deflate.js'
 import { join } from '../utils/join.js'
 import { padHex } from '../utils/padHex.js'
+import Hash from '../utils/sha1.js'
 
 /**
  * @param {object} args
@@ -57,6 +56,6 @@ export async function _pack({ fs, dir, gitdir = join(dir, '.git'), oids }) {
   }
   // Write SHA1 checksum
   const digest = hash.digest()
-  outputStream.push(digest)
+  outputStream.push(Buffer.from(digest))
   return outputStream
 }

--- a/src/utils/sha1.js
+++ b/src/utils/sha1.js
@@ -1,0 +1,166 @@
+/*
+ * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
+ * in FIPS PUB 180-1
+ * Version 2.1a Copyright Paul Johnston 2000 - 2002.
+ * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+ * Distributed under the BSD License
+ * See http://pajhome.org.uk/crypt/md5 for details.
+ */
+
+// Code originally from https://github.com/crypto-browserify/sha.js/commit/100edf9c567e1e1079dc1d6d7c7725a0644e425c
+// This code has been modified to use modern ECMAScript. -WMH
+
+var K = [
+  0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0
+]
+
+var W = new Array(80)
+
+// prototype class for hash functions
+function Hash () {
+  this.init()
+  this._w = W
+
+  this._block = Buffer.alloc(64)
+  this._finalSize = 56
+  this._blockSize = 64
+  this._len = 0
+}
+
+Hash.prototype.update = function (data, enc) {
+  if (typeof data === 'string') {
+    enc = enc || 'utf8'
+    data = Buffer.from(data, enc)
+  }
+
+  var block = this._block
+  var blockSize = this._blockSize
+  var length = data.length
+  var accum = this._len
+
+  for (var offset = 0; offset < length;) {
+    var assigned = accum % blockSize
+    var remainder = Math.min(length - offset, blockSize - assigned)
+
+    for (var i = 0; i < remainder; i++) {
+      block[assigned + i] = data[offset + i]
+    }
+
+    accum += remainder
+    offset += remainder
+
+    if ((accum % blockSize) === 0) {
+      this._update(block)
+    }
+  }
+
+  this._len += length
+  return this
+}
+
+Hash.prototype.digest = function (enc) {
+  var rem = this._len % this._blockSize
+
+  this._block[rem] = 0x80
+
+  // zero (rem + 1) trailing bits, where (rem + 1) is the smallest
+  // non-negative solution to the equation (length + 1 + (rem + 1)) === finalSize mod blockSize
+  this._block.fill(0, rem + 1)
+
+  if (rem >= this._finalSize) {
+    this._update(this._block)
+    this._block.fill(0)
+  }
+
+  var bits = this._len * 8
+
+  // uint32
+  if (bits <= 0xffffffff) {
+    this._block.writeUInt32BE(bits, this._blockSize - 4)
+
+  // uint64
+  } else {
+    var lowBits = (bits & 0xffffffff) >>> 0
+    var highBits = (bits - lowBits) / 0x100000000
+
+    this._block.writeUInt32BE(highBits, this._blockSize - 8)
+    this._block.writeUInt32BE(lowBits, this._blockSize - 4)
+  }
+
+  this._update(this._block)
+  var hash = this._hash()
+
+  return enc ? hash.toString(enc) : hash
+}
+
+Hash.prototype.init = function () {
+  this._a = 0x67452301
+  this._b = 0xefcdab89
+  this._c = 0x98badcfe
+  this._d = 0x10325476
+  this._e = 0xc3d2e1f0
+
+  return this
+}
+
+function rotl1 (num) {
+  return (num << 1) | (num >>> 31)
+}
+
+function rotl5 (num) {
+  return (num << 5) | (num >>> 27)
+}
+
+function rotl30 (num) {
+  return (num << 30) | (num >>> 2)
+}
+
+function ft (s, b, c, d) {
+  if (s === 0) return (b & c) | ((~b) & d)
+  if (s === 2) return (b & c) | (b & d) | (c & d)
+  return b ^ c ^ d
+}
+
+Hash.prototype._update = function (M) {
+  var W = this._w
+
+  var a = this._a | 0
+  var b = this._b | 0
+  var c = this._c | 0
+  var d = this._d | 0
+  var e = this._e | 0
+
+  for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+  for (; i < 80; ++i) W[i] = rotl1(W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16])
+
+  for (var j = 0; j < 80; ++j) {
+    var s = ~~(j / 20)
+    var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
+
+    e = d
+    d = c
+    c = rotl30(b)
+    b = a
+    a = t
+  }
+
+  this._a = (a + this._a) | 0
+  this._b = (b + this._b) | 0
+  this._c = (c + this._c) | 0
+  this._d = (d + this._d) | 0
+  this._e = (e + this._e) | 0
+}
+
+Hash.prototype._hash = function () {
+  var H = Buffer.allocUnsafe(20)
+
+  H.writeInt32BE(this._a | 0, 0)
+  H.writeInt32BE(this._b | 0, 4)
+  H.writeInt32BE(this._c | 0, 8)
+  H.writeInt32BE(this._d | 0, 12)
+  H.writeInt32BE(this._e | 0, 16)
+
+  return H
+}
+
+export default Hash

--- a/src/utils/sha1.js
+++ b/src/utils/sha1.js
@@ -10,91 +10,132 @@
 // Code originally from https://github.com/crypto-browserify/sha.js/commit/100edf9c567e1e1079dc1d6d7c7725a0644e425c
 // This code has been modified to use Typed ArrayBuffers. -WMH
 
-var K = [0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0]
+const K = [0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0]
 
-var W = new Array(80)
+const BLOCK_SIZE = 64
+const FINAL_SIZE = 56
+
+// Re-usable scratch buffer of size 80 bytes
+let W
 
 // prototype class for hash functions
-function Hash() {
-  this.init()
-  this._w = W
+export default class Hash {
+  constructor() {
+    if (!W) W = new Array(80)
 
-  this._buffer = new ArrayBuffer(64)
-  this._block = new DataView(this._buffer)
-  this._finalSize = 56
-  this._blockSize = 64
-  this._len = 0
-}
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
 
-Hash.prototype.update = function(data) {
-  var block = this._block
-  var blockSize = this._blockSize
-  var length = data.length
-  var accum = this._len
-
-  for (var offset = 0; offset < length; ) {
-    var assigned = accum % blockSize
-    var remainder = Math.min(length - offset, blockSize - assigned)
-
-    for (var i = 0; i < remainder; i++) {
-      block.setUint8(assigned + i, data[offset + i])
-    }
-
-    accum += remainder
-    offset += remainder
-
-    if (accum % blockSize === 0) {
-      this._update(block)
-    }
+    this._buffer = new ArrayBuffer(64)
+    this._block = new DataView(this._buffer)
+    this._len = 0
   }
 
-  this._len += length
-  return this
-}
+  update(data) {
+    var block = this._block
+    var blockSize = BLOCK_SIZE
+    var length = data.length
+    var accum = this._len
 
-Hash.prototype.digest = function(enc) {
-  var rem = this._len % this._blockSize
+    for (var offset = 0; offset < length; ) {
+      var assigned = accum % blockSize
+      var remainder = Math.min(length - offset, blockSize - assigned)
 
-  this._block.setUint8(rem, 0x80)
+      for (var i = 0; i < remainder; i++) {
+        block.setUint8(assigned + i, data[offset + i])
+      }
 
-  // zero (rem + 1) trailing bits, where (rem + 1) is the smallest
-  // non-negative solution to the equation (length + 1 + (rem + 1)) === finalSize mod blockSize
-  for (var i = rem + 1; i < this._blockSize; i++) this._block.setUint8(i, 0)
+      accum += remainder
+      offset += remainder
 
-  if (rem >= this._finalSize) {
+      if (accum % blockSize === 0) {
+        this._update(block)
+      }
+    }
+
+    this._len += length
+    return this
+  }
+
+  digest() {
+    var rem = this._len % BLOCK_SIZE
+
+    this._block.setUint8(rem, 0x80)
+
+    // zero (rem + 1) trailing bits, where (rem + 1) is the smallest
+    // non-negative solution to the equation (length + 1 + (rem + 1)) === finalSize mod blockSize
+    for (var i = rem + 1; i < BLOCK_SIZE; i++) this._block.setUint8(i, 0)
+
+    if (rem >= FINAL_SIZE) {
+      this._update(this._block)
+      for (i = 0; i < BLOCK_SIZE; i++) this._block.setUint8(i, 0)
+    }
+
+    var bits = this._len * 8
+
+    // uint32
+    if (bits <= 0xffffffff) {
+      this._block.setUint32(BLOCK_SIZE - 4, bits)
+
+      // uint64
+    } else {
+      var lowBits = (bits & 0xffffffff) >>> 0
+      var highBits = (bits - lowBits) / 0x100000000
+
+      this._block.setUint32(BLOCK_SIZE - 8, highBits)
+      this._block.setUint32(BLOCK_SIZE - 4, lowBits)
+    }
+
     this._update(this._block)
-    for (i = 0; i < this._blockSize; i++) this._block.setUint8(i, 0)
+    var hash = this._hash()
+
+    return hash
   }
 
-  var bits = this._len * 8
+  _update(M) {
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
 
-  // uint32
-  if (bits <= 0xffffffff) {
-    this._block.setUint32(this._blockSize - 4, bits)
+    for (var i = 0; i < 16; ++i) W[i] = M.getUint32(i * 4)
+    for (; i < 80; ++i)
+      W[i] = rotl1(W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16])
 
-    // uint64
-  } else {
-    var lowBits = (bits & 0xffffffff) >>> 0
-    var highBits = (bits - lowBits) / 0x100000000
+    for (var j = 0; j < 80; ++j) {
+      var s = ~~(j / 20)
+      var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
 
-    this._block.setUint32(this._blockSize - 8, highBits)
-    this._block.setUint32(this._blockSize - 4, lowBits)
+      e = d
+      d = c
+      c = rotl30(b)
+      b = a
+      a = t
+    }
+
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
   }
 
-  this._update(this._block)
-  var hash = this._hash()
+  _hash() {
+    var B = new ArrayBuffer(20)
+    var H = new DataView(B)
 
-  return hash
-}
+    H.setUint32(0, this._a | 0)
+    H.setUint32(4, this._b | 0)
+    H.setUint32(8, this._c | 0)
+    H.setUint32(12, this._d | 0)
+    H.setUint32(16, this._e | 0)
 
-Hash.prototype.init = function() {
-  this._a = 0x67452301
-  this._b = 0xefcdab89
-  this._c = 0x98badcfe
-  this._d = 0x10325476
-  this._e = 0xc3d2e1f0
-
-  return this
+    return B
+  }
 }
 
 function rotl1(num) {
@@ -114,48 +155,3 @@ function ft(s, b, c, d) {
   if (s === 2) return (b & c) | (b & d) | (c & d)
   return b ^ c ^ d
 }
-
-Hash.prototype._update = function(M) {
-  var W = this._w
-
-  var a = this._a | 0
-  var b = this._b | 0
-  var c = this._c | 0
-  var d = this._d | 0
-  var e = this._e | 0
-
-  for (var i = 0; i < 16; ++i) W[i] = M.getUint32(i * 4)
-  for (; i < 80; ++i) W[i] = rotl1(W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16])
-
-  for (var j = 0; j < 80; ++j) {
-    var s = ~~(j / 20)
-    var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
-
-    e = d
-    d = c
-    c = rotl30(b)
-    b = a
-    a = t
-  }
-
-  this._a = (a + this._a) | 0
-  this._b = (b + this._b) | 0
-  this._c = (c + this._c) | 0
-  this._d = (d + this._d) | 0
-  this._e = (e + this._e) | 0
-}
-
-Hash.prototype._hash = function() {
-  var B = new ArrayBuffer(20)
-  var H = new DataView(B)
-
-  H.setUint32(0, this._a | 0)
-  H.setUint32(4, this._b | 0)
-  H.setUint32(8, this._c | 0)
-  H.setUint32(12, this._d | 0)
-  H.setUint32(16, this._e | 0)
-
-  return B
-}
-
-export default Hash

--- a/src/utils/sha1.js
+++ b/src/utils/sha1.js
@@ -10,14 +10,12 @@
 // Code originally from https://github.com/crypto-browserify/sha.js/commit/100edf9c567e1e1079dc1d6d7c7725a0644e425c
 // This code has been modified to use Typed ArrayBuffers. -WMH
 
-var K = [
-  0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0
-]
+var K = [0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0]
 
 var W = new Array(80)
 
 // prototype class for hash functions
-function Hash () {
+function Hash() {
   this.init()
   this._w = W
 
@@ -28,13 +26,13 @@ function Hash () {
   this._len = 0
 }
 
-Hash.prototype.update = function (data) {
+Hash.prototype.update = function(data) {
   var block = this._block
   var blockSize = this._blockSize
   var length = data.length
   var accum = this._len
 
-  for (var offset = 0; offset < length;) {
+  for (var offset = 0; offset < length; ) {
     var assigned = accum % blockSize
     var remainder = Math.min(length - offset, blockSize - assigned)
 
@@ -45,7 +43,7 @@ Hash.prototype.update = function (data) {
     accum += remainder
     offset += remainder
 
-    if ((accum % blockSize) === 0) {
+    if (accum % blockSize === 0) {
       this._update(block)
     }
   }
@@ -54,7 +52,7 @@ Hash.prototype.update = function (data) {
   return this
 }
 
-Hash.prototype.digest = function (enc) {
+Hash.prototype.digest = function(enc) {
   var rem = this._len % this._blockSize
 
   this._block.setUint8(rem, 0x80)
@@ -74,7 +72,7 @@ Hash.prototype.digest = function (enc) {
   if (bits <= 0xffffffff) {
     this._block.setUint32(this._blockSize - 4, bits)
 
-  // uint64
+    // uint64
   } else {
     var lowBits = (bits & 0xffffffff) >>> 0
     var highBits = (bits - lowBits) / 0x100000000
@@ -89,7 +87,7 @@ Hash.prototype.digest = function (enc) {
   return hash
 }
 
-Hash.prototype.init = function () {
+Hash.prototype.init = function() {
   this._a = 0x67452301
   this._b = 0xefcdab89
   this._c = 0x98badcfe
@@ -99,25 +97,25 @@ Hash.prototype.init = function () {
   return this
 }
 
-function rotl1 (num) {
+function rotl1(num) {
   return (num << 1) | (num >>> 31)
 }
 
-function rotl5 (num) {
+function rotl5(num) {
   return (num << 5) | (num >>> 27)
 }
 
-function rotl30 (num) {
+function rotl30(num) {
   return (num << 30) | (num >>> 2)
 }
 
-function ft (s, b, c, d) {
-  if (s === 0) return (b & c) | ((~b) & d)
+function ft(s, b, c, d) {
+  if (s === 0) return (b & c) | (~b & d)
   if (s === 2) return (b & c) | (b & d) | (c & d)
   return b ^ c ^ d
 }
 
-Hash.prototype._update = function (M) {
+Hash.prototype._update = function(M) {
   var W = this._w
 
   var a = this._a | 0
@@ -147,7 +145,7 @@ Hash.prototype._update = function (M) {
   this._e = (e + this._e) | 0
 }
 
-Hash.prototype._hash = function () {
+Hash.prototype._hash = function() {
   var B = new ArrayBuffer(20)
   var H = new DataView(B)
 

--- a/src/utils/sha1.js
+++ b/src/utils/sha1.js
@@ -148,15 +148,16 @@ Hash.prototype._update = function (M) {
 }
 
 Hash.prototype._hash = function () {
-  var H = Buffer.allocUnsafe(20)
+  var B = new ArrayBuffer(20)
+  var H = new DataView(B)
 
-  H.writeInt32BE(this._a | 0, 0)
-  H.writeInt32BE(this._b | 0, 4)
-  H.writeInt32BE(this._c | 0, 8)
-  H.writeInt32BE(this._d | 0, 12)
-  H.writeInt32BE(this._e | 0, 16)
+  H.setUint32(0, this._a | 0)
+  H.setUint32(4, this._b | 0)
+  H.setUint32(8, this._c | 0)
+  H.setUint32(12, this._d | 0)
+  H.setUint32(16, this._e | 0)
 
-  return H
+  return B
 }
 
 export default Hash

--- a/src/utils/shasum.js
+++ b/src/utils/shasum.js
@@ -1,6 +1,5 @@
 /* eslint-env node, browser */
-import Hash from 'sha.js/sha1.js'
-
+import Hash from './sha1.js'
 import { toHex } from './toHex.js'
 
 let supportsSubtleSHA1 = null
@@ -16,7 +15,7 @@ export async function shasum(buffer) {
 // but without the 'json-stable-stringify' dependency and
 // extra type-casting features.
 function shasumSync(buffer) {
-  return new Hash().update(buffer).digest('hex')
+  return toHex(new Hash().update(buffer).digest())
 }
 
 async function subtleSHA1(buffer) {


### PR DESCRIPTION
It uses Buffer. So we gotta ditch it if we really want to get benefits from not using Buffer ourselves.

Part of a series of PRs where I see if removing Buffer is possible yet.