### PR TITLE
posixify symlink path when adding file to repository

### DIFF
--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -1,5 +1,12 @@
 /* eslint-env node, browser, jasmine */
-const { init, add, listFiles } = require('isomorphic-git')
+const {
+  init,
+  add,
+  listFiles,
+  readBlob,
+  walk,
+  STAGE,
+} = require('isomorphic-git')
 
 const { makeFixture } = require('./__helpers__/FixtureFS.js')
 
@@ -9,6 +16,10 @@ const writeGitIgnore = async (fs, dir) =>
     dir + '/.gitignore',
     ['*-pattern.js', 'i.txt', 'js_modules', '.DS_Store'].join('\n')
   )
+
+// NOTE: we cannot actually commit a real symlink in fixtures because it relies on core.symlinks being enabled
+const writeSymlink = async (fs, dir) =>
+  fs._symlink('c/e.txt', dir + '/e-link.txt')
 
 describe('add', () => {
   it('file', async () => {
@@ -24,6 +35,36 @@ describe('add', () => {
     expect((await listFiles({ fs, dir })).length).toEqual(2)
     await add({ fs, dir, filepath: 'b.txt' })
     expect((await listFiles({ fs, dir })).length).toEqual(3)
+  })
+  it('symlink', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    // it's not currently possible to tests symlinks in the browser since there's no way to create them
+    const symlinkCreated = await writeSymlink(fs, dir)
+      .then(() => true)
+      .catch(() => false)
+    // Test
+    await init({ fs, dir })
+    await add({ fs, dir, filepath: 'c/e.txt' })
+    expect((await listFiles({ fs, dir })).length).toEqual(1)
+    if (!symlinkCreated) return
+    await add({ fs, dir, filepath: 'e-link.txt' })
+    expect((await listFiles({ fs, dir })).length).toEqual(2)
+    const walkResult = await walk({
+      fs,
+      dir,
+      trees: [STAGE()],
+      map: async (filepath, [stage]) =>
+        filepath === 'e-link.txt' && stage ? stage.oid() : undefined,
+    })
+    expect(walkResult.length).toEqual(1)
+    const oid = walkResult[0]
+    const { blob: symlinkTarget } = await readBlob({ fs, dir, oid })
+    let symlinkTargetStr = Buffer.from(symlinkTarget).toString('utf8')
+    if (symlinkTargetStr.startsWith('./')) {
+      symlinkTargetStr = symlinkTargetStr.substr(2)
+    }
+    expect(symlinkTargetStr).toEqual('c/e.txt')
   })
   it('ignored file', async () => {
     // Setup

--- a/src/api/add.js
+++ b/src/api/add.js
@@ -8,6 +8,7 @@ import { FileSystem } from '../models/FileSystem.js'
 import { _writeObject } from '../storage/writeObject.js'
 import { assertParameter } from '../utils/assertParameter.js'
 import { join } from '../utils/join.js'
+import { posixifyPathBuffer } from '../utils/posixifyPathBuffer.js'
 
 /**
  * Add a file to the git index (aka staging area)
@@ -69,7 +70,7 @@ async function addToIndex({ dir, gitdir, fs, filepath, index }) {
     await Promise.all(promises)
   } else {
     const object = stats.isSymbolicLink()
-      ? await fs.readlink(join(dir, filepath))
+      ? await fs.readlink(join(dir, filepath)).then(posixifyPathBuffer)
       : await fs.read(join(dir, filepath))
     if (object === null) throw new NotFoundError(filepath)
     const oid = await _writeObject({ fs, gitdir, type: 'blob', object })

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -201,7 +201,8 @@ export class FileSystem {
     // Note: FileSystem.readlink returns a buffer by default
     // so we can dump it into GitObject.write just like any other file.
     try {
-      return this._readlink(filename, opts)
+      const link = await this._readlink(filename, opts)
+      return Buffer.isBuffer(link) ? link : Buffer.from(link)
     } catch (err) {
       if (err.code === 'ENOENT') {
         return null

--- a/src/utils/posixifyPathBuffer.js
+++ b/src/utils/posixifyPathBuffer.js
@@ -1,0 +1,5 @@
+export function posixifyPathBuffer(buffer) {
+  let idx
+  while (~(idx = buffer.indexOf(92))) buffer[idx] = 47
+  return buffer
+}


### PR DESCRIPTION
If backslashes are detected in return value of fs.readlink, change them to forward slashes. This logic is handled by the new posixifyPathBuffer helper, which filters the return value of fs.readlink.

I've also added a test to verify that symlinks can be added to the repository and that the contents of the symlink is the target path in posix form.

closes #1381