### PR TITLE
fix(react-native): fix for "<Intermediate Value>.stream is not a function" errors in React Native

### DIFF
--- a/src/utils/deflate.js
+++ b/src/utils/deflate.js
@@ -22,6 +22,8 @@ async function browserDeflate(buffer) {
 function testCompressionStream() {
   try {
     const cs = new CompressionStream('deflate')
+    // Test if `Blob.stream` is present. React Native does not have the `stream` method
+    new Blob([]).stream()
     if (cs) return true
   } catch (_) {
     // no bother


### PR DESCRIPTION
## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"

## Explanation

While working on my React Native app, I kept finding myself running into `<Intermediate Value>.stream is not a function` errors. After some investigating, I realized that it was thanks to React Native's `Blob` supporting constructors but not the `stream` method. However, it _does_ support `CompressionStream`. As such, it was defaulting to use `browserDeflate`, which was causing errors to be thrown.

I thought I could work around this by polyfilling `Blob.stream`:

```javascript
    const streams = require('web-streams-polyfill/ponyfill');

    const stream = function stream() {
      let position = 0;
      // eslint-disable-next-line @typescript-eslint/no-this-alias
      const blob = this;

      return new streams.ReadableStream({
        type: 'bytes',
        autoAllocateChunkSize: 524288,

        pull: function(controller) {
          const v = controller.byobRequest.view;
          const chunk = blob.slice(position, position + v.byteLength);
          return chunk.arrayBuffer().then(function(buffer) {
            const uint8array = new Uint8Array(buffer);
            const bytesRead = uint8array.byteLength;

            position += bytesRead;
            v.set(uint8array);
            controller.byobRequest.respond(bytesRead);

            if (position >= blob.size) controller.close();
          });
        },
      });
    };

    // eslint-disable-next-line no-undef
    Blob.prototype.stream = stream;

    const b = new Blob([])
    console.log('b', b);
    b.stream()
```

But once this was done, I got an error that "anything passed to `pipeThrough` must be a `WritableStream`", so I figured a single LOC change was better than not.

By adding a simple check to see if `stream` is a function, we can tell React Native to instead use `pako.deflate`, which works exactly as expected.