### PR TITLE
chore(deps-dev): bump eslint-config-prettier from 6.10.0 to 6.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9596,9 +9596,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
       "dev": true,
       "dependencies": {
         "get-stdin": "^6.0.0"
@@ -37475,9 +37475,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"


### PR DESCRIPTION
## I'm updating a dependency

This PR updates `eslint-config-prettier` to close #1395. This is a low risk update that adds a few features. We can't upgrade to v7.x until we update `eslint`.

### Notes

We are still using v6.10.0:

```
$ npm ls eslint-config-prettier
```

<img width="682" alt="image" src="https://user-images.githubusercontent.com/2585460/163926791-bda8231d-72d3-410e-a962-5a43719f1847.png">

We can update to the latest 6.x version, 6.15.0:

```
$ npm show 'eslint-config-prettier@>=6.10.0' version
eslint-config-prettier@6.10.0 '6.10.0'
eslint-config-prettier@6.10.1 '6.10.1'
eslint-config-prettier@6.11.0 '6.11.0'
eslint-config-prettier@6.12.0 '6.12.0'
eslint-config-prettier@6.13.0 '6.13.0'
eslint-config-prettier@6.14.0 '6.14.0'
eslint-config-prettier@6.15.0 '6.15.0'
eslint-config-prettier@7.0.0 '7.0.0'
```

### Test Plan

- When we run `npm run format` there are no issues reported or fixed
