### PR TITLE
chore(deps-dev): bump markdown-table from 1.1.3 to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "karma-sauce-launcher": "1.2.0",
         "karma-verbose-reporter": "0.0.6",
         "karma-webpack": "4.0.2",
-        "markdown-table": "1.1.3",
+        "markdown-table": "^2.0.0",
         "nps": "^5.10.0",
         "nps-utils": "1.7.0",
         "prettier": "1.19.1",
@@ -18854,10 +18854,17 @@
       }
     },
     "node_modules/markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/marked": {
       "version": "2.1.1",
@@ -44600,10 +44607,13 @@
       "requires": {}
     },
     "markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
     },
     "marked": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-verbose-reporter": "0.0.6",
     "karma-webpack": "4.0.2",
-    "markdown-table": "1.1.3",
+    "markdown-table": "^2.0.0",
     "nps": "^5.10.0",
     "nps-utils": "1.7.0",
     "prettier": "1.19.1",


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `markdown-table` to close #1549.

We'll only update to v2.0.0 today. The update to v3 is ESM only. We can defer that update.

### Test Plan

`markdown-table` is used in these two files:

- \_\_tests\_\_/\_\_helpers\_\_/generate-docs.cjs
- \_\_tests\_\_/\_\_helpers\_\_/karma-pr-comment-reporter.cjs

If we write the output to a file for v1.1.3 and v2.0.0 the output is identical.

### Notes

We are still using v1.1.3:

```
$ npm ls markdown-table
```

<img width="677" alt="image" src="https://user-images.githubusercontent.com/2585460/164143611-e19debf2-6656-4257-a475-b79a4d4b5608.png">

We'll use v2.0.0 which is the latest 2.x release:

```
$ npm show 'markdown-table@>=1.1.3' version
markdown-table@1.1.3 '1.1.3'
markdown-table@2.0.0 '2.0.0' ⭐️
markdown-table@3.0.0 '3.0.0'
markdown-table@3.0.1 '3.0.1'
markdown-table@3.0.2 '3.0.2'
```
