### PR TITLE
chore: Prevent Dependabot from updating puppeteer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,6 @@ updates:
   - dependency-name: handlebars
     versions:
     - 4.7.6
+  - dependency-name: puppeteer
+    versions:
+    - "> 2.0.0"


### PR DESCRIPTION
As discussed in https://github.com/isomorphic-git/isomorphic-git/pull/1572#issuecomment-1126798804 we can configure Dependabot not to automatically update `puppeteer`.  
We only want to update `puppeteer` when we update the supported version of Chrome.
