### PR TITLE
feat(http): Added agent parameter to request function of http plugin for Node.js

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -58,6 +58,7 @@ const http = {
   async request ({
     url,
     method,
+    agent,
     headers,
     body,
     onProgress
@@ -83,6 +84,7 @@ const http = {
 | ----------- | ----------------------------------- | ----------------------------------------------------------------------- |
 | **url**     | string                              | The URL to request                                                      |
 | **method**  | string = 'GET'                      | The HTTP method to use                                                  |
+| **agent**   | object (optional)                   | An HTTP/HTTPS agent that manages HTTP client connections (Node.js only) |
 | **headers** | object = {}                         | Headers to include in the HTTP request                                  |
 | **body**    | AsyncIterableIterator\<Uint8Array\> | An async iterator of Uint8Arrays that make up the body of POST requests |
 | onProgress  | function (optional)                 | Reserved for future use (emitting `GitProgressEvent`s)                  |

--- a/src/http/node/index.js
+++ b/src/http/node/index.js
@@ -16,6 +16,7 @@ export async function request({
   url,
   method = 'GET',
   headers = {},
+  agent,
   body,
 }) {
   // If we can, we should send it as a single buffer so it sets a Content-Length header.
@@ -30,6 +31,7 @@ export async function request({
         url,
         method,
         headers,
+        agent,
         body,
       },
       (err, res) => {

--- a/src/typedefs-http.js
+++ b/src/typedefs-http.js
@@ -16,6 +16,7 @@
  * @property {string} url - The URL to request
  * @property {string} [method='GET'] - The HTTP method to use
  * @property {Object<string, string>} [headers={}] - Headers to include in the HTTP request
+ * @property {Object} [agent] - An HTTP or HTTPS agent that manages connections for the HTTP client (Node.js only)
  * @property {AsyncIterableIterator<Uint8Array>} [body] - An async iterator of Uint8Arrays that make up the body of POST requests
  * @property {ProgressCallback} [onProgress] - Reserved for future use (emitting `GitProgressEvent`s)
  * @property {object} [signal] - Reserved for future use (canceling a request)


### PR DESCRIPTION
resolves #1491

- pass agent parameter to underlying http client
- update reference docs to include new parameter
- update faq to show how to wrap built-in http plugin to inject an agent

## I'm adding a parameter to the http plugin

- [x] add parameter to the function
- [x] document the parameter in the JSDoc comment above the function
- [x] add a test case in `__tests__/test-clone.js`
- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "feat(X): Added 'bar' parameter"
