### PR TITLE
fix(onProgress): the "Resolving deltas" count was off by 1

### DIFF
--- a/src/models/GitPackIndex.js
+++ b/src/models/GitPackIndex.js
@@ -176,7 +176,7 @@ export class GitPackIndex {
     const objectsByDepth = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     for (let offset in offsetToObject) {
       offset = Number(offset)
-      const percent = Math.floor((count++ * 100) / totalObjectCount)
+      const percent = Math.floor((count * 100) / totalObjectCount)
       if (percent !== lastPercent) {
         if (onProgress) {
           await onProgress({
@@ -186,6 +186,7 @@ export class GitPackIndex {
           })
         }
       }
+      count++
       lastPercent = percent
 
       const o = offsetToObject[offset]


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [x] squash merge the PR with commit message "fix: [Description of fix]"

A Stoplight customer complained that the count is off by one, which it is.