### PR TITLE
fix: set remote tracking branch on clone

### DIFF
--- a/__tests__/test-clone.js
+++ b/__tests__/test-clone.js
@@ -7,6 +7,7 @@ const {
   clone,
   currentBranch,
   resolveRef,
+  getConfig,
 } = require('isomorphic-git')
 
 const { makeFixture } = require('./__helpers__/FixtureFS.js')
@@ -225,5 +226,28 @@ describe('clone', () => {
       // Intentionally left blank.
     }
     expect(await fs.exists(gitdir)).toBe(false, `'gitdir' does not exist`)
+  })
+
+  it('should set up the remote tracking branch by default', async () => {
+    const { fs, dir, gitdir } = await makeFixture('isomorphic-git')
+    await clone({
+      fs,
+      http,
+      dir,
+      gitdir,
+      depth: 1,
+      singleBranch: true,
+      remote: 'foo',
+      url: 'https://github.com/isomorphic-git/isomorphic-git.git',
+      corsProxy: process.browser ? `http://${localhost}:9999` : undefined,
+    })
+
+    const [merge, remote] = await Promise.all([
+      await getConfig({ fs, dir, gitdir, path: 'branch.main.merge' }),
+      await getConfig({ fs, dir, gitdir, path: 'branch.main.remote' }),
+    ])
+
+    expect(merge).toBe('refs/heads/main')
+    expect(remote).toBe('foo')
   })
 })

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -48,7 +48,7 @@ export async function _checkout({
   noUpdateHead,
   dryRun,
   force,
-  track,
+  track = true,
 }) {
   // Get tree oid
   let oid


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"


This PR fixes a bug introduced by https://github.com/isomorphic-git/isomorphic-git/commit/64506265ff1cb7c0ebe56472705239fb8d636d2e. When cloning a repo, the remote tracking branch was not setup anymore cause of the change made. By making the `checkout` command set `track` to `true` by default (and not only on the API layer), it should fix the issue.