### PR TITLE
feat(init): add optional 'defaultBranch' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/isomorphic-git/isomorphic-git/master/website/static/img/isomorphic-git-logo.svg?sanitize=true" alt="" height="150"/>
+  <img src="https://raw.githubusercontent.com/isomorphic-git/isomorphic-git/main/website/static/img/isomorphic-git-logo.svg?sanitize=true" alt="" height="150"/>
 </p>
 
 # isomorphic-git
@@ -22,7 +22,7 @@ The following environments are tested in CI and will continue to be supported un
 
 <table width="100%">
 <tr>
-<td align="center"><img src="https://raw.githubusercontent.com/isomorphic-git/isomorphic-git/master/website/static/img/browsers/node.webp" alt="" width="64" height="64"><br> Node 10</td>
+<td align="center"><img src="https://raw.githubusercontent.com/isomorphic-git/isomorphic-git/main/website/static/img/browsers/node.webp" alt="" width="64" height="64"><br> Node 10</td>
 <td align="center"><img src="https://raw.githubusercontent.com/alrra/browser-logos/bc47e4601d2c1fd46a7912f9aed5cdda4afdb301/src/chrome/chrome.svg?sanitize=true" alt="" width="64" height="64"><br> Chrome 79</td>
 <td align="center"><img src="https://raw.githubusercontent.com/alrra/browser-logos/bc47e4601d2c1fd46a7912f9aed5cdda4afdb301/src/edge/edge.svg?sanitize=true" alt="" width="64" height="64"><br> Edge 79</td>
 <td align="center"><img src="https://raw.githubusercontent.com/alrra/browser-logos/bc47e4601d2c1fd46a7912f9aed5cdda4afdb301/src/firefox/firefox.svg?sanitize=true" alt="" width="64" height="64"><br> Firefox 72</td>

--- a/docs/guide-quickstart.md
+++ b/docs/guide-quickstart.md
@@ -43,7 +43,7 @@ await git.clone({
   dir,
   corsProxy: 'https://cors.isomorphic-git.org',
   url: 'https://github.com/isomorphic-git/isomorphic-git',
-  ref: 'master',
+  ref: 'main',
   singleBranch: true,
   depth: 10
 });

--- a/docs/http.md
+++ b/docs/http.md
@@ -104,5 +104,5 @@ You don't _have_ to support streaming (and in some cases, like uploads in the br
 If you are not streaming responses, you can simply fake it by returning an array with a single `Uint8Array` inside it.
 This works because the async iteration protocol (`for await ... of`) will fallback to the sync iteration protocol, which is supported by plain Arrays.
 
-To get started, you might want to look at [`src/http/node/index.js`](https://github.com/isomorphic-git/isomorphic-git/blob/master/src/http/node/index.js)
-and [`src/http/web/index.js`](https://github.com/isomorphic-git/isomorphic-git/blob/master/src/http/web/index.js).
+To get started, you might want to look at [`src/http/node/index.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/http/node/index.js)
+and [`src/http/web/index.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/http/web/index.js).

--- a/docs/onSign.md
+++ b/docs/onSign.md
@@ -42,7 +42,7 @@ To verify signed commits and signed annotated tag objects, you use the signature
 // Verify a whole bunch of commits
 import { pgp } from '@isomorphic-git/pgp-plugin'
 
-let commits = await git.log({ fs, dir, ref: 'master' })
+let commits = await git.log({ fs, dir, ref: 'main' })
 for (const { commit, payload } of commits) {
   let { valid, invalid } = await pgp.verify({ payload, publicKey, signature: commit.gpgsig })
   // valid is a string[] of the valid key ids
@@ -54,7 +54,7 @@ for (const { commit, payload } of commits) {
 // Verify a commit object
 import { pgp } from '@isomorphic-git/pgp-plugin'
 
-let oid = await git.resolveRef({ fs, dir, ref: 'master' })
+let oid = await git.resolveRef({ fs, dir, ref: 'main' })
 let { commit, payload } = await git.readCommit({ fs, dir, oid })
 let { valid, invalid } = await pgp.verify({ payload, publicKey, signature: commit.gpgsig })
 // valid is a string[] of the valid key ids

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -89,8 +89,8 @@ const buildDir = path.join(sourceDir, 'website/build/isomorphic-git.github.io')
   dir = buildDir
   await git.init({ fs, dir })
   await git.addRemote({ fs, dir, url, remote: 'origin' })
-  await git.fetch({ http, fs, dir, ref: 'master', depth: 1 })
-  await git.checkout({ fs, dir, ref: 'master', noCheckout: true })
+  await git.fetch({ http, fs, dir, ref: 'main', depth: 1 })
+  await git.checkout({ fs, dir, ref: 'main', noCheckout: true })
   await git.add({ fs, dir, filepath: '.' })
   await git.commit({ fs, dir, author: commit.author, message: commit.message })
   await git.push({

--- a/website/scripts/deploy-gh-pages.js
+++ b/website/scripts/deploy-gh-pages.js
@@ -21,11 +21,11 @@ let dir = path.join(__dirname, '../..')
   await git.fetch({
     dir,
     depth: 1,
-    ref: 'master'
+    ref: 'main'
   })
   await git.checkout({
     dir,
-    ref: 'master',
+    ref: 'main',
     noCheckout: true
   })
   await git.add({

--- a/website/versioned_docs/version-0.70.7/STAGE.md
+++ b/website/versioned_docs/version-0.70.7/STAGE.md
@@ -17,7 +17,7 @@ See [walkBeta2](./walkBeta2.md)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/STAGE.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/STAGE.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/TREE.md
+++ b/website/versioned_docs/version-0.70.7/TREE.md
@@ -18,7 +18,7 @@ See [walkBeta2](./walkBeta2.md)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/TREE.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/TREE.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/WORKDIR.md
+++ b/website/versioned_docs/version-0.70.7/WORKDIR.md
@@ -17,7 +17,7 @@ See [walkBeta2](./walkBeta2.md)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/WORKDIR.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/WORKDIR.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/add.md
+++ b/website/versioned_docs/version-0.70.7/add.md
@@ -32,7 +32,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/add.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/add.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/addRemote.md
+++ b/website/versioned_docs/version-0.70.7/addRemote.md
@@ -29,7 +29,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/addRemote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/addRemote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/annotatedTag.md
+++ b/website/versioned_docs/version-0.70.7/annotatedTag.md
@@ -46,7 +46,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/annotatedTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/annotatedTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/branch.md
+++ b/website/versioned_docs/version-0.70.7/branch.md
@@ -28,7 +28,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/branch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/branch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/checkout.md
+++ b/website/versioned_docs/version-0.70.7/checkout.md
@@ -42,7 +42,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/checkout.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/checkout.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/clone.md
+++ b/website/versioned_docs/version-0.70.7/clone.md
@@ -53,7 +53,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/clone.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/clone.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/commit.md
+++ b/website/versioned_docs/version-0.70.7/commit.md
@@ -47,7 +47,7 @@ console.log(sha)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/commit.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/commit.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/config.md
+++ b/website/versioned_docs/version-0.70.7/config.md
@@ -45,7 +45,7 @@ console.log(value)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/config.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/config.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/currentBranch.md
+++ b/website/versioned_docs/version-0.70.7/currentBranch.md
@@ -28,7 +28,7 @@ console.log(branch)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/currentBranch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/currentBranch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/deleteBranch.md
+++ b/website/versioned_docs/version-0.70.7/deleteBranch.md
@@ -29,7 +29,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/deleteBranch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/deleteBranch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/deleteRef.md
+++ b/website/versioned_docs/version-0.70.7/deleteRef.md
@@ -29,7 +29,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/deleteRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/deleteRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/deleteRemote.md
+++ b/website/versioned_docs/version-0.70.7/deleteRemote.md
@@ -27,7 +27,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/deleteRemote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/deleteRemote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/deleteTag.md
+++ b/website/versioned_docs/version-0.70.7/deleteTag.md
@@ -27,7 +27,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/deleteTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/deleteTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/expandOid.md
+++ b/website/versioned_docs/version-0.70.7/expandOid.md
@@ -27,7 +27,7 @@ console.log(oid)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/expandOid.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/expandOid.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/expandRef.md
+++ b/website/versioned_docs/version-0.70.7/expandRef.md
@@ -27,7 +27,7 @@ console.log(fullRef)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/expandRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/expandRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/fastCheckout.md
+++ b/website/versioned_docs/version-0.70.7/fastCheckout.md
@@ -54,7 +54,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/fastCheckout.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/fastCheckout.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/fetch.md
+++ b/website/versioned_docs/version-0.70.7/fetch.md
@@ -70,7 +70,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/fetch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/fetch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/findRoot.md
+++ b/website/versioned_docs/version-0.70.7/findRoot.md
@@ -30,7 +30,7 @@ console.log(gitroot) // '/path/to/some/gitrepo'
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/findRoot.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/findRoot.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/getRemoteInfo.md
+++ b/website/versioned_docs/version-0.70.7/getRemoteInfo.md
@@ -51,7 +51,7 @@ console.log(info);
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/getRemoteInfo.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/getRemoteInfo.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/hashBlob.md
+++ b/website/versioned_docs/version-0.70.7/hashBlob.md
@@ -41,7 +41,7 @@ console.log('format', format)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/hashBlob.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/hashBlob.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/indexPack.md
+++ b/website/versioned_docs/version-0.70.7/indexPack.md
@@ -31,7 +31,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/indexPack.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/indexPack.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/init.md
+++ b/website/versioned_docs/version-0.70.7/init.md
@@ -28,7 +28,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/init.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/init.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/isDescendent.md
+++ b/website/versioned_docs/version-0.70.7/isDescendent.md
@@ -31,7 +31,7 @@ await git.isDescendent({ dir: '$input((/))', oid, ancestor, depth: $input((-1)) 
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/isDescendent.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/isDescendent.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/listBranches.md
+++ b/website/versioned_docs/version-0.70.7/listBranches.md
@@ -35,7 +35,7 @@ console.log(remoteBranches)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/listBranches.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/listBranches.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/listFiles.md
+++ b/website/versioned_docs/version-0.70.7/listFiles.md
@@ -34,7 +34,7 @@ console.log(files)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/listFiles.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/listFiles.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/listRemotes.md
+++ b/website/versioned_docs/version-0.70.7/listRemotes.md
@@ -26,7 +26,7 @@ console.log(remotes)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/listRemotes.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/listRemotes.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/listTags.md
+++ b/website/versioned_docs/version-0.70.7/listTags.md
@@ -26,7 +26,7 @@ console.log(tags)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/listTags.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/listTags.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/log.md
+++ b/website/versioned_docs/version-0.70.7/log.md
@@ -55,7 +55,7 @@ console.log(commits)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/log.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/log.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/merge.md
+++ b/website/versioned_docs/version-0.70.7/merge.md
@@ -56,7 +56,7 @@ console.log(m)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/merge.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/merge.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/packObjects.md
+++ b/website/versioned_docs/version-0.70.7/packObjects.md
@@ -41,7 +41,7 @@ console.log(packfile)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/packObjects.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/packObjects.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/pull.md
+++ b/website/versioned_docs/version-0.70.7/pull.md
@@ -48,7 +48,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/pull.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/pull.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/push.md
+++ b/website/versioned_docs/version-0.70.7/push.md
@@ -67,7 +67,7 @@ console.log(pushResponse)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/push.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/push.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/readObject.md
+++ b/website/versioned_docs/version-0.70.7/readObject.md
@@ -94,7 +94,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readObject.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readObject.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/remove.md
+++ b/website/versioned_docs/version-0.70.7/remove.md
@@ -29,7 +29,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/remove.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/remove.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/resetIndex.md
+++ b/website/versioned_docs/version-0.70.7/resetIndex.md
@@ -30,7 +30,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/resetIndex.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/resetIndex.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/resolveRef.md
+++ b/website/versioned_docs/version-0.70.7/resolveRef.md
@@ -30,7 +30,7 @@ console.log(currentBranch)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/resolveRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/resolveRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/sign.md
+++ b/website/versioned_docs/version-0.70.7/sign.md
@@ -54,7 +54,7 @@ console.log(sha)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/sign.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/sign.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/status.md
+++ b/website/versioned_docs/version-0.70.7/status.md
@@ -43,7 +43,7 @@ console.log(status)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/status.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/status.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/statusMatrix.md
+++ b/website/versioned_docs/version-0.70.7/statusMatrix.md
@@ -139,7 +139,7 @@ For reference, here are all possible combinations:
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/statusMatrix.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/statusMatrix.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/tag.md
+++ b/website/versioned_docs/version-0.70.7/tag.md
@@ -29,7 +29,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/tag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/tag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/verify.md
+++ b/website/versioned_docs/version-0.70.7/verify.md
@@ -49,7 +49,7 @@ console.log(keyids)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/verify.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/verify.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/version.md
+++ b/website/versioned_docs/version-0.70.7/version.md
@@ -24,7 +24,7 @@ console.log(git.version())
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/version.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/version.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/walkBeta1.md
+++ b/website/versioned_docs/version-0.70.7/walkBeta1.md
@@ -210,7 +210,7 @@ However you could use a custom function to traverse children serially or use a g
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/walkBeta1.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/walkBeta1.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/walkBeta2.md
+++ b/website/versioned_docs/version-0.70.7/walkBeta2.md
@@ -245,7 +245,7 @@ However you could use a custom function to traverse children serially or use a g
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/walkBeta2.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/walkBeta2.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/writeObject.md
+++ b/website/versioned_docs/version-0.70.7/writeObject.md
@@ -65,7 +65,7 @@ console.log('tag', oid)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeObject.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeObject.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.70.7/writeRef.md
+++ b/website/versioned_docs/version-0.70.7/writeRef.md
@@ -41,7 +41,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/checkout.md
+++ b/website/versioned_docs/version-0.74.0/checkout.md
@@ -43,7 +43,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/checkout.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/checkout.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/clone.md
+++ b/website/versioned_docs/version-0.74.0/clone.md
@@ -55,7 +55,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/clone.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/clone.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/fetch.md
+++ b/website/versioned_docs/version-0.74.0/fetch.md
@@ -71,7 +71,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/fetch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/fetch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/pull.md
+++ b/website/versioned_docs/version-0.74.0/pull.md
@@ -50,7 +50,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/pull.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/pull.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/push.md
+++ b/website/versioned_docs/version-0.74.0/push.md
@@ -68,7 +68,7 @@ console.log(pushResponse)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/push.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/push.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/readBlob.md
+++ b/website/versioned_docs/version-0.74.0/readBlob.md
@@ -44,7 +44,7 @@ console.log(blob.toString('utf8'))
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readBlob.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readBlob.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/readCommit.md
+++ b/website/versioned_docs/version-0.74.0/readCommit.md
@@ -61,7 +61,7 @@ console.log(commit)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readCommit.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readCommit.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/readObject.md
+++ b/website/versioned_docs/version-0.74.0/readObject.md
@@ -99,7 +99,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readObject.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readObject.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/readTag.md
+++ b/website/versioned_docs/version-0.74.0/readTag.md
@@ -46,7 +46,7 @@ type TagObject = {
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/readTree.md
+++ b/website/versioned_docs/version-0.74.0/readTree.md
@@ -43,7 +43,7 @@ type TreeEntry = {
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readTree.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readTree.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/writeBlob.md
+++ b/website/versioned_docs/version-0.74.0/writeBlob.md
@@ -32,7 +32,7 @@ console.log('oid', oid) // should be 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeBlob.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeBlob.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/writeCommit.md
+++ b/website/versioned_docs/version-0.74.0/writeCommit.md
@@ -41,7 +41,7 @@ type CommitObject = {
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeCommit.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeCommit.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/writeObject.md
+++ b/website/versioned_docs/version-0.74.0/writeObject.md
@@ -70,7 +70,7 @@ console.log('tag', oid)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeObject.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeObject.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/writeTag.md
+++ b/website/versioned_docs/version-0.74.0/writeTag.md
@@ -62,7 +62,7 @@ console.log('tag', oid)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.74.0/writeTree.md
+++ b/website/versioned_docs/version-0.74.0/writeTree.md
@@ -33,7 +33,7 @@ type TreeEntry = {
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/writeTree.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/writeTree.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.75.0/addNote.md
+++ b/website/versioned_docs/version-0.75.0/addNote.md
@@ -31,7 +31,7 @@ Add or update an object note
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/addNote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/addNote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.75.0/listNotes.md
+++ b/website/versioned_docs/version-0.75.0/listNotes.md
@@ -20,7 +20,7 @@ List all the object notes
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/listNotes.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/listNotes.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.75.0/readNote.md
+++ b/website/versioned_docs/version-0.75.0/readNote.md
@@ -21,7 +21,7 @@ Read the contents of a note
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/readNote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/readNote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.75.0/removeNote.md
+++ b/website/versioned_docs/version-0.75.0/removeNote.md
@@ -29,7 +29,7 @@ Remove an object note
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/removeNote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/removeNote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.76.0/statusMatrix.md
+++ b/website/versioned_docs/version-0.76.0/statusMatrix.md
@@ -140,7 +140,7 @@ For reference, here are all possible combinations:
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/statusMatrix.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/statusMatrix.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.77.0/push.md
+++ b/website/versioned_docs/version-0.77.0/push.md
@@ -69,7 +69,7 @@ console.log(pushResponse)
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/push.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/push.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.78.0/checkout.md
+++ b/website/versioned_docs/version-0.78.0/checkout.md
@@ -44,7 +44,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/checkout.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/checkout.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.78.0/clone.md
+++ b/website/versioned_docs/version-0.78.0/clone.md
@@ -56,7 +56,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/clone.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/clone.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.78.0/fastCheckout.md
+++ b/website/versioned_docs/version-0.78.0/fastCheckout.md
@@ -56,7 +56,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/fastCheckout.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/fastCheckout.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-0.78.0/pull.md
+++ b/website/versioned_docs/version-0.78.0/pull.md
@@ -51,7 +51,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/commands/pull.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/commands/pull.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/add.md
+++ b/website/versioned_docs/version-1.x/add.md
@@ -40,7 +40,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/add.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/add.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/addNote.md
+++ b/website/versioned_docs/version-1.x/addNote.md
@@ -47,7 +47,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/addNote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/addNote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/addRemote.md
+++ b/website/versioned_docs/version-1.x/addRemote.md
@@ -46,7 +46,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/addRemote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/addRemote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/annotatedTag.md
+++ b/website/versioned_docs/version-1.x/annotatedTag.md
@@ -59,7 +59,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/annotatedTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/annotatedTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/branch.md
+++ b/website/versioned_docs/version-1.x/branch.md
@@ -40,7 +40,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/branch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/branch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/checkout.md
+++ b/website/versioned_docs/version-1.x/checkout.md
@@ -27,11 +27,11 @@ If the branch already exists it will check out that branch. Otherwise, it will c
 Example Code:
 
 ```js live
-// switch to the master branch
+// switch to the main branch
 await git.checkout({
   fs,
   dir: '/tutorial',
-  ref: 'master'
+  ref: 'main'
 })
 console.log('done')
 ```
@@ -77,7 +77,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/checkout.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/checkout.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/clone.md
+++ b/website/versioned_docs/version-1.x/clone.md
@@ -64,7 +64,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/clone.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/clone.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/commit.md
+++ b/website/versioned_docs/version-1.x/commit.md
@@ -64,7 +64,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/commit.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/commit.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/currentBranch.md
+++ b/website/versioned_docs/version-1.x/currentBranch.md
@@ -7,14 +7,14 @@ original_id: currentBranch
 
 Get the name of the branch currently pointed to by .git/HEAD
 
-| param          | type [= default]                | description                                                                                                   |
-| -------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                        | a file system implementation                                                                                  |
-| dir            | string                          | The [working tree](dir-vs-gitdir.md) directory path                                                           |
-| **gitdir**     | string = join(dir,'.git')       | The [git directory](dir-vs-gitdir.md) path                                                                    |
-| fullname       | boolean = false                 | Return the full path (e.g. "refs/heads/master") instead of the abbreviated form.                              |
-| test           | boolean = false                 | If the current branch doesn't actually exist (such as 'master' right after git init) then return `undefined`. |
-| return         | Promise\<(string &#124; void)\> | The name of the current branch or undefined if the HEAD is detached.                                          |
+| param          | type [= default]                | description                                                                                          |
+| -------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                        | a file system implementation                                                                         |
+| dir            | string                          | The [working tree](dir-vs-gitdir.md) directory path                                                  |
+| **gitdir**     | string = join(dir,'.git')       | The [git directory](dir-vs-gitdir.md) path                                                           |
+| fullname       | boolean = false                 | Return the full path (e.g. "refs/heads/main") instead of the abbreviated form.                       |
+| test           | boolean = false                 | If the current branch doesn't actually exist (such as right after git init) then return `undefined`. |
+| return         | Promise\<(string &#124; void)\> | The name of the current branch or undefined if the HEAD is detached.                                 |
 
 Example Code:
 
@@ -45,7 +45,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/currentBranch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/currentBranch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/deleteBranch.md
+++ b/website/versioned_docs/version-1.x/deleteBranch.md
@@ -41,7 +41,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/deleteBranch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/deleteBranch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/deleteRef.md
+++ b/website/versioned_docs/version-1.x/deleteRef.md
@@ -39,7 +39,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/deleteRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/deleteRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/deleteRemote.md
+++ b/website/versioned_docs/version-1.x/deleteRemote.md
@@ -39,7 +39,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/deleteRemote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/deleteRemote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/deleteTag.md
+++ b/website/versioned_docs/version-1.x/deleteTag.md
@@ -39,7 +39,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/deleteTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/deleteTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/expandOid.md
+++ b/website/versioned_docs/version-1.x/expandOid.md
@@ -39,7 +39,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/expandOid.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/expandOid.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/expandRef.md
+++ b/website/versioned_docs/version-1.x/expandRef.md
@@ -18,7 +18,7 @@ Expand an abbreviated ref to its full name
 Example Code:
 
 ```js live
-let fullRef = await git.expandRef({ fs, dir: '/tutorial', ref: 'master'})
+let fullRef = await git.expandRef({ fs, dir: '/tutorial', ref: 'main'})
 console.log(fullRef)
 ```
 
@@ -39,7 +39,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/expandRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/expandRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/fastForward.md
+++ b/website/versioned_docs/version-1.x/fastForward.md
@@ -34,7 +34,7 @@ await git.fastForward({
   fs,
   http,
   dir: '/tutorial',
-  ref: 'master',
+  ref: 'main',
   singleBranch: true
 })
 console.log('done')
@@ -57,7 +57,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/fastForward.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/fastForward.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/fetch.md
+++ b/website/versioned_docs/version-1.x/fetch.md
@@ -38,7 +38,7 @@ The object returned has the following schema:
 
 ```ts
 type FetchResult = {
-  defaultBranch: string | null; // The branch that is cloned if no branch is specified (typically "master")
+  defaultBranch: string | null; // The branch that is cloned if no branch is specified
   fetchHead: string | null; // The SHA-1 object id of the fetched head commit
   fetchHeadDescription: string | null; // a textual description of the branch that was fetched
   headers?: Object<string, string>; // The HTTP response headers returned by the git server
@@ -55,7 +55,7 @@ let result = await git.fetch({
   dir: '/tutorial',
   corsProxy: 'https://cors.isomorphic-git.org',
   url: 'https://github.com/isomorphic-git/isomorphic-git',
-  ref: 'master',
+  ref: 'main',
   depth: 1,
   singleBranch: true,
   tags: false
@@ -80,7 +80,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/fetch.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/fetch.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/findMergeBase.md
+++ b/website/versioned_docs/version-1.x/findMergeBase.md
@@ -31,7 +31,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/findMergeBase.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/findMergeBase.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/findRoot.md
+++ b/website/versioned_docs/version-1.x/findRoot.md
@@ -43,7 +43,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/findRoot.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/findRoot.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/getConfig.md
+++ b/website/versioned_docs/version-1.x/getConfig.md
@@ -48,7 +48,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/getConfig.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/getConfig.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/getConfigAll.md
+++ b/website/versioned_docs/version-1.x/getConfigAll.md
@@ -36,7 +36,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/getConfigAll.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/getConfigAll.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/getRemoteInfo.md
+++ b/website/versioned_docs/version-1.x/getRemoteInfo.md
@@ -63,7 +63,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/getRemoteInfo.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/getRemoteInfo.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/hashBlob.md
+++ b/website/versioned_docs/version-1.x/hashBlob.md
@@ -53,7 +53,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/hashBlob.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/hashBlob.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/indexPack.md
+++ b/website/versioned_docs/version-1.x/indexPack.md
@@ -51,7 +51,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/indexPack.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/indexPack.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/init.md
+++ b/website/versioned_docs/version-1.x/init.md
@@ -7,13 +7,14 @@ original_id: init
 
 Initialize a new repository
 
-| param          | type [= default]          | description                                                   |
-| -------------- | ------------------------- | ------------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                  | a file system client                                          |
-| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path           |
-| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path                    |
-| bare           | boolean = false           | Initialize a bare repository                                  |
-| return         | Promise\<void\>           | Resolves successfully when filesystem operations are complete |
+| param          | type [= default]          | description                                                                       |
+| -------------- | ------------------------- | --------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                  | a file system client                                                              |
+| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path                               |
+| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path                                        |
+| bare           | boolean = false           | Initialize a bare repository                                                      |
+| defaultBranch  | string = 'master'         | The name of the default branch (might be changed to a required argument in 2.0.0) |
+| return         | Promise\<void\>           | Resolves successfully when filesystem operations are complete                     |
 
 Example Code:
 
@@ -39,7 +40,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/init.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/init.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/isDescendent.md
+++ b/website/versioned_docs/version-1.x/isDescendent.md
@@ -20,7 +20,7 @@ Check whether a git commit is descended from another
 Example Code:
 
 ```js live
-let oid = await git.resolveRef({ fs, dir: '/tutorial', ref: 'master' })
+let oid = await git.resolveRef({ fs, dir: '/tutorial', ref: 'main' })
 let ancestor = await git.resolveRef({ fs, dir: '/tutorial', ref: 'v0.20.0' })
 console.log(oid, ancestor)
 await git.isDescendent({ fs, dir: '/tutorial', oid, ancestor, depth: -1 })
@@ -43,7 +43,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/isDescendent.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/isDescendent.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/listBranches.md
+++ b/website/versioned_docs/version-1.x/listBranches.md
@@ -47,7 +47,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/listBranches.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/listBranches.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/listFiles.md
+++ b/website/versioned_docs/version-1.x/listFiles.md
@@ -46,7 +46,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/listFiles.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/listFiles.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/listNotes.md
+++ b/website/versioned_docs/version-1.x/listNotes.md
@@ -32,7 +32,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/listNotes.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/listNotes.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/listRemotes.md
+++ b/website/versioned_docs/version-1.x/listRemotes.md
@@ -38,7 +38,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/listRemotes.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/listRemotes.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/listTags.md
+++ b/website/versioned_docs/version-1.x/listTags.md
@@ -38,7 +38,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/listTags.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/listTags.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/log.md
+++ b/website/versioned_docs/version-1.x/log.md
@@ -55,7 +55,7 @@ let commits = await git.log({
   fs,
   dir: '/tutorial',
   depth: 5,
-  ref: 'master'
+  ref: 'main'
 })
 console.log(commits)
 ```
@@ -77,7 +77,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/log.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/log.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/merge.md
+++ b/website/versioned_docs/version-1.x/merge.md
@@ -59,8 +59,8 @@ Example Code:
 let m = await git.merge({
   fs,
   dir: '/tutorial',
-  ours: 'master',
-  theirs: 'remotes/origin/master'
+  ours: 'main',
+  theirs: 'remotes/origin/main'
 })
 console.log(m)
 ```
@@ -82,7 +82,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/merge.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/merge.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/packObjects.md
+++ b/website/versioned_docs/version-1.x/packObjects.md
@@ -54,7 +54,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/packObjects.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/packObjects.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/pull.md
+++ b/website/versioned_docs/version-1.x/pull.md
@@ -46,7 +46,7 @@ await git.pull({
   fs,
   http,
   dir: '/tutorial',
-  ref: 'master',
+  ref: 'main',
   singleBranch: true
 })
 console.log('done')
@@ -69,7 +69,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/pull.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/pull.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/push.md
+++ b/website/versioned_docs/version-1.x/push.md
@@ -60,7 +60,7 @@ let pushResult = await git.push({
   http,
   dir: '/tutorial',
   remote: 'origin',
-  ref: 'master',
+  ref: 'main',
   onAuth: () => ({ username: process.env.GITHUB_TOKEN }),
 })
 console.log(pushResult)
@@ -83,7 +83,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/push.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/push.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/readBlob.md
+++ b/website/versioned_docs/version-1.x/readBlob.md
@@ -28,8 +28,8 @@ type ReadBlobResult = {
 Example Code:
 
 ```js live
-// Get the contents of 'README.md' in the master branch.
-let commitOid = await git.resolveRef({ fs, dir: '/tutorial', ref: 'master' })
+// Get the contents of 'README.md' in the main branch.
+let commitOid = await git.resolveRef({ fs, dir: '/tutorial', ref: 'main' })
 console.log(commitOid)
 let { blob } = await git.readBlob({
   fs,
@@ -57,7 +57,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/readBlob.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/readBlob.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/readCommit.md
+++ b/website/versioned_docs/version-1.x/readCommit.md
@@ -50,7 +50,7 @@ Example Code:
 
 ```js live
 // Read a commit object
-let sha = await git.resolveRef({ fs, dir: '/tutorial', ref: 'master' })
+let sha = await git.resolveRef({ fs, dir: '/tutorial', ref: 'main' })
 console.log(sha)
 let commit = await git.readCommit({ fs, dir: '/tutorial', oid: sha })
 console.log(commit)
@@ -73,7 +73,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/readCommit.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/readCommit.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/readNote.md
+++ b/website/versioned_docs/version-1.x/readNote.md
@@ -33,7 +33,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/readNote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/readNote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/readObject.md
+++ b/website/versioned_docs/version-1.x/readObject.md
@@ -253,7 +253,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/readObject.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/readObject.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/readTag.md
+++ b/website/versioned_docs/version-1.x/readTag.md
@@ -60,7 +60,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/readTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/readTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/readTree.md
+++ b/website/versioned_docs/version-1.x/readTree.md
@@ -59,7 +59,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/readTree.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/readTree.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/remove.md
+++ b/website/versioned_docs/version-1.x/remove.md
@@ -41,7 +41,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/remove.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/remove.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/removeNote.md
+++ b/website/versioned_docs/version-1.x/removeNote.md
@@ -45,7 +45,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/removeNote.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/removeNote.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/resetIndex.md
+++ b/website/versioned_docs/version-1.x/resetIndex.md
@@ -42,7 +42,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/resetIndex.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/resetIndex.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/resolveRef.md
+++ b/website/versioned_docs/version-1.x/resolveRef.md
@@ -42,7 +42,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/resolveRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/resolveRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/setConfig.md
+++ b/website/versioned_docs/version-1.x/setConfig.md
@@ -66,7 +66,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/setConfig.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/setConfig.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/status.md
+++ b/website/versioned_docs/version-1.x/status.md
@@ -57,7 +57,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/status.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/status.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/statusMatrix.md
+++ b/website/versioned_docs/version-1.x/statusMatrix.md
@@ -163,7 +163,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/statusMatrix.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/statusMatrix.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/tag.md
+++ b/website/versioned_docs/version-1.x/tag.md
@@ -41,7 +41,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/tag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/tag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/version.md
+++ b/website/versioned_docs/version-1.x/version.md
@@ -37,7 +37,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/version.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/version.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/walk.md
+++ b/website/versioned_docs/version-1.x/walk.md
@@ -281,7 +281,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/walk.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/walk.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/writeBlob.md
+++ b/website/versioned_docs/version-1.x/writeBlob.md
@@ -45,7 +45,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/writeBlob.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/writeBlob.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/writeCommit.md
+++ b/website/versioned_docs/version-1.x/writeCommit.md
@@ -55,7 +55,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/writeCommit.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/writeCommit.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/writeObject.md
+++ b/website/versioned_docs/version-1.x/writeObject.md
@@ -134,7 +134,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/writeObject.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/writeObject.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/writeRef.md
+++ b/website/versioned_docs/version-1.x/writeRef.md
@@ -55,7 +55,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/writeRef.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/writeRef.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/writeTag.md
+++ b/website/versioned_docs/version-1.x/writeTag.md
@@ -77,7 +77,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/writeTag.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/writeTag.js';
   }
 })();
 </script>

--- a/website/versioned_docs/version-1.x/writeTree.md
+++ b/website/versioned_docs/version-1.x/writeTree.md
@@ -49,7 +49,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/writeTree.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/writeTree.js';
   }
 })();
 </script>


### PR DESCRIPTION
Yeah I know. Technically I added the defaultBranch param in the _previous_ commit to the default branch. This is actually a cleanup PR fixing links on the website. But I wanted to trigger a normal release going through the PR workflow.

## I'm adding a parameter to an existing command X:

- [x] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [x] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat(X): Added 'bar' parameter"
