### PR TITLE
fix(git-log): check commit array before popping

### DIFF
--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -31,7 +31,7 @@ export async function _log({ fs, cache, gitdir, ref, depth, since }) {
   const oid = await GitRefManager.resolve({ fs, gitdir, ref })
   const tips = [await _readCommit({ fs, cache, gitdir, oid })]
 
-  while (true) {
+  while (tips.length > 0) {
     const commit = tips.pop()
 
     // Stop the log if we've hit the age limit
@@ -58,9 +58,6 @@ export async function _log({ fs, cache, gitdir, ref, depth, since }) {
         }
       }
     }
-
-    // Stop the loop if there are no more commit parents
-    if (tips.length === 0) break
 
     // Process tips in order by age
     tips.sort((a, b) => compareAge(a.commit, b.commit))


### PR DESCRIPTION
I hit an error due to this - I somehow got into a situation where `tips` was empty before the check for `tips.length === 0`, so `pop` returned an `undefined`.

This change keeps the logic identical - there's no reason to try to execute the while loop when there are no commits to process. The only difference is that there's a small chance `tips.sort` is called on an empty array, which is a no-op anyway.

I didn't add myself as a contributor as I have another PR open (#1247) where I did.