### PR TITLE
feat: add updateIndex API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ docs/setConfig.md
 docs/status.md
 docs/statusMatrix.md
 docs/tag.md
+docs/updateIndex.md
 docs/version.md
 docs/walk.md
 docs/writeBlob.md

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ unless there is a major version bump.
 - [status](https://isomorphic-git.github.io/docs/status.html)
 - [statusMatrix](https://isomorphic-git.github.io/docs/statusMatrix.html)
 - [tag](https://isomorphic-git.github.io/docs/tag.html)
+- [updateIndex](https://isomorphic-git.github.io/docs/updateIndex.html)
 - [version](https://isomorphic-git.github.io/docs/version.html)
 - [walk](https://isomorphic-git.github.io/docs/walk.html)
 - [writeBlob](https://isomorphic-git.github.io/docs/writeBlob.html)

--- a/__tests__/test-exports.js
+++ b/__tests__/test-exports.js
@@ -65,6 +65,7 @@ describe('exports', () => {
         "status",
         "statusMatrix",
         "tag",
+        "updateIndex",
         "version",
         "walk",
         "writeBlob",

--- a/__tests__/test-updateIndex.js
+++ b/__tests__/test-updateIndex.js
@@ -1,0 +1,268 @@
+/* eslint-env node, browser, jasmine */
+const path = require('path')
+
+const { writeBlob, updateIndex, status, add } = require('isomorphic-git')
+
+const { makeFixture } = require('./__helpers__/FixtureFS.js')
+
+describe('updateIndex', () => {
+  it('should be possible to add a file on disk to the index', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'hello.md'), 'Hello, World!')
+    // Test
+    const oid = await updateIndex({
+      fs,
+      dir,
+      add: true,
+      filepath: 'hello.md',
+    })
+    expect(oid).toBe('b45ef6fec89518d314f546fd6c3025367b721684')
+    const fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('added')
+  })
+
+  it('should be possible to remove a file from the index which is not present in the workdir', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'hello.md'), 'Hello, World!')
+    await add({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    await fs.rm(path.join(dir, 'hello.md'))
+    // Test
+    let fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('*absent')
+    await updateIndex({
+      fs,
+      dir,
+      remove: true,
+      filepath: 'hello.md',
+    })
+    fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('absent')
+  })
+
+  it('should not remove file from index by default if file still exists in workdir', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'hello.md'), 'Hello, World!')
+    await add({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    // Test
+    let fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('added')
+    await updateIndex({
+      fs,
+      dir,
+      remove: true,
+      filepath: 'hello.md',
+    })
+    fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('added')
+  })
+
+  it('should remove file from index which exists on disk if force is used', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'hello.md'), 'Hello, World!')
+    await add({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    // Test
+    let fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('added')
+    await updateIndex({
+      fs,
+      dir,
+      remove: true,
+      force: true,
+      filepath: 'hello.md',
+    })
+    fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('*added')
+  })
+
+  it('should be possible to add a file from the object database to the index', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    const oid = await writeBlob({
+      fs,
+      dir,
+      blob: Buffer.from('Hello, World!'),
+    })
+    // Test
+    const updatedOid = await updateIndex({
+      fs,
+      dir,
+      add: true,
+      filepath: 'hello.md',
+      oid,
+    })
+    expect(updatedOid).toBe(oid)
+    const fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('*absent')
+  })
+
+  it('should be possible to update a file', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'hello.md'), 'Hello, World!')
+    await add({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    await fs.write(path.join(dir, 'hello.md'), 'Hello World')
+    // Test
+    let fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('*added')
+    const oid = await updateIndex({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(oid).toBe('5e1c309dae7f45e0f39b1bf3ac3cd9db12e7d689')
+    fileStatus = await status({
+      fs,
+      dir,
+      filepath: 'hello.md',
+    })
+    expect(fileStatus).toBe('added')
+  })
+
+  it('should throw if we try to update a new file without providing `add`', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, 'hello.md'), 'Hello, World!')
+    // Test
+    let error = null
+    try {
+      await updateIndex({
+        fs,
+        dir,
+        filepath: 'hello.md',
+      })
+    } catch (e) {
+      error = e
+    }
+    expect(error).not.toBeNull()
+    expect(error.caller).toEqual('git.updateIndex')
+    error = error.toJSON()
+    delete error.stack
+    expect(error).toMatchInlineSnapshot(`
+      Object {
+        "caller": "git.updateIndex",
+        "code": "NotFoundError",
+        "data": Object {
+          "what": "file at \\"hello.md\\" in index and \\"add\\" not set",
+        },
+        "message": "Could not find file at \\"hello.md\\" in index and \\"add\\" not set.",
+      }
+    `)
+  })
+
+  it('should throw if we try to update a file which does not exist on disk', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    // Test
+    let error = null
+    try {
+      await updateIndex({
+        fs,
+        dir,
+        filepath: 'hello.md',
+      })
+    } catch (e) {
+      error = e
+    }
+    expect(error).not.toBeNull()
+    expect(error.caller).toEqual('git.updateIndex')
+    error = error.toJSON()
+    delete error.stack
+    expect(error).toMatchInlineSnapshot(`
+      Object {
+        "caller": "git.updateIndex",
+        "code": "NotFoundError",
+        "data": Object {
+          "what": "file at \\"hello.md\\" on disk and \\"remove\\" not set",
+        },
+        "message": "Could not find file at \\"hello.md\\" on disk and \\"remove\\" not set.",
+      }
+    `)
+  })
+
+  it('should throw if we try to add a directory', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-empty')
+    await fs.mkdir(path.join(dir, 'hello-world'))
+    // Test
+    let error = null
+    try {
+      await updateIndex({
+        fs,
+        dir,
+        filepath: 'hello-world',
+      })
+    } catch (e) {
+      error = e
+    }
+    expect(error).not.toBeNull()
+    expect(error.caller).toEqual('git.updateIndex')
+    error = error.toJSON()
+    delete error.stack
+    expect(error).toMatchInlineSnapshot(`
+      Object {
+        "caller": "git.updateIndex",
+        "code": "InvalidFilepathError",
+        "data": Object {
+          "reason": "directory",
+        },
+        "message": "\\"filepath\\" should not be a directory.",
+      }
+    `)
+  })
+})

--- a/docs/alphabetic.md
+++ b/docs/alphabetic.md
@@ -58,6 +58,7 @@ sidebar_label: Alphabetical Index
 - [status](status)
 - [statusMatrix](statusMatrix)
 - [tag](tag)
+- [updateIndex](updateIndex)
 - [version](version)
 - [walk](walk)
 - [writeBlob](writeBlob)

--- a/src/api/updateIndex.js
+++ b/src/api/updateIndex.js
@@ -60,7 +60,6 @@ export async function updateIndex({
   remove,
   force,
 }) {
-  // TODO what if no remove, no add and only a filepath???
   try {
     assertParameter('fs', _fs)
     assertParameter('gitdir', gitdir)
@@ -135,7 +134,9 @@ export async function updateIndex({
         stats = fileStats
 
         // Write the file to the object database
-        const object = await fs.read(join(dir, filepath))
+        const object = stats.isSymbolicLink()
+          ? await fs.readlink(join(dir, filepath))
+          : await fs.read(join(dir, filepath))
 
         oid = await _writeObject({
           fs,

--- a/src/api/updateIndex.js
+++ b/src/api/updateIndex.js
@@ -1,0 +1,161 @@
+// @ts-check
+import { InvalidFilepathError } from '../errors/InvalidFilepathError.js'
+import { NotFoundError } from '../errors/NotFoundError.js'
+import { GitIndexManager } from '../managers/GitIndexManager.js'
+import { FileSystem } from '../models/FileSystem.js'
+import { _writeObject } from '../storage/writeObject.js'
+import { assertParameter } from '../utils/assertParameter.js'
+import { join } from '../utils/join.js'
+
+/**
+ * Register file contents in the working tree or object database to the git index (aka staging area).
+ *
+ * @param {object} args
+ * @param {FsClient} args.fs - a file system client
+ * @param {string} args.dir - The [working tree](dir-vs-gitdir.md) directory path
+ * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} args.filepath - File to act upon.
+ * @param {string} [args.oid] - OID of the object in the object database to add to the index with the specified filepath.
+ * @param {number} [args.mode = 100644] - The file mode to add the file to the index.
+ * @param {boolean} [args.add] - Adds the specified file to the index if it does not yet exist in the index.
+ * @param {boolean} [args.remove] - Remove the specified file from the index if it does not exist in the workspace anymore.
+ * @param {boolean} [args.force] - Remove the specified file from the index, even if it still exists in the workspace.
+ * @param {object} [args.cache] - a [cache](cache.md) object
+ *
+ * @returns {Promise<string | void>} Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed.
+ *
+ * @example
+ * await git.updateIndex({
+ *   fs,
+ *   dir: '/tutorial',
+ *   filepath: 'readme.md'
+ * })
+ *
+ * @example
+ * // Manually create a blob in the object database.
+ * let oid = await git.writeBlob({
+ *   fs,
+ *   dir: '/tutorial',
+ *   blob: new Uint8Array([])
+ * })
+ *
+ * // Write the object in the object database to the index.
+ * await git.updateIndex({
+ *   fs,
+ *   dir: '/tutorial',
+ *   add: true,
+ *   filepath: 'readme.md',
+ *   oid
+ * })
+ */
+export async function updateIndex({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, '.git'),
+  cache = {},
+  filepath,
+  oid,
+  mode,
+  add,
+  remove,
+  force,
+}) {
+  // TODO what if no remove, no add and only a filepath???
+  try {
+    assertParameter('fs', _fs)
+    assertParameter('gitdir', gitdir)
+    assertParameter('filepath', filepath)
+
+    const fs = new FileSystem(_fs)
+
+    if (remove) {
+      return await GitIndexManager.acquire(
+        { fs, gitdir, cache },
+        async function(index) {
+          let fileStats
+
+          if (!force) {
+            // Check if the file is still present in the working directory
+            fileStats = await fs.lstat(join(dir, filepath))
+
+            if (fileStats) {
+              // Do nothing if we don't force and the file still exists in the workdir
+              return
+            }
+          }
+
+          // Remove the file from the index if it's forced or the file does not exist
+          index.delete({
+            filepath,
+          })
+        }
+      )
+    }
+
+    // Test if it is a file and exists on disk if `remove` is not provided, only of no oid is provided
+    let fileStats
+
+    if (!oid) {
+      fileStats = await fs.lstat(join(dir, filepath))
+
+      if (!fileStats) {
+        throw new NotFoundError(
+          `file at "${filepath}" on disk and "remove" not set`
+        )
+      }
+
+      if (fileStats.isDirectory()) {
+        throw new InvalidFilepathError('directory')
+      }
+    }
+
+    return await GitIndexManager.acquire({ fs, gitdir, cache }, async function(
+      index
+    ) {
+      if (!add && !index.has({ filepath })) {
+        // If the index does not contain the filepath yet and `add` is not set, we should throw
+        throw new NotFoundError(
+          `file at "${filepath}" in index and "add" not set`
+        )
+      }
+
+      // By default we use 0 for the stats of the index file
+      let stats = {
+        ctime: new Date(0),
+        mtime: new Date(0),
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        size: 0,
+      }
+
+      if (!oid) {
+        stats = fileStats
+
+        // Write the file to the object database
+        const object = await fs.read(join(dir, filepath))
+
+        oid = await _writeObject({
+          fs,
+          gitdir,
+          type: 'blob',
+          format: 'content',
+          object,
+        })
+      }
+
+      index.insert({
+        filepath,
+        oid: oid,
+        stats,
+      })
+
+      return oid
+    })
+  } catch (err) {
+    err.caller = 'git.updateIndex'
+    throw err
+  }
+}

--- a/src/errors/InvalidFilepathError.js
+++ b/src/errors/InvalidFilepathError.js
@@ -2,12 +2,14 @@ import { BaseError } from './BaseError.js'
 
 export class InvalidFilepathError extends BaseError {
   /**
-   * @param {'leading-slash'|'trailing-slash'} [reason]
+   * @param {'leading-slash'|'trailing-slash'|'directory'} [reason]
    */
   constructor(reason) {
     let message = 'invalid filepath'
     if (reason === 'leading-slash' || reason === 'trailing-slash') {
       message = `"filepath" parameter should not include leading or trailing directory separators because these can cause problems on some platforms.`
+    } else if (reason === 'directory') {
+      message = `"filepath" should not be a directory.`
     }
     super(message)
     this.code = this.name = InvalidFilepathError.code

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ import { setConfig } from './api/setConfig.js'
 import { status } from './api/status.js'
 import { statusMatrix } from './api/statusMatrix.js'
 import { tag } from './api/tag.js'
+import { updateIndex } from './api/updateIndex.js'
 import { version } from './api/version.js'
 import { walk } from './api/walk.js'
 import { writeBlob } from './api/writeBlob.js'
@@ -123,6 +124,7 @@ export {
   removeNote,
   renameBranch,
   resetIndex,
+  updateIndex,
   resolveRef,
   status,
   statusMatrix,
@@ -193,6 +195,7 @@ export default {
   removeNote,
   renameBranch,
   resetIndex,
+  updateIndex,
   resolveRef,
   status,
   statusMatrix,

--- a/src/models/GitIndex.js
+++ b/src/models/GitIndex.js
@@ -183,6 +183,10 @@ export class GitIndex {
     this._dirty = true
   }
 
+  has({ filepath }) {
+    return this._entries.has(filepath)
+  }
+
   render() {
     return this.entries
       .map(entry => `${entry.mode.toString(8)} ${entry.oid}    ${entry.path}`)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -84,6 +84,7 @@
       "expandRef",
       "expandOid",
       "resetIndex",
+      "updateIndex",
       "resolveRef",
       "writeRef",
       "deleteRef",

--- a/website/versioned_docs/version-1.x/alphabetic.md
+++ b/website/versioned_docs/version-1.x/alphabetic.md
@@ -60,6 +60,7 @@ original_id: alphabetic
 - [status](status)
 - [statusMatrix](statusMatrix)
 - [tag](tag)
+- [updateIndex](updateIndex)
 - [version](version)
 - [walk](walk)
 - [writeBlob](writeBlob)

--- a/website/versioned_docs/version-1.x/updateIndex.md
+++ b/website/versioned_docs/version-1.x/updateIndex.md
@@ -1,0 +1,72 @@
+---
+title: updateIndex
+sidebar_label: updateIndex
+id: version-1.x-updateIndex
+original_id: updateIndex
+---
+
+Register file contents in the working tree or object database to the git index (aka staging area).
+
+| param          | type [= default]                | description                                                                                                                       |
+| -------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                        | a file system client                                                                                                              |
+| **dir**        | string                          | The [working tree](dir-vs-gitdir.md) directory path                                                                               |
+| **gitdir**     | string = join(dir, '.git')      | The [git directory](dir-vs-gitdir.md) path                                                                                        |
+| **filepath**   | string                          | File to act upon.                                                                                                                 |
+| oid            | string                          | OID of the object in the object database to add to the index with the specified filepath.                                         |
+| mode           | number = 100644                 | The file mode to add the file to the index.                                                                                       |
+| add            | boolean                         | Adds the specified file to the index if it does not yet exist in the index.                                                       |
+| remove         | boolean                         | Remove the specified file from the index if it does not exist in the workspace anymore.                                           |
+| force          | boolean                         | Remove the specified file from the index, even if it still exists in the workspace.                                               |
+| cache          | object                          | a [cache](cache.md) object                                                                                                        |
+| return         | Promise\<(string &#124; void)\> | Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed. |
+
+Example Code:
+
+```js live
+await git.updateIndex({
+  fs,
+  dir: '/tutorial',
+  filepath: 'readme.md'
+})
+```
+
+```js live
+// Manually create a blob in the object database.
+let oid = await git.writeBlob({
+  fs,
+  dir: '/tutorial',
+  blob: new Uint8Array([])
+})
+
+// Write the object in the object database to the index.
+await git.updateIndex({
+  fs,
+  dir: '/tutorial',
+  add: true,
+  filepath: 'readme.md',
+  oid
+})
+```
+
+
+---
+
+<details>
+<summary><i>Tip: If you need a clean slate, expand and run this snippet to clean up the file system.</i></summary>
+
+```js live
+window.fs = new LightningFS('fs', { wipe: true })
+window.pfs = window.fs.promises
+console.log('done')
+```
+</details>
+
+<script>
+(function rewriteEditLink() {
+  const el = document.querySelector('a.edit-page-link.button');
+  if (el) {
+    el.href = 'https://github.com/isomorphic-git/isomorphic-git/edit/main/src/api/updateIndex.js';
+  }
+})();
+</script>

--- a/website/versioned_sidebars/version-1.x-sidebars.json
+++ b/website/versioned_sidebars/version-1.x-sidebars.json
@@ -84,6 +84,7 @@
       "version-1.x-expandRef",
       "version-1.x-expandOid",
       "version-1.x-resetIndex",
+      "version-1.x-updateIndex",
       "version-1.x-resolveRef",
       "version-1.x-writeRef",
       "version-1.x-deleteRef",


### PR DESCRIPTION
closes #1494

I've added a new API, which is the `updateIndex` API. This is based on the [git update-index](https://git-scm.com/docs/git-update-index) command.

The current implementation allows for adding, removing, force-removing files on disk, or files which are virtual and only live in the object database. The latter use case covers `git update-index --cacheinfo <mode>,<object>,<file>`.

I'm throwing errors based on how `git update-index` throws. I was back-and-forth on adding new error types, but wasn't sure so I worked with what was already there.

I've added quite some tests to it, and tested this new API locally already with the tool that I'm building and seems to work like it should.

## I'm adding a new command:

- [x] add as a new file in `src/api` (and `src/commands` if necessary)
- [x] add command to `src/index.js`
- [x] update `__tests__/test-exports.js`
- [x] create a test in `src/__tests__`
- [x] document the command with a JSDoc comment
- [x] add page to the Docs Sidebar `website/sidebars.json`
- [x] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "feat: add updateIndex API"
