### PR TITLE
chore(deps): bump acorn from 6.4.0 to 6.4.2 in /website/packages/codemirrorify

### DIFF
--- a/website/packages/codemirrorify/package-lock.json
+++ b/website/packages/codemirrorify/package-lock.json
@@ -219,9 +219,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1658,16 +1658,16 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1675,16 +1675,16 @@
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
@@ -1693,16 +1693,16 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1711,16 +1711,16 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1728,31 +1728,30 @@
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -1760,9 +1759,9 @@
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4.0.0"
@@ -1770,16 +1769,16 @@
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true,
       "inBundle": true,
+      "license": "Apache-2.0",
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -1790,9 +1789,9 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
@@ -1800,16 +1799,16 @@
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
@@ -1824,9 +1823,9 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -1845,16 +1844,16 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -1865,9 +1864,9 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
@@ -1875,9 +1874,9 @@
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -1886,17 +1885,16 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "engines": {
         "node": "*"
@@ -1904,9 +1902,9 @@
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -1917,16 +1915,16 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1937,16 +1935,16 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -1955,9 +1953,9 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
@@ -1965,10 +1963,9 @@
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
@@ -1979,16 +1976,16 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
@@ -2004,10 +2001,9 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
-      "deprecated": "Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future",
       "dev": true,
       "inBundle": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
@@ -2027,9 +2023,9 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "abbrev": "1",
@@ -2041,9 +2037,9 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
@@ -2051,16 +2047,16 @@
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
@@ -2069,9 +2065,9 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
@@ -2082,9 +2078,9 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2092,9 +2088,9 @@
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2102,9 +2098,9 @@
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "wrappy": "1"
@@ -2112,9 +2108,9 @@
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2122,9 +2118,9 @@
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2132,9 +2128,9 @@
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
@@ -2143,9 +2139,9 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2153,16 +2149,16 @@
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -2176,16 +2172,16 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -2199,9 +2195,9 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -2212,30 +2208,30 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver"
@@ -2243,23 +2239,23 @@
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -2267,9 +2263,9 @@
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -2282,9 +2278,9 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -2295,9 +2291,9 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2305,9 +2301,9 @@
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
@@ -2324,16 +2320,16 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
@@ -2341,16 +2337,16 @@
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/get-caller-file": {
@@ -5156,9 +5152,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true
     },
     "ajv": {


### PR DESCRIPTION
## I'm updating a dependency

This PR updates `acorn` to close #1100. The release is low risk update. The changes to `acorn` modified how regular expressions are handled to improve security/stability.

### Notes

We are updated to v6.4.2 which is the latest 6.x version:

```
$ npm show 'acorn@^6.4.0' version
acorn@6.4.0 '6.4.0'
acorn@6.4.1 '6.4.1'
acorn@6.4.2 '6.4.2'
```

We are still using v6.4.0:

```
$ npm ls acorn
```

<img width="802" alt="image" src="https://user-images.githubusercontent.com/2585460/163728116-34b5e627-ec1b-4030-8994-b7b7d02352b8.png">

There are more changes to `package-lock.json` file than I would expect but they were caused by `npm update`. It is reproducibly running the following commands which makes me think there are still rough edges with npm v8:

```
npm install -g npm@latest
npm install --package-lock-only
npm update acorn
```
