### PR TITLE
Handle edge cases in walk diff example

### DIFF
--- a/src/api/walk.js
+++ b/src/api/walk.js
@@ -177,12 +177,15 @@ import { join } from '../utils/join.js'
  *
  * Example 2: Return the difference between the working directory and the HEAD commit
  * ```js
- * const diff = require('diff-lines')
- * async function map(filepath, [head, workdir]) {
+ * import diff from 'diff-lines'
+ * const map = async (filepath, [head, workdir]) => {
  *   return {
  *     filepath,
- *     oid: await head.oid(),
- *     diff: diff((await head.content()).toString('utf8'), (await workdir.content()).toString('utf8'))
+ *     oid: await head?.oid(),
+ *     diff: diff(
+ *       (await head?.content())?.toString('utf8') || '',
+ *       (await workdir?.content())?.toString('utf8') || ''
+ *     )
  *   }
  * }
  * ```

--- a/src/api/walk.js
+++ b/src/api/walk.js
@@ -177,7 +177,6 @@ import { join } from '../utils/join.js'
  *
  * Example 2: Return the difference between the working directory and the HEAD commit
  * ```js
- * import diff from 'diff-lines'
  * const map = async (filepath, [head, workdir]) => {
  *   return {
  *     filepath,


### PR DESCRIPTION
The walk docs example 2 creates difficult to decipher errors when head is undefined or  a document is empty.

sidenote: ` gitdir` is not required... yet it's marked as required. I was able to figure it out, but a complete example would have helped.

```
import { default as isomorphicGitFsClient } from 'node:fs'
import diff from 'diff-lines'
import { fetch, clone, fastForward, currentBranch, walk, TREE, WORKDIR, STAGE } from 'isomorphic-git'
const http = await import('./node_modules/isomorphic-git/http/node/index.js')
const isomorphicGitWorkingTreeDir = '.'

const gitStatus = async () => {
  const ref = 'HEAD'
  const trees = [TREE({ ref }), WORKDIR(), STAGE()]
  const map = async (filepath, [head, workdir]) => {
    return {
      filepath,
      oid: await head?.oid(),
      diff: diff(
        (await head?.content())?.toString('utf8') || '',
        (await workdir?.content())?.toString('utf8') || ''
      )
    }
  }
  const result = await walk({
    fs: isomorphicGitFsClient,
    dir: isomorphicGitWorkingTreeDir,
    trees,
    map
  })
  console.log(result)
}

gitStatus()
```