### PR TITLE
feat: Added 'worktreeAdd' command

### DIFF
--- a/__tests__/test-exports.js
+++ b/__tests__/test-exports.js
@@ -66,6 +66,7 @@ describe('exports', () => {
         "tag",
         "version",
         "walk",
+        "worktreeAdd",
         "writeBlob",
         "writeCommit",
         "writeObject",

--- a/__tests__/test-worktreeAdd.js
+++ b/__tests__/test-worktreeAdd.js
@@ -1,0 +1,54 @@
+/* eslint-env node, browser, jasmine */
+import http from 'isomorphic-git/http'
+
+const { worktreeAdd } = require('isomorphic-git')
+
+const { makeFixture } = require('./__helpers__/FixtureFS.js')
+
+describe('worktreeAdd', () => {
+  // Note: because worktreeAdd relies on clone underneath, the same performance issues
+  // that plague clone tests are also relevant here
+  it('worktreeAdd without ref', async () => {
+    const { fs, dir, gitdir } = await makeFixture('isomorphic-git')
+    await worktreeAdd({
+      fs,
+      http,
+      dir,
+      gitdir,
+      path: '../test-branch',
+    })
+    expect(await fs.exists(`${dir}/../test-branch`)).toBe(true)
+    expect(await fs.exists(`${dir}/../test-branch/.git/objects`)).toBe(true)
+    expect(
+      await fs.exists(
+        `${dir}/../test-branch/.git/refs/remotes/origin/test-branch`
+      )
+    ).toBe(true)
+    expect(
+      await fs.exists(`${dir}/../test-branch/.git/refs/heads/test-branch`)
+    ).toBe(true)
+    expect(await fs.exists(`${dir}/../test-branch/package.json`)).toBe(false)
+  })
+  it('worktreeAdd with ref', async () => {
+    const { fs, dir, gitdir } = await makeFixture('isomorphic-git')
+    await worktreeAdd({
+      fs,
+      http,
+      dir,
+      gitdir,
+      path: '../test-repo',
+      ref: 'test-branch',
+    })
+    expect(await fs.exists(`${dir}/../test-repo`)).toBe(true)
+    expect(await fs.exists(`${dir}/../test-repo/.git/objects`)).toBe(true)
+    expect(
+      await fs.exists(
+        `${dir}/../test-repo/.git/refs/remotes/origin/test-branch`
+      )
+    ).toBe(true)
+    expect(
+      await fs.exists(`${dir}/../test-repo/.git/refs/heads/test-branch`)
+    ).toBe(true)
+    expect(await fs.exists(`${dir}/../test-repo/package.json`)).toBe(false)
+  })
+})

--- a/src/api/worktreeAdd.js
+++ b/src/api/worktreeAdd.js
@@ -1,0 +1,53 @@
+import '../typedefs.js'
+
+import { _worktreeAdd } from '../commands/worktreeAdd.js'
+import { FileSystem } from '../models/FileSystem.js'
+import { assertParameter } from '../utils/assertParameter.js'
+import { join } from '../utils/join.js'
+
+/**
+ * Create a new working tree attached to an existing repository
+ *
+ * @param {object} args
+ * @param {FsClient} args.fs - a file system implementation
+ * @param {HttpClient} args.http - an HTTP client
+ * @param {string} args.dir - The [working tree](dir-vs-gitdir.md) directory path
+ * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} args.path - The path to create a new working tree into
+ * @param {string} [args.ref=path.split('/').pop()] - What to name the new branch in the new working tree
+ *
+ * @returns {Promise<void>} Resolves successfully when worktree operation completes
+ *
+ * @example
+ * await git.({
+ *   fs,
+ *   http,
+ *   dir: '/tutorial',
+ *   path: '../hotfix'
+ * })
+ */
+export async function worktreeAdd({
+  fs,
+  http,
+  dir,
+  gitdir = join(dir, '.git'),
+  path,
+  ref = path.split('/').pop(),
+}) {
+  try {
+    assertParameter('fs', fs)
+    assertParameter('http', http)
+    assertParameter('gitdir', gitdir)
+    assertParameter('path', path)
+    assertParameter('ref', ref)
+    return await _worktreeAdd({
+      fs: new FileSystem(fs),
+      gitdir,
+      path,
+      ref,
+    })
+  } catch (err) {
+    err.caller = 'git.worktreeAdd'
+    throw err
+  }
+}

--- a/src/commands/worktreeAdd.js
+++ b/src/commands/worktreeAdd.js
@@ -1,0 +1,15 @@
+import '../typedefs.js'
+
+import { _branch } from '../commands/branch.js'
+import { _clone } from '../commands/clone.js'
+import { GitConfigManager } from '../managers/GitConfigManager.js'
+import { join } from '../utils/join.js'
+
+export async function _worktreeAdd({ fs, http, gitdir, path, ref }) {
+  const config = await GitConfigManager.get({ fs, gitdir })
+  const remote = await config.get(`branch.${ref}.remote`)
+  const url = await config.get(`remote.${remote}.url`)
+  const gitpath = join(path, '.git')
+  await _clone({ fs, http, gitpath, url })
+  await _branch({ fs, gitpath, ref, checkout: true })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ import { statusMatrix } from './api/statusMatrix.js'
 import { tag } from './api/tag.js'
 import { version } from './api/version.js'
 import { walk } from './api/walk.js'
+import { worktreeAdd } from './api/worktreeAdd.js'
 import { writeBlob } from './api/writeBlob.js'
 import { writeCommit } from './api/writeCommit.js'
 import { writeObject } from './api/writeObject.js'
@@ -127,6 +128,7 @@ export {
   tag,
   version,
   walk,
+  worktreeAdd,
   writeBlob,
   writeCommit,
   writeObject,
@@ -196,6 +198,7 @@ export default {
   tag,
   version,
   walk,
+  worktreeAdd,
   writeBlob,
   writeCommit,
   writeObject,

--- a/src/utils/mergeTree.js
+++ b/src/utils/mergeTree.js
@@ -121,6 +121,9 @@ export async function mergeTree({
     reduce: async (parent, children) => {
       const entries = children.filter(Boolean) // remove undefineds
 
+      // if the parent was deleted, the children have to go
+      if (!parent) return
+
       // automatically delete directories if they have been emptied
       if (parent && parent.type === 'tree' && entries.length === 0) return
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,7 +14,8 @@
       "pull",
       "fastForward",
       "merge",
-      "walk"
+      "walk",
+      "worktreeAdd"
     ],
     "Callbacks": [
       "onAuth",

--- a/website/versioned_sidebars/version-1.x-sidebars.json
+++ b/website/versioned_sidebars/version-1.x-sidebars.json
@@ -14,7 +14,8 @@
       "version-1.x-pull",
       "version-1.x-fastForward",
       "version-1.x-merge",
-      "version-1.x-walk"
+      "version-1.x-walk",
+      "version-1.x-worktreeAdd"
     ],
     "Callbacks": [
       "version-1.x-onAuth",


### PR DESCRIPTION
## I'm adding a new command:

- [X] add as a new file in `src/api` (and `src/commands` if necessary)
- [X] add command to `src/index.js`
- [X] update `__tests__/test-exports.js`
- [X] create a test in `src/__tests__`
- [X] document the command with a JSDoc comment
- [X] add page to the Docs Sidebar `website/sidebars.json`
- [X] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [X] squash merge the PR with commit message "feat: Added 'X' command"

Basic functionality of the [git-worktree](https://git-scm.com/docs/git-worktree) command.