### PR TITLE
fix: signature of WalkerMap

### DIFF
--- a/src/api/walk.js
+++ b/src/api/walk.js
@@ -9,7 +9,7 @@ import { join } from '../utils/join.js'
 /**
  * @callback WalkerMap
  * @param {string} filename
- * @param {(?WalkerEntry)[]} entries
+ * @param {Array<WalkerEntry | null>} entries
  * @returns {Promise<any>}
  */
 


### PR DESCRIPTION
As pointed out in #1313, the `entries` parameter of the `WalkerMap` callback may contain `null` elements. #1314 addressed this issue, which seemingly resulted in the correct type, but broke the docs generator. I've replaced the type annotation with a semantically identical one that doesn't break the docs generator.