### PR TITLE
Fix filepath option of readTree

### DIFF
--- a/src/utils/resolveTree.js
+++ b/src/utils/resolveTree.js
@@ -3,6 +3,7 @@ import { GitAnnotatedTag } from '../models/GitAnnotatedTag.js'
 import { GitCommit } from '../models/GitCommit.js'
 import { GitTree } from '../models/GitTree.js'
 import { _readObject } from '../storage/readObject.js'
+import { resolveBlob } from '../utils/resolveBlob.js'
 
 export async function resolveTree({ fs, cache, gitdir, oid }) {
   // Empty tree - bypass `readObject`
@@ -19,6 +20,9 @@ export async function resolveTree({ fs, cache, gitdir, oid }) {
   if (type === 'commit') {
     oid = GitCommit.from(object).parse().tree
     return resolveTree({ fs, cache, gitdir, oid })
+  }
+  if (type === 'blob') {
+    return resolveBlob({ fs, cache, gitdir, oid })
   }
   if (type !== 'tree') {
     throw new ObjectTypeError(oid, type, 'tree')


### PR DESCRIPTION
## Problem

The [docs for `readTree`](https://isomorphic-git.org/docs/en/readTree) say:

filepath | string | Don't return the object with `oid` itself, but resolve `oid` to a tree and then return the tree object at that filepath.
:-- | :-- | :--

However, if you use this option, an `ObjectTypeError` is always thrown:

> `Uncaught ObjectTypeError: Object 678a5b2bab22a1d0ad7c842c1b0dab93d8892384 was anticipated to be a tree but it is a blob.`

Working code snippet:

```javascript
const tree = await git.readTree({fs, dir, cache, oid: commit.commit.tree});
```

Add `filepath` and it throws:

```javascript
const filepath = 'download_counts.json';
const tree = await git.readTree({fs, dir, cache, oid: commit.commit.tree, filepath});
```

## Cause

If `filepath` is set, `readTree` replaces the input oid with the oid of the file blob. But this is then passed to `resolveTree`, which only accepts oids of type `tag`, `commit`, or `tree`:

https://github.com/isomorphic-git/isomorphic-git/blob/0f24b6e56abb4167a9d64c5a825e60d182a3aeda/src/utils/resolveTree.js#L14-L25

So passing a blob oid can't work.

## Changes

Now `readTree` no longer passes a blob oid to `resolveTree`. Instead it calls `resolveBlob` in the `filepath` handler block, so calling code will receive back the blob of the requested filepath.
