### PR TITLE
perf(push): don't send any objects if commit is already on remote

### DIFF
--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -144,14 +144,16 @@ export async function _push({
     })
     for (const oid of mergebase) finish.push(oid)
     // @ts-ignore
-    const commits = await listCommitsAndTags({
-      fs,
-      gitdir,
-      start: [oid],
-      finish,
-    })
-    // @ts-ignore
-    objects = await listObjects({ fs, gitdir, oids: commits })
+    if (!mergebase.includes(oid)) {
+      const commits = await listCommitsAndTags({
+        fs,
+        gitdir,
+        start: [oid],
+        finish,
+      })
+      // @ts-ignore
+      objects = await listObjects({fs, gitdir, oids: commits})
+    }
 
     if (!force) {
       // Is it a tag that already exists?


### PR DESCRIPTION
This is a very naïve proposition to fix #1136. It works on the two projects we tried it on but it's just a conversation starter on how to fix this.