### PR TITLE
fix(fetch): fetching a specific commit hash with `singleBranch: true`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -434,6 +434,16 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "willstott101",
+      "name": "Will Stott",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/335152?v=4",
+      "profile": "https://github.com/willstott101",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -325,10 +325,11 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/linfaxin"><img src="https://avatars2.githubusercontent.com/u/3705017?v=4?s=60" width="60px;" alt=""/><br /><sub><b>林法鑫</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Alinfaxin" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://github.com/willstott101"><img src="https://avatars2.githubusercontent.com/u/335152?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Will Stott</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=willstott101" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=willstott101" title="Tests">⚠️</a></td>
   </tr>
 </table>
 
-<!-- markdownlint-enable -->
+<!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -138,6 +138,29 @@ describe('fetch', () => {
     )
   })
 
+  it('shallow fetch single commit by hash (from Github)', async () => {
+    const { fs, gitdir } = await makeFixture('test-fetch-cors')
+    await setConfig({
+      fs,
+      gitdir,
+      path: 'http.corsProxy',
+      value: `http://${localhost}:9999`,
+    })
+    // Test
+    await fetch({
+      fs,
+      http,
+      gitdir,
+      singleBranch: true,
+      remote: 'origin',
+      depth: 1,
+      ref: '36d201c8fea9d87128e7fccd32c21643f355540d',
+    })
+    expect(await fs.exists(`${gitdir}/shallow`)).toBe(true)
+    const shallow = (await fs.read(`${gitdir}/shallow`)).toString('utf8')
+    expect(shallow).toEqual('36d201c8fea9d87128e7fccd32c21643f355540d\n')
+  })
+
   it('shallow fetch since (from Github)', async () => {
     const { fs, gitdir } = await makeFixture('test-fetch-cors')
     await setConfig({

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -269,7 +269,11 @@ export async function _fetch({
       key = value
     }
     // final value must not be a symref but a real ref
-    refs.set(key, remoteRefs.get(key))
+    const realRef = remoteRefs.get(key)
+    // There may be no ref at all if we've fetched a specific commit hash
+    if (realRef) {
+      refs.set(key, realRef)
+    }
     const { pruned } = await GitRefManager.updateRemoteRefs({
       fs,
       gitdir,


### PR DESCRIPTION
Addresses my comment https://github.com/isomorphic-git/isomorphic-git/issues/714#issuecomment-688215101

I guess there is no ref information to update on download. Not 100% sure about this fix, but the test definitely catches it.

Would it be better to skip calling `updateRemoteRefs` rather than calling with an empty Map?