### PR TITLE
chore(deps): bump karma-verbose-reporter from 0.0.6 to 0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "karma-junit-reporter": "^2.0.1",
         "karma-safari-launcher": "1.0.0",
         "karma-sauce-launcher": "1.2.0",
-        "karma-verbose-reporter": "0.0.6",
+        "karma-verbose-reporter": "0.0.8",
         "karma-webpack": "4.0.2",
         "markdown-table": "^2.0.0",
         "nps": "^5.10.0",
@@ -18016,12 +18016,12 @@
       }
     },
     "node_modules/karma-verbose-reporter": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.6.tgz",
-      "integrity": "sha1-WQkFJFHGB/Aqx3x2N5Gi/hJRJgw=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.8.tgz",
+      "integrity": "sha512-wHgevIcEpfgKwR3CnWd8t1ErzWeVlctO7ZtXkKFR1inb006ogz+7ZKg95eIVOnHCYWL3Gdy1dRMOGjVP0n4MlA==",
       "dev": true,
       "dependencies": {
-        "colors": ">=1.0"
+        "colors": "1.4.0"
       },
       "peerDependencies": {
         "karma": ">=0.12"
@@ -44094,12 +44094,12 @@
       }
     },
     "karma-verbose-reporter": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.6.tgz",
-      "integrity": "sha1-WQkFJFHGB/Aqx3x2N5Gi/hJRJgw=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.8.tgz",
+      "integrity": "sha512-wHgevIcEpfgKwR3CnWd8t1ErzWeVlctO7ZtXkKFR1inb006ogz+7ZKg95eIVOnHCYWL3Gdy1dRMOGjVP0n4MlA==",
       "dev": true,
       "requires": {
-        "colors": ">=1.0"
+        "colors": "1.4.0"
       }
     },
     "karma-webpack": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "karma-junit-reporter": "^2.0.1",
     "karma-safari-launcher": "1.0.0",
     "karma-sauce-launcher": "1.2.0",
-    "karma-verbose-reporter": "0.0.6",
+    "karma-verbose-reporter": "0.0.8",
     "karma-webpack": "4.0.2",
     "markdown-table": "^2.0.0",
     "nps": "^5.10.0",


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `karma-verbose-reporter`.

[Comparing tags](https://github.com/usrz/javascript-karma-verbose-reporter/compare/0.0.6...0.0.8) shows that this is a low risk change that adds an elapsed time and a dependency.

### Notes

We are using 0.0.6:

```
$ npm ls lodash
```

<img width="680" alt="Screen Shot 2022-05-14 at 20 29 56" src="https://user-images.githubusercontent.com/2585460/168452530-be4f1b01-6456-4022-80c5-0abd354a605d.png">

v0.0.8 is the latest version:

```
$ npm show 'karma-verbose-reporter@>=0.0.6' version
karma-verbose-reporter@0.0.6 '0.0.6'
karma-verbose-reporter@0.0.7 '0.0.7'
karma-verbose-reporter@0.0.8 '0.0.8'
```
