### PR TITLE
Two commits from master missing in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Check out the [`CONTRIBUTING`](./CONTRIBUTING.md) document for more instructions
 ## Who is using isomorphic-git?
 
 - [nde](https://nde.now.sh) - a futuristic next-generation web IDE
-- [git-app-manager](https://git-app-manager-tcibxepsta.now.sh) - install "unhosted" websites locally by git cloning them
+- [git-app-manager](https://git-app-manager.now.sh/) - install "unhosted" websites locally by git cloning them
 - [GIT Web Terminal](https://jcubic.github.io/git/)
 - [Next Editor](https://next-editor.app/)
 - [Clever Cloud](https://www.clever-cloud.com/?utm_source=ref&utm_medium=link&utm_campaign=isomorphic-git)

--- a/src/utils/deflate.js
+++ b/src/utils/deflate.js
@@ -22,6 +22,8 @@ async function browserDeflate(buffer) {
 function testCompressionStream() {
   try {
     const cs = new CompressionStream('deflate')
+    // Test if `Blob.stream` is present. React Native does not have the `stream` method
+    new Blob([]).stream()
     if (cs) return true
   } catch (_) {
     // no bother


### PR DESCRIPTION
I guess there were 2 PRs opened before master was renamed to main, and when those two PRs were merged, they landed in the wrong branch.

One of these 2 commits is a fix for react-native which is not in the currently released 1.8.0 version. I've just hit the problem, and by pure random fluke, found the fix. I'd be delighted to see 1.8.1 shipped with that fix included! :-)