### PR TITLE
fix: propagate corsProxy setting on clone command to internal _fetch call

### DIFF
--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -78,6 +78,7 @@ export async function _clone({
     gitdir,
     ref,
     remote,
+    corsProxy,
     depth,
     since,
     exclude,


### PR DESCRIPTION
The clone command does not pass the corsProxy setting to the internal _fetch call. As a result, the _fetch command does an unnecessary call to lookup the corsProxy setting again. Additionally, it performs that lookup even when the value is explicitly set to false.

This change matches the behavior of the fetch command, which does pass the corsProxy setting to the internal _fetch call.