### PR TITLE
chore(deps): bump yargs-parser from 13.1.1 to 13.1.2 in /website/pack…

### DIFF
--- a/website/packages/codemirrorify/package-lock.json
+++ b/website/packages/codemirrorify/package-lock.json
@@ -4941,9 +4941,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -9099,9 +9099,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `yargs-parser` to close #1227.

The update from v13.1.1 to v13.1.2 is a low risk security patch for prototype pollution. [This issue](https://github.com/yargs/yargs-parser/issues/320) explains that there is no published release or changelog for this backported patch.

### Notes

We are still using v13.1.1:

```
$ npm ls yargs-parser
```

<img width="822" alt="image" src="https://user-images.githubusercontent.com/2585460/168448120-00e7f128-bb5a-4a8b-83f6-efc558a23c28.png">

v13.1.2 is still the latest version:

```
$ $ npm show 'yargs-parser@13' version
yargs-parser@13.0.0 '13.0.0'
yargs-parser@13.1.0 '13.1.0'
yargs-parser@13.1.1 '13.1.1'
yargs-parser@13.1.2 '13.1.2'
```
