### PR TITLE
feat: expose internal api

### DIFF
--- a/declaration.tsconfig.json
+++ b/declaration.tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["index.js", "http/web/index.js", "http/node/index.js"],
+  "include": ["index.js", "http/web/index.js", "http/node/index.js", "internal-apis.js"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "types": [],

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "index.umd.min.js",
     "index.umd.min.d.ts",
     "index.umd.min.js.map",
+    "internal-apis.js",
+    "internal-apis.cjs",
     "size_report.html"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "index.umd.min.js.map",
     "internal-apis.js",
     "internal-apis.cjs",
+    "internal-apis.d.ts",
     "size_report.html"
   ],
   "dependencies": {


### PR DESCRIPTION
fixes #1071 and #1495
It probably needs some documenation (e.g. expect breaking changes not only in new major versions, not officially supported, ...)
I also haven't figured out how to tell typescript that the `internal-apis.d.ts" belongs to the `internal-apis.js` file. The [triple slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-) does not seem to work.