### PR TITLE
Remove dead link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Check out the [`CONTRIBUTING`](./CONTRIBUTING.md) document for more instructions
 ## Who is using isomorphic-git?
 
 - [nde](https://nde.now.sh) - a futuristic next-generation web IDE
-- [git-app-manager](https://git-app-manager-tcibxepsta.now.sh) - install "unhosted" websites locally by git cloning them
+- [git-app-manager](https://git-app-manager.now.sh/) - install "unhosted" websites locally by git cloning them
 - [GIT Web Terminal](https://jcubic.github.io/git/)
 - [Next Editor](https://next-editor.app/)
 - [Clever Cloud](https://www.clever-cloud.com/?utm_source=ref&utm_medium=link&utm_campaign=isomorphic-git)


### PR DESCRIPTION
> git-app-manager - install "unhosted" websites locally by git cloning them

The link for the `git-app-manager` on the README looks dead.

I think this is the matching link: https://git-app-manager.now.sh/ .
It was posted here https://github.com/isomorphic-git/isomorphic-git/issues/97#issuecomment-381365557 by @wmhilton