### PR TITLE
fix: add HEAD to GetRemoteInfoResult type.

### DIFF
--- a/src/api/getRemoteInfo.js
+++ b/src/api/getRemoteInfo.js
@@ -9,6 +9,7 @@ import { assertParameter } from '../utils/assertParameter.js'
  * @typedef {Object} GetRemoteInfoResult - The object returned has the following schema:
  * @property {string[]} capabilities - The list of capabilities returned by the server (part of the Git protocol)
  * @property {Object} [refs]
+ * @property {string} [HEAD] - The default branch of the remote
  * @property {Object<string, string>} [refs.heads] - The branches on the remote
  * @property {Object<string, string>} [refs.pull] - The special branches representing pull requests (non-standard)
  * @property {Object<string, string>} [refs.tags] - The tags on the remote


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

Fixes #1274.

Unfortunately, I can't run the tests locally due to #1158.
I hope this is how the types are handled by this project, I couldn't find any other type definitions. Please let me know if this works for you or if I should change something :smile_cat: 
