### PR TITLE
feat: add --force and statusMatrix --ignored

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Remote",
+      "address": "localhost",
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**/*.js"]
+    },
+    ]
+}

--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -94,8 +94,22 @@ describe('add', () => {
       dir,
       filepath: ['a.txt', 'i.txt'],
     })
-    expect((await listFiles({ fs, dir })).length).toEqual(1)
-    expect(await listFiles({ fs, dir })).toEqual(['a.txt'])
+  })
+  it('multiple files with 1 ignored and force:true', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    await writeGitIgnore(fs, dir)
+
+    // Test
+    await init({ fs, dir })
+    await add({
+      fs,
+      dir,
+      filepath: ['a.txt', 'i.txt'],
+      force: true,
+    })
+    expect((await listFiles({ fs, dir })).length).toEqual(2)
+    expect(await listFiles({ fs, dir })).toEqual(['a.txt', 'i.txt'])
   })
   it('symlink', async () => {
     // Setup
@@ -136,6 +150,15 @@ describe('add', () => {
     await add({ fs, dir, filepath: 'i.txt' })
     expect((await listFiles({ fs, dir })).length).toEqual(0)
   })
+  it('ignored file but with force=true', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    await writeGitIgnore(fs, dir)
+    // Test
+    await init({ fs, dir })
+    await add({ fs, dir, filepath: 'i.txt', force: true })
+    expect((await listFiles({ fs, dir })).length).toEqual(1)
+  })
   it('non-existant file', async () => {
     // Setup
     const { fs, dir } = await makeFixture('test-add')
@@ -167,6 +190,16 @@ describe('add', () => {
     expect((await listFiles({ fs, dir })).length).toEqual(0)
     await add({ fs, dir, filepath: 'c' })
     expect((await listFiles({ fs, dir })).length).toEqual(3)
+  })
+  it('folder with .gitignore and force', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    await writeGitIgnore(fs, dir)
+    // Test
+    await init({ fs, dir })
+    expect((await listFiles({ fs, dir })).length).toEqual(0)
+    await add({ fs, dir, filepath: 'c', force: true })
+    expect((await listFiles({ fs, dir })).length).toEqual(4)
   })
   it('git add .', async () => {
     // Setup

--- a/src/api/add.js
+++ b/src/api/add.js
@@ -19,7 +19,7 @@ import { join } from '../utils/join.js'
  * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string|string[]} args.filepath - The path to the file to add to the index
  * @param {object} [args.cache] - a [cache](cache.md) object
- * @param {boolean} args.force - add to index even if matches gitignore. Think `git add --force`
+ * @param {boolean} [args.force=false] - add to index even if matches gitignore. Think `git add --force`
  *
  * @returns {Promise<void>} Resolves successfully once the git index has been updated
  *

--- a/src/api/add.js
+++ b/src/api/add.js
@@ -57,15 +57,15 @@ async function addToIndex({ dir, gitdir, fs, filepath, index, force }) {
   // TODO: Should ignore UNLESS it's already in the index.
   filepath = Array.isArray(filepath) ? filepath : [filepath]
   const promises = filepath.map(async currentFilepath => {
-    const ignored = force
-      ? false
-      : await GitIgnoreManager.isIgnored({
-          fs,
-          dir,
-          gitdir,
-          filepath: currentFilepath,
-        })
-    if (ignored) return
+    if (!force) {
+      const ignored = await GitIgnoreManager.isIgnored({
+        fs,
+        dir,
+        gitdir,
+        filepath: currentFilepath,
+      })
+      if (ignored) return
+    }
     const stats = await fs.lstat(join(dir, currentFilepath))
     if (!stats) throw new NotFoundError(currentFilepath)
 

--- a/src/api/add.js
+++ b/src/api/add.js
@@ -60,11 +60,11 @@ async function addToIndex({ dir, gitdir, fs, filepath, index, force }) {
     const ignored = force
       ? false
       : await GitIgnoreManager.isIgnored({
-        fs,
-        dir,
-        gitdir,
-        filepath: currentFilepath,
-      })
+          fs,
+          dir,
+          gitdir,
+          filepath: currentFilepath,
+        })
     if (ignored) return
     const stats = await fs.lstat(join(dir, currentFilepath))
     if (!stats) throw new NotFoundError(currentFilepath)

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -160,7 +160,7 @@ export async function statusMatrix({
   filepaths = ['.'],
   filter,
   cache = {},
-  ignored = false,
+  ignored: shouldIgnore = false,
 }) {
   try {
     assertParameter('fs', _fs)
@@ -177,16 +177,15 @@ export async function statusMatrix({
       map: async function(filepath, [head, workdir, stage]) {
         // Ignore ignored files, but only if they are not already tracked.
         if (!head && !stage && workdir) {
-          if (
-            ignored
-              ? false
-              : await GitIgnoreManager.isIgnored({
-                  fs,
-                  dir,
-                  filepath,
-                })
-          ) {
-            return null
+          if (!shouldIgnore) {
+            const isIgnored = await GitIgnoreManager.isIgnored({
+              fs,
+              dir,
+              filepath,
+            })
+            if (isIgnored) {
+              return null
+            }
           }
         }
         // match against base paths

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -147,7 +147,7 @@ import { worthWalking } from '../utils/worthWalking.js'
  * @param {string[]} [args.filepaths = ['.']] - Limit the query to the given files and directories
  * @param {function(string): boolean} [args.filter] - Filter the results to only those whose filepath matches a function.
  * @param {object} [args.cache] - a [cache](cache.md) object
- * @param {boolean} [args.ignored] - include ignored files in the result
+ * @param {boolean} [args.ignored = false] - include ignored files in the result
  *
  * @returns {Promise<Array<StatusRow>>} Resolves with a status matrix, described below.
  * @see StatusRow

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -174,17 +174,17 @@ export async function statusMatrix({
       dir,
       gitdir,
       trees: [TREE({ ref }), WORKDIR(), STAGE()],
-      map: async function (filepath, [head, workdir, stage]) {
+      map: async function(filepath, [head, workdir, stage]) {
         // Ignore ignored files, but only if they are not already tracked.
         if (!head && !stage && workdir) {
           if (
             ignored
               ? false
               : await GitIgnoreManager.isIgnored({
-                fs,
-                dir,
-                filepath,
-              })
+                  fs,
+                  dir,
+                  filepath,
+                })
           ) {
             return null
           }

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -147,6 +147,7 @@ import { worthWalking } from '../utils/worthWalking.js'
  * @param {string[]} [args.filepaths = ['.']] - Limit the query to the given files and directories
  * @param {function(string): boolean} [args.filter] - Filter the results to only those whose filepath matches a function.
  * @param {object} [args.cache] - a [cache](cache.md) object
+ * @param {boolean} [args.ignored] - include ignored files in the result
  *
  * @returns {Promise<Array<StatusRow>>} Resolves with a status matrix, described below.
  * @see StatusRow
@@ -159,6 +160,7 @@ export async function statusMatrix({
   filepaths = ['.'],
   filter,
   cache = {},
+  ignored = false,
 }) {
   try {
     assertParameter('fs', _fs)
@@ -172,15 +174,17 @@ export async function statusMatrix({
       dir,
       gitdir,
       trees: [TREE({ ref }), WORKDIR(), STAGE()],
-      map: async function(filepath, [head, workdir, stage]) {
+      map: async function (filepath, [head, workdir, stage]) {
         // Ignore ignored files, but only if they are not already tracked.
         if (!head && !stage && workdir) {
           if (
-            await GitIgnoreManager.isIgnored({
-              fs,
-              dir,
-              filepath,
-            })
+            ignored
+              ? false
+              : await GitIgnoreManager.isIgnored({
+                fs,
+                dir,
+                filepath,
+              })
           ) {
             return null
           }

--- a/website/versioned_docs/version-1.x/add.md
+++ b/website/versioned_docs/version-1.x/add.md
@@ -7,14 +7,15 @@ original_id: add
 
 Add a file to the git index (aka staging area)
 
-| param          | type [= default]                | description                                               |
-| -------------- | ------------------------------- | --------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                        | a file system implementation                              |
-| **dir**        | string                          | The [working tree](dir-vs-gitdir.md) directory path       |
-| **gitdir**     | string = join(dir, '.git')      | The [git directory](dir-vs-gitdir.md) path                |
-| **filepath**   | string  &#124;  Array\<string\> | The path to the file to add to the index                  |
-| cache          | object                          | a [cache](cache.md) object                                |
-| return         | Promise\<void\>                 | Resolves successfully once the git index has been updated |
+| param          | type [= default]                | description                                                     |
+| -------------- | ------------------------------- | --------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                        | a file system implementation                                    |
+| **dir**        | string                          | The [working tree](dir-vs-gitdir.md) directory path             |
+| **gitdir**     | string = join(dir, '.git')      | The [git directory](dir-vs-gitdir.md) path                      |
+| **filepath**   | string  &#124;  Array\<string\> | The path to the file to add to the index                        |
+| cache          | object                          | a [cache](cache.md) object                                      |
+| **force**      | boolean                         | add to index even if matches gitignore. Think `git add --force` |
+| return         | Promise\<void\>                 | Resolves successfully once the git index has been updated       |
 
 Example Code:
 

--- a/website/versioned_docs/version-1.x/statusMatrix.md
+++ b/website/versioned_docs/version-1.x/statusMatrix.md
@@ -16,6 +16,7 @@ Efficiently get the status of multiple files at once.
 | filepaths      | Array\<string\> = ['.']       | Limit the query to the given files and directories                                                 |
 | filter         | function(string): boolean     | Filter the results to only those whose filepath matches a function.                                |
 | cache          | object                        | a [cache](cache.md) object                                                                         |
+| ignored        | boolean                       | include ignored files in the result                                                                |
 | return         | Promise\<Array\<StatusRow\>\> | Resolves with a status matrix, described below.                                                    |
 
 ```ts


### PR DESCRIPTION
## I'm adding a parameter to an existing command add/statusMatrix:
see https://github.com/isomorphic-git/isomorphic-git/issues/1515

create a boolean `force` param for add (equivalent of `git add --force`...add it to the index even if it would match the .gitignore)

create a boolean `ignored` param for statusMatrix (it already returns anything in the index, even if ignored, but would NOT show new files if they are ignored).  This allows for that use case

---

> note 1: the `git status --ignored` flag was at some point modfied to take arguments.  

This hard to implement as an object with a default, so I left it as a boolean and it's doing "traditional"
see https://git-scm.com/docs/git-status

My recommendation would be that if you ever wanted those, you'd have another prop on the object called ignored-mode that defaults to "traditional" and implements all that other logic, so that `ignored` would represent the "presence" of the `ignored` flag, and the ignored-mode would represent its value

---
> note 2: the status command returns `ignored` for ignored files, which seems perfectly fine

- [x] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [x] document the parameter in the JSDoc comment above the function
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat(X): Added 'bar' parameter"
