### PR TITLE
fix: Assert parameter is confusing... fix

### DIFF
--- a/src/api/add.js
+++ b/src/api/add.js
@@ -41,7 +41,7 @@ export async function add({
     assertParameter('fs', _fs)
     assertParameter('dir', dir)
     assertParameter('gitdir', gitdir)
-    assertParameter('filepaths', filepath)
+    assertParameter('filepath', filepath)
 
     const fs = new FileSystem(_fs)
     await GitIndexManager.acquire({ fs, gitdir, cache }, async index => {


### PR DESCRIPTION
## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "fix: [Description of fix]"

```
MissingParameterError: The function requires a "filepaths" parameter but none was provided.
```

There is no such parameter as filepaths... there is a filepath, hence the PR. 

Also, we are not following any case convention :/ , corsProxy and singleBranch are came cased, but filepath is lower cased. I propose deprecating and printing a deprecation warning.

To make matters worse filePath is not a normal file path... a path relative to the git repo. perhaps it should be called realtivePath instead.