### PR TITLE
perf: replace git-apply-delta with hand-rolled code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3804,11 +3804,6 @@
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
-    "base64-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
-    },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
@@ -4059,15 +4054,6 @@
       "optional": true,
       "requires": {
         "hoek": "2.x.x"
-      }
-    },
-    "bops": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.7.tgz",
-      "integrity": "sha1-tKClqDmkBkVK8P4FqLkaenZqVOI=",
-      "requires": {
-        "base64-js": "0.0.2",
-        "to-utf8": "0.0.1"
       }
     },
     "bottleneck": {
@@ -9476,15 +9462,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "git-apply-delta": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/git-apply-delta/-/git-apply-delta-0.0.7.tgz",
-      "integrity": "sha1-+3auFEVA15RAtSsx3gPmPJk8chk=",
-      "requires": {
-        "bops": "~0.0.6",
-        "varint": "0.0.3"
       }
     },
     "git-http-mock-server": {
@@ -22979,11 +22956,6 @@
         }
       }
     },
-    "to-utf8": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -23522,11 +23494,6 @@
       "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
       "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
       "dev": true
-    },
-    "varint": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-0.0.3.tgz",
-      "integrity": "sha1-uCHemwSzizzSL3LBjZSp+3KrNRg="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "clean-git-ref": "^2.0.1",
     "crc-32": "^1.2.0",
     "diff3": "0.0.3",
-    "git-apply-delta": "0.0.7",
     "ignore": "^5.1.4",
     "minimisted": "^2.0.0",
     "pako": "^1.0.10",

--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -1,13 +1,12 @@
 import crc32 from 'crc-32'
-import applyDelta from 'git-apply-delta'
 
 import { InternalError } from '../errors/InternalError.js'
+import { GitObject } from '../models/GitObject'
 import { BufferCursor } from '../utils/BufferCursor.js'
+import { applyDelta } from '../utils/applyDelta.js'
 import { listpack } from '../utils/git-list-pack.js'
 import { inflate } from '../utils/inflate.js'
 import { shasum } from '../utils/shasum.js'
-
-import { GitObject } from './GitObject'
 
 function decodeVarInt(reader) {
   const bytes = []

--- a/src/utils/BufferCursor.js
+++ b/src/utils/BufferCursor.js
@@ -36,6 +36,12 @@ export class BufferCursor {
     return r
   }
 
+  copy(source, start, end) {
+    const r = source.copy(this.buffer, this._start, start, end)
+    this._start += r
+    return r
+  }
+
   readUInt8() {
     const r = this.buffer.readUInt8(this._start)
     this._start += 1

--- a/src/utils/applyDelta.js
+++ b/src/utils/applyDelta.js
@@ -1,0 +1,87 @@
+import { InternalError } from '../errors/InternalError.js'
+import { BufferCursor } from '../utils/BufferCursor.js'
+
+/**
+ * @param {Buffer} delta
+ * @param {Buffer} source
+ * @returns {Buffer}
+ */
+export function applyDelta(delta, source) {
+  const reader = new BufferCursor(delta)
+  const sourceSize = readVarIntLE(reader)
+
+  if (sourceSize !== source.byteLength) {
+    throw new InternalError(
+      `applyDelta expected source buffer to be ${sourceSize} bytes but the provided buffer was ${source.length} bytes`
+    )
+  }
+  const targetSize = readVarIntLE(reader)
+  let target
+
+  const firstOp = readOp(reader, source)
+  // Speed optimization - return raw buffer if it's just single simple copy
+  if (firstOp.byteLength === targetSize) {
+    target = firstOp
+  } else {
+    // Otherwise, allocate a fresh buffer and slices
+    target = Buffer.alloc(targetSize)
+    const writer = new BufferCursor(target)
+    writer.copy(firstOp)
+
+    while (!reader.eof()) {
+      writer.copy(readOp(reader, source))
+    }
+
+    const tell = writer.tell()
+    if (targetSize !== tell) {
+      throw new InternalError(
+        `applyDelta expected target buffer to be ${targetSize} bytes but the resulting buffer was ${tell} bytes`
+      )
+    }
+  }
+  return target
+}
+
+function readVarIntLE(reader) {
+  let result = 0
+  let shift = 0
+  let byte = null
+  do {
+    byte = reader.readUInt8()
+    result |= (byte & 0b01111111) << shift
+    shift += 7
+  } while (byte & 0b10000000)
+  return result
+}
+
+function readCompactLE(reader, flags, size) {
+  let result = 0
+  let shift = 0
+  while (size--) {
+    if (flags & 0b00000001) {
+      result |= reader.readUInt8() << shift
+    }
+    flags >>= 1
+    shift += 8
+  }
+  return result
+}
+
+function readOp(reader, source) {
+  /** @type {number} */
+  const byte = reader.readUInt8()
+  const COPY = 0b10000000
+  const OFFS = 0b00001111
+  const SIZE = 0b01110000
+  if (byte & COPY) {
+    // copy consists of 4 byte offset, 3 byte size (in LE order)
+    const offset = readCompactLE(reader, byte & OFFS, 4)
+    let size = readCompactLE(reader, (byte & SIZE) >> 4, 3)
+    // Yup. They really did this optimization.
+    if (size === 0) size = 0x10000
+    return source.slice(offset, offset + size)
+  } else {
+    // insert
+    return reader.slice(byte)
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,12 +30,6 @@ module.exports = [
         strict: true,
       }),
     ],
-    resolve: {
-      alias: {
-        // 'bops' depends on 0.0.2 but 1.x (used by node-libs-browser) is compatible
-        'base64-js': require.resolve('base64-js'),
-      },
-    },
     module: {
       rules: [
         {


### PR DESCRIPTION
Replaces the `git-apply-delta` dependency with my own code. Shaves a little over a 1KB off the bundle gzip size (68.73KB -> 67.59KB), and eliminates the following direct and indirect dependencies:

- git-apply-delta@0.0.7
- varint@0.0.3
- bops@0.0.7
- to-utf8@0.0.1
- base64-js@0.0.2

Results are mixed as to whether my version is _faster_ but the speed is negligible anyway. 

cloning https://github.com/git/git.git
my git-apply-delta: 10s
old git-apply-delta: 11s
total time: 4 minutes

cloning https://gitlab.com/gitlab-org/gitlab.git
my git-apply-delta: 87s
old git-apply-delta: 79s
total time: 25 minutes


The _real_ reason I did this, is I'm considering implementing xdelta compression so we can generate efficient sized packfiles (which I consider a prerequisite to adding garbage collection), and rather than dive straight into compression, I thought I'd implement decompression first to make sure I know what I'm doing.