### PR TITLE
Make GitConfig parser more resilience

### DIFF
--- a/src/models/GitConfig.js
+++ b/src/models/GitConfig.js
@@ -124,7 +124,7 @@ export class GitConfig {
   constructor(text) {
     let section = null
     let subsection = null
-    this.parsedConfig = text.split('\n').map(line => {
+    this.parsedConfig = (text || '').split('\n').map(line => {
       let name = null
       let value = null
 


### PR DESCRIPTION
It seems git.clone method only writes the config if [corsProxy is enabled](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/commands/clone.js#L68), this causes all other methods that rely on getConfig to fail since the config does not exist.