### PR TITLE
chore: fix generate-docs.js to use 'main' instead of 'master'

### DIFF
--- a/__tests__/__helpers__/can-i-skip-tests.js
+++ b/__tests__/__helpers__/can-i-skip-tests.js
@@ -2,7 +2,7 @@
 var whitelist = process.argv.slice(2)
 var { execSync } = require('child_process')
 
-var result = execSync('git diff master --name-only', { encoding: 'utf8' })
+var result = execSync('git diff main --name-only', { encoding: 'utf8' })
 
 var files = result.trim().split('\n')
 

--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -291,7 +291,7 @@ console.log('done')
 (function rewriteEditLink() {
   const el = document.querySelector('a.edit-page-link.button');
   if (el) {
-    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/master/src/api/${obj.name}.js';
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/${obj.name}.js';
   }
 })();
 </script>`

--- a/__tests__/__helpers__/karma-translate-browser.js
+++ b/__tests__/__helpers__/karma-translate-browser.js
@@ -7,7 +7,7 @@ module.exports = function translateBrowser(fullname) {
   } else if (fullname.startsWith('Mobile Safari')) {
     return 'sl_ios_safari'
   } else if (fullname.startsWith('Chrome Mobile')) {
-    return 'sl_android_chrome'
+    return 'bs_android_chrome'
   } else if (fullname.startsWith('Safari')) {
     return 'sl_safari'
   } else if (fullname.startsWith('Chrome')) {

--- a/__tests__/__helpers__/set-TRAVIS_PULL_REQUEST_SHA.js
+++ b/__tests__/__helpers__/set-TRAVIS_PULL_REQUEST_SHA.js
@@ -4,7 +4,7 @@ if (!process.env.TRAVIS_PULL_REQUEST_SHA) {
   // I'm trying not to rely on isomorphic-git here since that's the thing being tested.
   const log = execSync('git log --pretty=%P -n 1', { encoding: 'utf8' })
   const parents = log.split(' ').map(x => x.trim())
-  // parents[0] === master branch
+  // parents[0] === main branch
   // parents[1] === pr branch
   process.env.TRAVIS_PULL_REQUEST_SHA = parents[1]
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -79,7 +79,7 @@ module.exports = function(config) {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'macOS 10.15',
-        version: '13.0',
+        version: '13.1',
       },
       sl_ios_safari: {
         base: 'SauceLabs',


### PR DESCRIPTION
Slipped by me the first go-around because that script is in the `__tests__` directory.