### PR TITLE
fix(statusMatrix, walk): don't remove the executable bit from file mode (Windows-only bug)

### DIFF
--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -128,7 +128,15 @@ export class GitWalkerFs {
             oid = await shasum(
               GitObject.wrap({ type: 'blob', object: await entry.content() })
             )
-            if (stage && oid === stage.oid) {
+            // Update the stats in the index so we will get a "cache hit" next time
+            // 1) if we can (because the oid and mode are the same)
+            // 2) and only if we need to (because other stats differ)
+            if (
+              stage &&
+              oid === stage.oid &&
+              stats.mode === stage.mode &&
+              compareStats(stats, stage)
+            ) {
               index.insert({
                 filepath: entry._fullpath,
                 stats,

--- a/website/versioned_docs/version-1.x/log.md
+++ b/website/versioned_docs/version-1.x/log.md
@@ -7,16 +7,19 @@ original_id: log
 
 Get commit descriptions from the git history
 
-| param          | type [= default]                     | description                                                                                         |
-| -------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                             | a file system client                                                                                |
-| dir            | string                               | The [working tree](dir-vs-gitdir.md) directory path                                                 |
-| **gitdir**     | string = join(dir,'.git')            | The [git directory](dir-vs-gitdir.md) path                                                          |
-| ref            | string = 'HEAD'                      | The commit to begin walking backwards through the history from                                      |
-| depth          | number                               | Limit the number of commits returned. No limit by default.                                          |
-| since          | Date                                 | Return history newer than the given date. Can be combined with `depth` to get whichever is shorter. |
-| cache          | object                               | a [cache](cache.md) object                                                                          |
-| return         | Promise\<Array\<ReadCommitResult\>\> | Resolves to an array of ReadCommitResult objects                                                    |
+| param          | type [= default]                     | description                                                                                             |
+| -------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                             | a file system client                                                                                    |
+| dir            | string                               | The [working tree](dir-vs-gitdir.md) directory path                                                     |
+| **gitdir**     | string = join(dir,'.git')            | The [git directory](dir-vs-gitdir.md) path                                                              |
+| filepath       | string                               | optional get the commit for the filepath only                                                           |
+| ref            | string = 'HEAD'                      | The commit to begin walking backwards through the history from                                          |
+| depth          | number                               | Limit the number of commits returned. No limit by default.                                              |
+| since          | Date                                 | Return history newer than the given date. Can be combined with `depth` to get whichever is shorter.     |
+| force          | boolean = false                      | do not throw error if filepath is not exist (works only for a single file). defaults to false           |
+| follow         | boolean = false                      | Continue listing the history of a file beyond renames (works only for a single file). defaults to false |
+| cache          | object                               | a [cache](cache.md) object                                                                              |
+| return         | Promise\<Array\<ReadCommitResult\>\> | Resolves to an array of ReadCommitResult objects                                                        |
 
 ```ts
 type ReadCommitResult = {

--- a/website/versioned_docs/version-1.x/walk.md
+++ b/website/versioned_docs/version-1.x/walk.md
@@ -166,7 +166,7 @@ type Stat = {
 
 
 ```ts
-type WalkerMap = (filename: string, entries: Array<WalkerEntry>) => Promise<any>;
+type WalkerMap = (filename: string, entries: Array<(WalkerEntry|null)>) => Promise<any>;
 ```
 
 


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

Addresses bug https://github.com/stoplightio/platform-internal/issues/9154 in Studio Desktop, where all executable files have their mode changed to non-executable in the git index on Windows.

- [x] squash merge the PR with commit message "fix: [Description of fix]"
