### PR TITLE
Report correct expected type in resolveFilePath

### DIFF
--- a/src/utils/resolveFilepath.js
+++ b/src/utils/resolveFilepath.js
@@ -58,7 +58,7 @@ async function _resolveFilepath({
           oid: entry.oid,
         })
         if (type !== 'tree') {
-          throw new ObjectTypeError(oid, type, 'blob', filepath)
+          throw new ObjectTypeError(oid, type, 'tree', filepath)
         }
         tree = GitTree.from(object)
         return _resolveFilepath({


### PR DESCRIPTION
While investigating an `ObjectTypeError` (I think not this one), I noticed that this spot is checking for `tree` but reporting `blob` as expected in its message. As I understand it they should be the same; now they are.
