### PR TITLE
chore(lint): ran nps lint.fix

### DIFF
--- a/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
+++ b/__tests__/__helpers__/FixtureFS/makeBrowserFS.js
@@ -1,4 +1,5 @@
 const { FileSystem } = require('isomorphic-git/internal-apis')
+
 const pify = require('pify')
 
 let browserFS = null

--- a/__tests__/__helpers__/fix-version-number.js
+++ b/__tests__/__helpers__/fix-version-number.js
@@ -1,7 +1,8 @@
 #! /usr/bin/env node
+var pkg = require('../../package.json')
+
 var replace = require('replace-in-file')
 
-var pkg = require('../../package.json')
 var options = {
   files: ['src/**/*.js'],
   from: /0\.0\.0-development/g,

--- a/__tests__/__helpers__/generate-docs.js
+++ b/__tests__/__helpers__/generate-docs.js
@@ -1,10 +1,10 @@
 const fs = require('fs')
 const path = require('path')
 
+const git = require('../..')
+
 const jsdoc = require('jsdoc-api')
 const table = require('markdown-table')
-
-const git = require('../..')
 
 const dir = path.join(__dirname, '..', '..')
 const thisFile = path.relative(dir, __filename).replace(/\\/g, '/')

--- a/__tests__/test-log.js
+++ b/__tests__/test-log.js
@@ -1,8 +1,9 @@
 /* eslint-env node, browser, jasmine */
-const { pgp } = require('@isomorphic-git/pgp-plugin')
 const { log } = require('isomorphic-git')
 
 const { makeFixture } = require('./__helpers__/FixtureFS.js')
+
+const { pgp } = require('@isomorphic-git/pgp-plugin')
 
 describe('log', () => {
   it('HEAD', async () => {

--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 const fs = require('fs')
 
-const minimisted = require('minimisted')
-
 const git = require('.')
 
 const http = require('./http/node')
+
+const minimisted = require('minimisted')
 
 // This really isn't much of a CLI. It's mostly for testing.
 // But it's very versatile and works surprisingly well.

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,8 +1,8 @@
 // package-scripts.js is a convention used by the 'nps' utility
 // It's like package.json scripts, but more flexible.
-const { concurrent, series, runInNewWindow } = require('nps-utils')
-
 const pkg = require('./package.json')
+
+const { concurrent, series, runInNewWindow } = require('nps-utils')
 
 const builtFiles = pkg.files.filter(f => !['cli.js'].includes(f))
 

--- a/src/api/writeRef.js
+++ b/src/api/writeRef.js
@@ -1,5 +1,4 @@
 // @ts-check
-import cleanGitRef from 'clean-git-ref'
 
 import { AlreadyExistsError } from '../errors/AlreadyExistsError.js'
 import { InvalidRefNameError } from '../errors/InvalidRefNameError.js'
@@ -7,6 +6,8 @@ import { GitRefManager } from '../managers/GitRefManager.js'
 import { FileSystem } from '../models/FileSystem.js'
 import { assertParameter } from '../utils/assertParameter.js'
 import { join } from '../utils/join.js'
+
+import cleanGitRef from 'clean-git-ref'
 
 /**
  * Write a ref which refers to the specified SHA-1 object id, or a symbolic ref which refers to the specified ref.

--- a/src/commands/addRemote.js
+++ b/src/commands/addRemote.js
@@ -1,11 +1,11 @@
 // @ts-check
 import '../typedefs.js'
 
-import cleanGitRef from 'clean-git-ref'
-
 import { AlreadyExistsError } from '../errors/AlreadyExistsError.js'
 import { InvalidRefNameError } from '../errors/InvalidRefNameError.js'
 import { GitConfigManager } from '../managers/GitConfigManager.js'
+
+import cleanGitRef from 'clean-git-ref'
 
 /**
  * @param {object} args

--- a/src/commands/branch.js
+++ b/src/commands/branch.js
@@ -1,11 +1,11 @@
 // @ts-check
 import '../typedefs.js'
 
-import cleanGitRef from 'clean-git-ref'
-
 import { AlreadyExistsError } from '../errors/AlreadyExistsError.js'
 import { InvalidRefNameError } from '../errors/InvalidRefNameError.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
+
+import cleanGitRef from 'clean-git-ref'
 
 /**
  * Create a branch

--- a/src/commands/pack.js
+++ b/src/commands/pack.js
@@ -1,10 +1,10 @@
-import Hash from 'sha.js/sha1.js'
-
 import { types } from '../commands/types.js'
 import { _readObject as readObject } from '../storage/readObject.js'
 import { deflate } from '../utils/deflate.js'
 import { join } from '../utils/join.js'
 import { padHex } from '../utils/padHex.js'
+
+import Hash from 'sha.js/sha1.js'
 
 /**
  * @param {object} args

--- a/src/http/node/index.js
+++ b/src/http/node/index.js
@@ -1,9 +1,9 @@
-import get from 'simple-get'
-
 import '../../typedefs-http.js'
 import { asyncIteratorToStream } from '../../utils/asyncIteratorToStream.js'
 import { collect } from '../../utils/collect.js'
 import { fromNodeStream } from '../../utils/fromNodeStream.js'
+
+import get from 'simple-get'
 
 /**
  * HttpClient

--- a/src/managers/GitIgnoreManager.js
+++ b/src/managers/GitIgnoreManager.js
@@ -1,8 +1,8 @@
-import ignore from 'ignore'
-
 import { basename } from '../utils/basename.js'
 import { dirname } from '../utils/dirname.js'
 import { join } from '../utils/join.js'
+
+import ignore from 'ignore'
 
 // I'm putting this in a Manager because I reckon it could benefit
 // from a LOT of cacheing.

--- a/src/managers/GitIndexManager.js
+++ b/src/managers/GitIndexManager.js
@@ -1,8 +1,9 @@
 // import LockManager from 'travix-lock-manager'
-import AsyncLock from 'async-lock'
 
 import { GitIndex } from '../models/GitIndex.js'
 import { compareStats } from '../utils/compareStats.js'
+
+import AsyncLock from 'async-lock'
 
 // import Lock from '../utils.js'
 

--- a/src/managers/GitShallowManager.js
+++ b/src/managers/GitShallowManager.js
@@ -1,6 +1,6 @@
-import AsyncLock from 'async-lock'
-
 import { join } from '../utils/join.js'
+
+import AsyncLock from 'async-lock'
 
 let lock = null
 

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -1,7 +1,7 @@
-import pify from 'pify'
-
 import { compareStrings } from '../utils/compareStrings.js'
 import { dirname } from '../utils/dirname.js'
+
+import pify from 'pify'
 
 /**
  * This is just a collection of helper functions really. At least that's how it started.

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -1,6 +1,3 @@
-import crc32 from 'crc-32'
-import applyDelta from 'git-apply-delta'
-
 import { InternalError } from '../errors/InternalError.js'
 import { BufferCursor } from '../utils/BufferCursor.js'
 import { listpack } from '../utils/git-list-pack.js'
@@ -8,6 +5,9 @@ import { inflate } from '../utils/inflate.js'
 import { shasum } from '../utils/shasum.js'
 
 import { GitObject } from './GitObject'
+
+import crc32 from 'crc-32'
+import applyDelta from 'git-apply-delta'
 
 function decodeVarInt(reader) {
   const bytes = []

--- a/src/utils/git-list-pack.js
+++ b/src/utils/git-list-pack.js
@@ -1,10 +1,11 @@
 // My version of git-list-pack - roughly 15x faster than the original
 // It's used slightly differently - instead of returning a through stream it wraps a stream.
 // (I tried to make it API identical, but that ended up being 2x slower than this version.)
-import pako from 'pako'
 
 import { InternalError } from '../errors/InternalError.js'
 import { StreamReader } from '../utils/StreamReader.js'
+
+import pako from 'pako'
 
 export async function listpack(stream, onData) {
   const reader = new StreamReader(stream)

--- a/src/utils/shasum.js
+++ b/src/utils/shasum.js
@@ -1,7 +1,7 @@
 /* eslint-env node, browser */
-import Hash from 'sha.js/sha1.js'
-
 import { toHex } from './toHex.js'
+
+import Hash from 'sha.js/sha1.js'
 
 let supportsSubtleSHA1 = null
 


### PR DESCRIPTION
Currently, when I run `yarn nps lint`, I get about 20 errors:

<details>
  <summary>Linting errors</summary>
```
​C:\Users\crutchcorn\git\GitGui\isomorphic-git [renameBranch ≡]
λ  yarn nps lint
yarn run v1.22.4
$ C:\Users\crutchcorn\git\GitGui\isomorphic-git\node_modules\.bin\nps lint
nps is executing `lint` : eslint .

C:\Users\crutchcorn\git\GitGui\isomorphic-git\cli.js
  4:20  error  `minimisted` import should occur after import of `./http/node`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\package-scripts.js
  5:13  error  `./package.json` import should occur before import of `nps-utils`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\api\writeRef.js
  2:1  error  `clean-git-ref` import should occur after import of `../utils/join.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\commands\addRemote.js
  4:1  error  `clean-git-ref` import should occur after import of `../managers/GitConfigManager.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\commands\branch.js
  4:1  error  `clean-git-ref` import should occur after import of `../managers/GitRefManager.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\commands\pack.js
  1:1  error  `sha.js/sha1.js` import should occur after import of `../utils/padHex.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\http\node\index.js
  1:1  error  `simple-get` import should occur after import of `../../utils/fromNodeStream.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\managers\GitIgnoreManager.js
  1:1  error  `ignore` import should occur after import of `../utils/join.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\managers\GitIndexManager.js
  2:1  error  `async-lock` import should occur after import of `../utils/compareStats.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\managers\GitShallowManager.js
  3:1  error  `../utils/join.js` import should occur before import of `async-lock`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\models\FileSystem.js
  1:1  error  `pify` import should occur after import of `../utils/dirname.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\models\GitPackIndex.js
  1:1  error  `crc-32` import should occur after import of `./GitObject`           import/order
  2:1  error  `git-apply-delta` import should occur after import of `./GitObject`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\utils\git-list-pack.js
  4:1  error  `pako` import should occur after import of `../utils/StreamReader.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\src\utils\shasum.js
  4:1  error  `./toHex.js` import should occur before import of `sha.js/sha1.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\__tests__\test-log.js
  2:17  error  There should be at least one empty line between import groups                                  import/order
  2:17  error  `@isomorphic-git/pgp-plugin` import should occur after import of `./__helpers__/FixtureFS.js`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\__tests__\__helpers__\fix-version-number.js
  4:11  error  `../../package.json` import should occur before import of `replace-in-file`  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\__tests__\__helpers__\FixtureFS\makeBrowserFS.js
  1:24  error  There should be at least one empty line between import groups  import/order

C:\Users\crutchcorn\git\GitGui\isomorphic-git\__tests__\__helpers__\generate-docs.js
  7:13  error  `../..` import should occur before import of `jsdoc-api`  import/order

✖ 20 problems (20 errors, 0 warnings)
  19 errors and 0 warnings potentially fixable with the `--fix` option.

The script called "lint" which runs "eslint ." failed with exit code 1 https://github.com/sezna/nps/blob/v5.9.8/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
</details>

This PR fixes those errors simply by running `yarn nps lint.fix` on a local development environment.

However, when formatting has been ran on my other PRs, I've noticed that CI flags the newly formatted code as incorrect. Seems there may be a mismatch for local dev vs. CI linting?