### PR TITLE
chore(deps): bump websocket-extensions from 0.1.3 to 0.1.4 in /website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13678,9 +13678,9 @@
       }
     },
     "node_modules/websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -25281,9 +25281,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "whatwg-url": {


### PR DESCRIPTION
## I'm updating a dependency

This PR updates `websocket-extensions` to close #1149. This is a low risk release. The update fixes a security vulnerability.

### Notes

We are still using v0.1.3:

```
$ npm ls websocket-extensions
```

<img width="570" alt="image" src="https://user-images.githubusercontent.com/2585460/163827156-33506041-f97c-4e14-94f4-efc3b58d3673.png">

The latest version is still 0.1.4:

```
$ npm show 'websocket-extensions@>=0.1.3' version
websocket-extensions@0.1.3 '0.1.3'
websocket-extensions@0.1.4 '0.1.4'
```
