### PR TITLE
chore(build): adds nps format command, per package json

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -33,6 +33,9 @@ module.exports = {
       default: `eslint .`,
       fix: optional(`eslint --fix .`),
     },
+    format: {
+      default: series.nps('lint.fix'),
+    },
     watch: {
       default: concurrent.nps('watch.rollup', 'watch.jest'),
       rollup: runInNewWindow('rollup -cw'),


### PR DESCRIPTION
I noticed that `package.json` had a `format: nps format` command, but `nps` did not have a format command itself. This PR adds that `nps` command

Closes #1174

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"
