### PR TITLE
Increase test timeouts to fix Android 10 disconnects

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -105,6 +105,8 @@ module.exports = function (config) {
         browser: 'android',
         device: 'Google Pixel 4',
         real_mobile: true,
+        captureTimeout: 5 * 60 * 1000, // defaults to 120 ms
+        timeout: 1000,                 // defaults to 300 ms
       },
       FirefoxHeadless: {
         base: 'Firefox',

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -53,12 +53,16 @@ module.exports = function (config) {
     port: 9876,
     // enable / disable colors in the output (reporters and logs)
     colors: true,
+
     // Increase timeouts since some actions take quite a while.
-    browserNoActivityTimeout: 4 * 60 * 1000, // default 10000
-    // https://support.saucelabs.com/hc/en-us/articles/225104707-Karma-Tests-Disconnect-Particularly-When-Running-Tests-on-Safari
-    browserDisconnectTimeout: 20000, // default 2000
-    browserDisconnectTolerance: 0, // default 0
-    captureTimeout: 4 * 60 * 1000, // default 60000
+    // Refer to:
+    // - https://support.saucelabs.com/hc/en-us/articles/225104707-Karma-Tests-Disconnect-Particularly-When-Running-Tests-on-Safari
+    // - https://github.com/karma-runner/karma-browserstack-launcher/issues/61
+    browserDisconnectTimeout: 5 * 60 * 1000,  // default 2000
+    browserDisconnectTolerance: 3,            // default 0
+    browserNoActivityTimeout: 5 * 60 * 1000,  // default 10000
+    captureTimeout: 5 * 60 * 1000,            // default 60000
+
     // SauceLabs browsers
     customLaunchers: {
       XXXsl_chrome: {

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -188,6 +188,11 @@ module.exports = function (config) {
         ],
       },
     ],
+    client: {
+      jasmine: {
+        timeoutInterval: 60000, // Defaults to 5000 ms
+      },
+    },
   }
 
   // Speed things up, at the cost of not saving the test results (except in the stdout log).


### PR DESCRIPTION
### What are you trying to do?

This PR attempts to fix the flaky test disconnects when testing using Android 10 on BrowserStack in the CI pipelines.

### How did we accomplish the goal?

- Change the global Jasmine (test runner) timeout from 5s to 60s. We change the test timeout in `__tests__/__helpers__/set-test-timeout.js` but it is not called consistently in all tests. The random test order could affect the outcomes.
- Change the BrowserStack timeouts specifically for the Android 10 profile. This follows [the docs](https://github.com/karma-runner/karma-browserstack-launcher#global-options).
- Increase the Karma timeouts based on indirect advice from BrowserStack support shared in [this issue](https://github.com/karma-runner/karma-browserstack-launcher/issues/61).

### Test Plan

Run the CI pipeline and hope it works. 🤞

### Test Results

The build failed the first time because the BrowserStack `timeout` must be 1000 or less. [2767](https://dev.azure.com/isomorphic-git/isomorphic-git/_build/results?buildId=2767&view=results).

After that we have 20+ passing builds in a row:

https://dev.azure.com/isomorphic-git/isomorphic-git/_build?definitionId=1&_a=summary
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/2585460/170650493-18879328-14a8-43e9-9ea9-3ee44cb6acca.png">
