### PR TITLE
fix(merge): ensure correct value of cleanMerge

### DIFF
--- a/src/utils/mergeTree.js
+++ b/src/utils/mergeTree.js
@@ -118,7 +118,7 @@ export async function mergeTree({
               theirName,
               mergeDriver,
             }).then(r => {
-              cleanMerge = r.cleanMerge
+              cleanMerge = cleanMerge && r.cleanMerge
               unmergedFiles.push(filepath)
               return r.mergeResult
             })


### PR DESCRIPTION
This should fix an issue where `mergeTree` might report a clean merge even if there was not one. If the most recent merged blob was merged cleanly, `cleanMerge` should still be `false` if previous blobs failed.