### PR TITLE
chore(ci): Update image from Ubuntu 18.04 to 20.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
   - job: Linux
 
     pool:
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'ubuntu-20.04'
 
     steps:
       - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-20.04'
 
+    # Most pipelines finish in under 15 minutes. 30 minutes should be more than enough.
+    # See https://dev.azure.com/isomorphic-git/isomorphic-git/_pipeline/analytics/duration.
+    timeoutInMinutes: 30
+
     steps:
       - task: NodeTool@0
         inputs:


### PR DESCRIPTION
## I'm updating a dependency

We haven't been having any luck with Ubuntu 22.04 in #1678.
This PR upgrades to Ubuntu 20.04 and will hopefully be more stable.
