### PR TITLE
fix: "TypeError: Cannot read property 'length' of undefined" at Inflate.push

### DIFF
--- a/src/utils/git-list-pack.js
+++ b/src/utils/git-list-pack.js
@@ -31,7 +31,7 @@ export async function listpack(stream, onData) {
     const inflator = new pako.Inflate()
     while (!inflator.result) {
       const chunk = await reader.chunk()
-      if (reader.ended) break
+      if (!chunk) break
       inflator.push(chunk, false)
       if (inflator.err) {
         throw new InternalError(`Pako error: ${inflator.msg}`)


### PR DESCRIPTION
fix #1399

## I'm fixing a bug or typo

- [ ] squash merge the PR with commit message "fix: [Description of fix]"

There is no `.ended` property on StreamReader. So that check always fails. (There's an `._ended` but it's private.) So there's a chance that `Inflate.push(undefined, true)` happens, in which case pako would might be trying to get length of undefined.