### PR TITLE
fix(updateIndex): prevent removing directories

### DIFF
--- a/src/api/updateIndex.js
+++ b/src/api/updateIndex.js
@@ -78,15 +78,22 @@ export async function updateIndex({
             fileStats = await fs.lstat(join(dir, filepath))
 
             if (fileStats) {
+              if (fileStats.isDirectory()) {
+                // Removing directories should not work
+                throw new InvalidFilepathError('directory')
+              }
+
               // Do nothing if we don't force and the file still exists in the workdir
               return
             }
           }
 
-          // Remove the file from the index if it's forced or the file does not exist
-          index.delete({
-            filepath,
-          })
+          // Directories are not allowed, so we make sure the provided filepath exists in the index
+          if (index.has({ filepath })) {
+            index.delete({
+              filepath,
+            })
+          }
         }
       )
     }


### PR DESCRIPTION
I noticed I had a small oversight inside the `updateIndex` API. 

- Removing a directory should throw an error if `force` was not used.
- Removing a directory with `force` should not remove all files inside that directory.

This PR fixes both issues and adds tests for both.

## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix(updateIndex): prevent removing directories"