### PR TITLE
feature: Initial work to add many files using git add

### DIFF
--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -25,6 +25,14 @@ describe('add', () => {
     await add({ fs, dir, filepath: 'b.txt' })
     expect((await listFiles({ fs, dir })).length).toEqual(3)
   })
+  it('multiple files', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    // Test
+    await init({ fs, dir })
+    await add({ fs, dir, filepaths: ['a.txt', 'a-copy.txt', 'b.txt'] })
+    expect((await listFiles({ fs, dir })).length).toEqual(3)
+  })
   it('ignored file', async () => {
     // Setup
     const { fs, dir } = await makeFixture('test-add')

--- a/src/errors/MultipleGitError.js
+++ b/src/errors/MultipleGitError.js
@@ -1,0 +1,18 @@
+import { BaseError } from './BaseError.js'
+
+export class MultipleGitError extends BaseError {
+  /**
+   * @param {Error[]} errors
+   * @param {string} message
+   */
+  constructor(errors) {
+    super(
+      `There are multiple errors that were thrown by the method. Please refer to the "errors" property to see more`
+    )
+    this.code = this.name = MultipleGitError.code
+    this.data = { errors }
+    this.errors = errors
+  }
+}
+/** @type {'MultipleGitError'} */
+MultipleGitError.code = 'MultipleGitError'


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm adding a parameter to an existing command X:

- [x] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [x] document the parameter in the JSDoc comment above the function
- [x] add a test case in `__tests__/test-X.js` if possible
- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "feat(X): Added 'bar' parameter"


This is the initial PR for the logic of #1182. However, I will note that the change made to errors thrown will be considered a breaking change for error handling. Do we want to change that so that it's no longer a breaking change?