### PR TITLE
chore(deps): bump async from 2.6.3 to 2.6.4 in /website

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -56,7 +56,7 @@ module.exports = function (config) {
     // Increase timeouts since some actions take quite a while.
     browserNoActivityTimeout: 4 * 60 * 1000, // default 10000
     // https://support.saucelabs.com/hc/en-us/articles/225104707-Karma-Tests-Disconnect-Particularly-When-Running-Tests-on-Safari
-    browserDisconnectTimeout: 10000, // default 2000
+    browserDisconnectTimeout: 20000, // default 2000
     browserDisconnectTolerance: 0, // default 0
     captureTimeout: 4 * 60 * 1000, // default 60000
     // SauceLabs browsers

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -15234,9 +15234,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `async` to close #1535.

The update from v2.6.3 to v2.6.4 is a low risk change.

### Notes

We are still using v2.6.3:

```
$ npm ls async
```

<img width="566" alt="image" src="https://user-images.githubusercontent.com/2585460/164280071-bc6006d5-ac10-4d98-9447-f6443acd9f4f.png">

v2.6.4 is still the latest version:

```
$ npm show 'async@^2.6.1' version
async@2.6.1 '2.6.1'
async@2.6.2 '2.6.2'
async@2.6.3 '2.6.3'
async@2.6.4 '2.6.4'
```
