### PR TITLE
fix: suggestion can be undefined in UnknownTransportError

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -538,6 +538,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "VitorLuizC",
+      "name": "Vitor Luiz Cavalcanti",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9027363?v=4",
+      "profile": "http://vitorluizc.github.io/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/strangedev"><img src="https://avatars.githubusercontent.com/u/3045979?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Noah Hummel</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=strangedev" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=strangedev" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/mtlewis"><img src="https://avatars.githubusercontent.com/u/542836?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Mike Lewis</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=mtlewis" title="Documentation">📖</a></td>
     <td align="center"><a href="https://twitter.com/SamVerschueren"><img src="https://avatars.githubusercontent.com/u/1913805?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Sam Verschueren</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=SamVerschueren" title="Code">💻</a></td>
+    <td align="center"><a href="http://vitorluizc.github.io/"><img src="https://avatars.githubusercontent.com/u/9027363?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Vitor Luiz Cavalcanti</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=VitorLuizC" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/src/errors/UnknownTransportError.js
+++ b/src/errors/UnknownTransportError.js
@@ -4,7 +4,7 @@ export class UnknownTransportError extends BaseError {
   /**
    * @param {string} url
    * @param {string} transport
-   * @param {string} suggestion
+   * @param {string} [suggestion]
    */
   constructor(url, transport, suggestion) {
     super(


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

The `suggestion` parameter in `UnknownTransportError` is optional (or at least it can be `undefined`), but it was declared as required in JSDocs.

https://github.com/isomorphic-git/isomorphic-git/blob/82433d2c4866c14657444c3d18554ba2dd365aee/src/managers/GitRemoteManager.js#L61
