### PR TITLE
chore(deps): bump lodash from 4.17.15 to 4.17.21 in /website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,6 @@ updates:
     - 6.0.3
     - 6.1.0
     - 6.1.1
-  - dependency-name: lodash
-    versions:
-    - 4.17.20
   - dependency-name: jasmine-core
     versions:
     - 3.6.0

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8299,9 +8299,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash._reinterpolate": {
@@ -20702,9 +20702,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash._reinterpolate": {


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `lodash` to close #1469 and lets Dependabot maintain it.

[Comparing tags](https://github.com/lodash/lodash/compare/4.17.15...4.17.21) shows that this is a low risk change including performance, security, and bug fixes.

### Notes

We are still using v4.17.15:

```
$ npm ls lodash
```

<img width="570" alt="Screen Shot 2022-05-14 at 19 58 39" src="https://user-images.githubusercontent.com/2585460/168452248-c47898e4-7eb5-490c-aa6d-c45c76f0acea.png">

v4.17.21 is still the latest version:

```
$ npm show 'lodash@>=4.17.15' version
lodash@4.17.15 '4.17.15'
lodash@4.17.16 '4.17.16'
lodash@4.17.17 '4.17.17'
lodash@4.17.18 '4.17.18'
lodash@4.17.19 '4.17.19'
lodash@4.17.20 '4.17.20'
lodash@4.17.21 '4.17.21'
```
