### PR TITLE
perf(push): short-circuit recursion in listObjects

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -19,6 +19,9 @@ minimisted(async function({ _: [command, ...args], ...opts }) {
           http,
           dir: '.',
           onAuth: () => ({ username: opts.username, password: opts.password }),
+          headers: {
+            'User-Agent': `git/isogit-${git.version()}`,
+          },
         },
         opts
       )

--- a/src/commands/listObjects.js
+++ b/src/commands/listObjects.js
@@ -23,6 +23,7 @@ export async function listObjects({
   // avoid reading Blob objects entirely since the Tree objects
   // tell us which oids are Blobs and which are Trees.
   async function walk(oid) {
+    if (visited.has(oid)) return
     visited.add(oid)
     const { type, object } = await readObject({ fs, gitdir, oid })
     if (type === 'tag') {
@@ -36,12 +37,11 @@ export async function listObjects({
     } else if (type === 'tree') {
       const tree = GitTree.from(object)
       for (const entry of tree) {
-        // only add blobs and trees to the set,
-        // skipping over submodules whose type is 'commit'
-        if (entry.type === 'blob' || entry.type === 'tree') {
+        // add blobs and submodules to the visited set
+        if (entry.type === 'blob' || entry.type === 'commit') {
           visited.add(entry.oid)
         }
-        // only recurse for trees
+        // recurse for trees
         if (entry.type === 'tree') {
           await walk(entry.oid)
         }


### PR DESCRIPTION
@hsablonniere 

This speeds up `listObjects` when there's a lot of commits by never revisiting an object that's already been visited. Should fix #1138

## Before
921 commits
12441 objects
42.219 seconds

## Before
921 commits
12441 objects
2.422 seconds