### PR TITLE
chore(deps): Replace deprecated Ubuntu 18.04 image with 22.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
   - job: Linux
 
     pool:
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'ubuntu-22.04'
 
     steps:
       - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-22.04'
 
+    # Most pipelines finish in under 15 minutes. 30 minutes should be more than enough.
+    # See https://dev.azure.com/isomorphic-git/isomorphic-git/_pipeline/analytics/duration.
+    timeoutInMinutes: 30
+
     steps:
       - task: NodeTool@0
         inputs:


### PR DESCRIPTION
## I'm updating a dependency

This PR updates the Ubuntu image in the pipeline. Ubuntu 18.04 has been deprecated and will be removed on December 1st. See [these release notes](https://learn.microsoft.com/en-us/azure/devops/release-notes/2022/sprint-208-update#announcing-deprecation-of-ubuntu-1804-images-updated) for more.

There is a warning in the pipeline as well (3rd card):

<img width="1783" alt="Screen Shot 2022-11-23 at 20 16 06" src="https://user-images.githubusercontent.com/2585460/203703750-160406cb-6f98-40cd-bf5f-7469d2f0f44f.png">
