### PR TITLE
chore(deps): bump extend from 3.0.1 to 3.0.2 in /website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3950,9 +3950,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {


### PR DESCRIPTION
## I'm updating a dependency

This PR updates `extend` in `/website` to close #993. The release fixes prototype pollution and poses low risk.

### Notes

v3.0.2 is still the latest version:
```
$ npm show extend@3 version
extend@3.0.0 '3.0.0'
extend@3.0.1 '3.0.1'
extend@3.0.2 '3.0.2'
```

We are still using v3.0.1:

```
$ npm ls 'extend@<=3.0.1'
```

<img width="567" alt="image" src="https://user-images.githubusercontent.com/2585460/163501389-a12e8129-625b-43f6-aaf7-cc4009c13beb.png">


