### PR TITLE
feat: Get remote tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ docs/getConfig.md
 docs/getConfigAll.md
 docs/getRemoteInfo.md
 docs/getRemoteInfo2.md
+docs/getRemoteTrackingBranch.md
 docs/hashBlob.md
 docs/indexPack.md
 docs/init.md

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ unless there is a major version bump.
 - [getConfigAll](https://isomorphic-git.github.io/docs/getConfigAll.html)
 - [getRemoteInfo](https://isomorphic-git.github.io/docs/getRemoteInfo.html)
 - [getRemoteInfo2](https://isomorphic-git.github.io/docs/getRemoteInfo2.html)
+- [getRemoteTrackingBranch](https://isomorphic-git.github.io/docs/getRemoteTrackingBranch.html)
 - [hashBlob](https://isomorphic-git.github.io/docs/hashBlob.html)
 - [indexPack](https://isomorphic-git.github.io/docs/indexPack.html)
 - [init](https://isomorphic-git.github.io/docs/init.html)

--- a/__tests__/__fixtures__/test-getRemoteTrackingBranch.git/config
+++ b/__tests__/__fixtures__/test-getRemoteTrackingBranch.git/config
@@ -1,0 +1,15 @@
+[core]
+	repositoryformatversion = 0
+	filemode = false
+	bare = true
+	symlinks = false
+	ignorecase = true
+[remote "foo"]
+	url = git@github.com:foo/foo.git
+	fetch = +refs/heads/*:refs/remotes/foo/*
+[remote "bar"]
+	url = git@github.com:bar/bar.git
+	fetch = +refs/heads/*:refs/remotes/bar/*
+[branch "test"]
+	remote = foo
+	merge = refs/heads/test

--- a/__tests__/test-exports.js
+++ b/__tests__/test-exports.js
@@ -34,6 +34,7 @@ describe('exports', () => {
         "getConfigAll",
         "getRemoteInfo",
         "getRemoteInfo2",
+        "getRemoteTrackingBranch",
         "hashBlob",
         "indexPack",
         "init",

--- a/__tests__/test-getRemoteTrackingBranch.js
+++ b/__tests__/test-getRemoteTrackingBranch.js
@@ -1,0 +1,18 @@
+/* eslint-env node, browser, jasmine */
+const { getRemoteTrackingBranch } = require('isomorphic-git')
+
+const { makeFixture } = require('./__helpers__/FixtureFS.js')
+
+describe('getRemoteTrackingBranch', () => {
+  it('gets the local branch matching', async () => {
+    // Setup
+    const { fs, gitdir } = await makeFixture('test-getRemoteTrackingBranch')
+    // Test
+    const trackedBranch = await getRemoteTrackingBranch({
+      fs,
+      gitdir,
+      ref: 'test',
+    })
+    expect(trackedBranch).toBe('refs/remotes/bar/test')
+  })
+})

--- a/docs/alphabetic.md
+++ b/docs/alphabetic.md
@@ -27,6 +27,7 @@ sidebar_label: Alphabetical Index
 - [getConfigAll](getConfigAll)
 - [getRemoteInfo](getRemoteInfo)
 - [getRemoteInfo2](getRemoteInfo2)
+- [getRemoteTrackingBranch](getRemoteTrackingBranch)
 - [hashBlob](hashBlob)
 - [indexPack](indexPack)
 - [init](init)

--- a/src/api/getRemoteTrackingBranch.js
+++ b/src/api/getRemoteTrackingBranch.js
@@ -1,0 +1,43 @@
+// @ts-check
+import '../typedefs.js'
+
+import { _getRemoteTrackingBranch } from '../commands/getRemoteTrackingBranch.js'
+import { FileSystem } from '../models/FileSystem.js'
+import { assertParameter } from '../utils/assertParameter.js'
+import { join } from '../utils/join.js'
+
+/**
+ * Find the tracked branch associated with a local branch
+ *
+ * @param {Object} args
+ * @param {FsClient} args.fs - a file system implementation
+ * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
+ * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} args.ref - The branch ref to find the tracking branch of
+ *
+ * @returns {Promise<string>} Resolves with the ref to the remote
+ *
+ * @example
+ * await git.getRemoteTrackingBranch({ fs, dir: '/tutorial', ref: 'refs/head/main' })
+ * console.log('done')
+ *
+ */
+export async function getRemoteTrackingBranch({
+  fs,
+  dir,
+  gitdir = join(dir, '.git'),
+  ref,
+}) {
+  try {
+    assertParameter('fs', fs)
+    assertParameter('ref', ref)
+    return await _getRemoteTrackingBranch({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref,
+    })
+  } catch (err) {
+    err.caller = 'git.getRemoteTrackingBranch'
+    throw err
+  }
+}

--- a/src/commands/getRemoteTrackingBranch.js
+++ b/src/commands/getRemoteTrackingBranch.js
@@ -1,0 +1,38 @@
+// @ts-check
+import '../typedefs.js'
+
+import { GitConfigManager } from '../managers/GitConfigManager'
+import { GitRefSpecSet } from '../models/GitRefSpecSet'
+
+/**
+ * Get the remote tracking branch.
+ *
+ * @param {object} args
+ * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {string} args.gitdir
+ * @param {string} args.ref
+ *
+ * @returns {Promise<string>} Resolves the tracked branch ref
+ *
+ */
+export async function _getRemoteTrackingBranch({ fs, gitdir, ref }) {
+  ref = ref.startsWith('refs/heads/') ? ref : `refs/heads/${ref}`
+
+  const config = await GitConfigManager.get({ fs, gitdir })
+
+  const remoteNames = await config.getSubsections(`remote`)
+
+  const fetches = await Promise.all(
+    remoteNames.map(remote => {
+      return config.get(`remote.${remote}.fetch`)
+    })
+  )
+
+  const refspec = new GitRefSpecSet()
+
+  for (const fetch of fetches) {
+    refspec.add(fetch)
+  }
+
+  return refspec.translateOne(ref)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import { getConfig } from './api/getConfig.js'
 import { getConfigAll } from './api/getConfigAll.js'
 import { getRemoteInfo } from './api/getRemoteInfo.js'
 import { getRemoteInfo2 } from './api/getRemoteInfo2.js'
+import { getRemoteTrackingBranch } from './api/getRemoteTrackingBranch.js'
 import { hashBlob } from './api/hashBlob.js'
 import { indexPack } from './api/indexPack.js'
 import { init } from './api/init.js'
@@ -96,6 +97,7 @@ export {
   findRoot,
   getRemoteInfo,
   getRemoteInfo2,
+  getRemoteTrackingBranch,
   hashBlob,
   indexPack,
   init,
@@ -165,6 +167,7 @@ export default {
   findRoot,
   getRemoteInfo,
   getRemoteInfo2,
+  getRemoteTrackingBranch,
   hashBlob,
   indexPack,
   init,

--- a/website/versioned_docs/version-1.x/alphabetic.md
+++ b/website/versioned_docs/version-1.x/alphabetic.md
@@ -29,6 +29,7 @@ original_id: alphabetic
 - [getConfigAll](getConfigAll)
 - [getRemoteInfo](getRemoteInfo)
 - [getRemoteInfo2](getRemoteInfo2)
+- [getRemoteTrackingBranch](getRemoteTrackingBranch)
 - [hashBlob](hashBlob)
 - [indexPack](indexPack)
 - [init](init)

--- a/website/versioned_docs/version-1.x/getRemoteTrackingBranch.md
+++ b/website/versioned_docs/version-1.x/getRemoteTrackingBranch.md
@@ -1,0 +1,45 @@
+---
+title: getRemoteTrackingBranch
+sidebar_label: getRemoteTrackingBranch
+id: version-1.x-getRemoteTrackingBranch
+original_id: getRemoteTrackingBranch
+---
+
+Find the tracked branch associated with a local branch
+
+| param          | type [= default]          | description                                         |
+| -------------- | ------------------------- | --------------------------------------------------- |
+| [**fs**](./fs) | FsClient                  | a file system implementation                        |
+| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path |
+| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path          |
+| **ref**        | string                    | The branch ref to find the tracking branch of       |
+| return         | Promise\<string\>         | Resolves with the ref to the remote                 |
+
+Example Code:
+
+```js live
+await git.getRemoteTrackingBranch({ fs, dir: '/tutorial', ref: 'refs/head/main' })
+console.log('done')
+```
+
+
+---
+
+<details>
+<summary><i>Tip: If you need a clean slate, expand and run this snippet to clean up the file system.</i></summary>
+
+```js live
+window.fs = new LightningFS('fs', { wipe: true })
+window.pfs = window.fs.promises
+console.log('done')
+```
+</details>
+
+<script>
+(function rewriteEditLink() {
+  const el = document.querySelector('a.edit-page-link.button');
+  if (el) {
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/getRemoteTrackingBranch.js';
+  }
+})();
+</script>


### PR DESCRIPTION
# I'm adding a new command:

This PR adds the `getRemoteTracking` command per #233

- [x] add as a new file in `src/api` (and `src/commands` if necessary)
- [x] add command to `src/index.js`
- [x] update `__tests__/__snapshots__/test-exports.js.snap`
- [x] create a test in `src/__tests__`
- [x] document the command with a JSDoc comment
- [x] add page to the Docs Sidebar `website/sidebars.json`
- [x] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "feat: Added 'X' command"
