### PR TITLE
fix(log): fix error being thrown when using 'filepath' parameter

### DIFF
--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -129,11 +129,11 @@ export async function _log({
             }
           }
           if (!found) {
-            if (!force && !follow) throw e
             if (isOk && lastFileOid) {
               commits.push(lastCommit)
-              // break
+              if (!force) break
             }
+            if (!force && !follow) throw e
           }
           lastCommit = commit
           isOk = false


### PR DESCRIPTION
Once we find the last occurrence of a file in the commit history (not using `force` or `follow`), we should try to break first instead of throwing an error.

Should fix #1558