### PR TITLE
chore(deps): bump ini from 1.3.5 to 1.3.8 in /website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7213,14 +7213,10 @@
       "dev": true
     },
     "node_modules/ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/inquirer": {
       "version": "6.5.0",
@@ -19833,9 +19829,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {


### PR DESCRIPTION
## I'm updating a depedency

This PR updates `ini` to close #1284.

[Reviewing the changes](https://github.com/npm/ini/compare/v1.3.5...v1.3.8) shows this is a low risk change including a security patch.

### Notes

We are using 1.3.5:

```
$ npm ls 'ini@<1.3.8'
```

<img width="570" alt="Screen Shot 2022-05-14 at 19 58 39" src="https://user-images.githubusercontent.com/2585460/168699393-e4de929c-406a-47db-8f10-583e71fa6b94.png">

v1.3.8 is still the latest version:

```
$ npm show 'ini@>=1.3.5' version
ini@1.3.5 '1.3.5'
ini@1.3.6 '1.3.6'
ini@1.3.7 '1.3.7'
ini@1.3.8 '1.3.8'
ini@2.0.0 '2.0.0'
ini@3.0.0 '3.0.0'
```
