### PR TITLE
chore(deps): bump async from 2.6.1 to 2.6.4

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -56,7 +56,7 @@ module.exports = function (config) {
     // Increase timeouts since some actions take quite a while.
     browserNoActivityTimeout: 4 * 60 * 1000, // default 10000
     // https://support.saucelabs.com/hc/en-us/articles/225104707-Karma-Tests-Disconnect-Particularly-When-Running-Tests-on-Safari
-    browserDisconnectTimeout: 10000, // default 2000
+    browserDisconnectTimeout: 20000, // default 2000
     browserDisconnectTolerance: 0, // default 0
     captureTimeout: 4 * 60 * 1000, // default 60000
     // SauceLabs browsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -5157,15 +5157,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/archiver/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/archiver/node_modules/bl": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
@@ -5491,12 +5482,12 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/async-each": {
@@ -33632,15 +33623,6 @@
         "zip-stream": "^2.1.2"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "bl": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
@@ -33950,12 +33932,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.14"
       }
     },
     "async-each": {


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `async` to close #1536.

The update from v2.6.1 to v2.6.4 is a low risk change that fixes vulnerability alerts.

### Notes

We are still using v2.6.1:

```
$ npm ls async@2
```

<img width="684" alt="image" src="https://user-images.githubusercontent.com/2585460/164279732-24c3ba0f-66e2-479d-8727-a965e21fcd18.png">

v2.6.4 is still the latest version:

```
$ npm show 'async@^2.6.1' version
async@2.6.1 '2.6.1'
async@2.6.2 '2.6.2'
async@2.6.3 '2.6.3'
async@2.6.4 '2.6.4'
```
