### PR TITLE
feat(branch): add force param to overwrite existing branch

### DIFF
--- a/__tests__/test-branch.js
+++ b/__tests__/test-branch.js
@@ -49,6 +49,45 @@ describe('branch', () => {
     expect(await listFiles({ fs, dir, gitdir, ref: 'test-branch' })).toEqual([])
   })
 
+  it('branch force', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-branch')
+    let error = null
+    // Test
+    await branch({ fs, dir, gitdir, ref: 'test-branch' })
+    expect(await currentBranch({ fs, dir, gitdir })).toEqual('master')
+    expect(
+      await fs.exists(path.resolve(gitdir, 'refs/heads/test-branch'))
+    ).toBeTruthy()
+    try {
+      await branch({ fs, dir, gitdir, ref: 'test-branch', force: true })
+    } catch (err) {
+      error = err
+    }
+    expect(error).toBeNull()
+  })
+
+  it('branch with start point force', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-branch-start-point')
+    let error = null
+    // Test
+    await branch({ fs, dir, gitdir, ref: 'test-branch', object: 'start-point' })
+    expect(await currentBranch({ fs, dir, gitdir })).toEqual('main')
+    expect(
+      await fs.exists(path.resolve(gitdir, 'refs/heads/test-branch'))
+    ).toBeTruthy()
+    try {
+      await branch({ fs, dir, gitdir, ref: 'test-branch', force: true })
+    } catch (err) {
+      error = err
+    }
+    expect(error).toBeNull()
+    expect(await listFiles({ fs, dir, gitdir, ref: 'test-branch' })).toEqual([
+      'new-file.txt',
+    ])
+  })
+
   it('branch --checkout', async () => {
     // Setup
     const { fs, dir, gitdir } = await makeFixture('test-branch')

--- a/src/api/branch.js
+++ b/src/api/branch.js
@@ -16,6 +16,7 @@ import { join } from '../utils/join.js'
  * @param {string} args.ref - What to name the branch
  * @param {string} [args.object = 'HEAD'] - What oid to use as the start point. Accepts a symbolic ref.
  * @param {boolean} [args.checkout = false] - Update `HEAD` to point at the newly created branch
+ * @param {boolean} [args.force = false] - Instead of throwing an error if a branched named `ref` already exists, overwrite the existing branch.
  *
  * @returns {Promise<void>} Resolves successfully when filesystem operations are complete
  *
@@ -31,6 +32,7 @@ export async function branch({
   ref,
   object,
   checkout = false,
+  force = false,
 }) {
   try {
     assertParameter('fs', fs)
@@ -42,6 +44,7 @@ export async function branch({
       ref,
       object,
       checkout,
+      force,
     })
   } catch (err) {
     err.caller = 'git.branch'

--- a/src/commands/branch.js
+++ b/src/commands/branch.js
@@ -16,6 +16,7 @@ import { GitRefManager } from '../managers/GitRefManager.js'
  * @param {string} args.ref
  * @param {string} [args.object = 'HEAD']
  * @param {boolean} [args.checkout = false]
+ * @param {boolean} [args.force = false]
  *
  * @returns {Promise<void>} Resolves successfully when filesystem operations are complete
  *
@@ -24,16 +25,25 @@ import { GitRefManager } from '../managers/GitRefManager.js'
  * console.log('done')
  *
  */
-export async function _branch({ fs, gitdir, ref, object, checkout = false }) {
+export async function _branch({
+  fs,
+  gitdir,
+  ref,
+  object,
+  checkout = false,
+  force = false,
+}) {
   if (ref !== cleanGitRef.clean(ref)) {
     throw new InvalidRefNameError(ref, cleanGitRef.clean(ref))
   }
 
   const fullref = `refs/heads/${ref}`
 
-  const exist = await GitRefManager.exists({ fs, gitdir, ref: fullref })
-  if (exist) {
-    throw new AlreadyExistsError('branch', ref, false)
+  if (!force) {
+    const exist = await GitRefManager.exists({ fs, gitdir, ref: fullref })
+    if (exist) {
+      throw new AlreadyExistsError('branch', ref, false)
+    }
   }
 
   // Get current HEAD tree oid


### PR DESCRIPTION
resolves #1636

## I'm adding a parameter to an existing command X:

- [x] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [x] document the parameter in the JSDoc comment above the function
- [x] add a test case in `__tests__/test-X.js` if possible
- [x] squash merge the PR with commit message "feat(X): Added 'bar' parameter"