### PR TITLE
fix: move `endCommit` above return statement

### DIFF
--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -57,6 +57,10 @@ export async function _log({
   let lastCommit
   let isOk
 
+  function endCommit(commit) {
+    if (isOk && filepath) commits.push(commit)
+  }
+
   while (tips.length > 0) {
     const commit = tips.pop()
 
@@ -166,8 +170,4 @@ export async function _log({
     tips.sort((a, b) => compareAge(a.commit, b.commit))
   }
   return commits
-
-  function endCommit(commit) {
-    if (isOk && filepath) commits.push(commit)
-  }
 }


### PR DESCRIPTION
Declaring it after the return statement is a little confusing and can trip up some tools - I am using [babel-plugin-transform-async-to-promises](https://npmjs.com/package/babel-plugin-transform-async-to-promises) which [hit an error](https://github.com/mmkal/plv8-git/pull/87) when updating isomorphic-git because of this.

## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"