### PR TITLE
fix: avoid recursing symlinked directories

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,17 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
       "type": "node",
       "request": "attach",
       "name": "Attach to Remote",
       "address": "localhost",
       "port": 9229,
-      "skipFiles": ["<node_internals>/**/*.js"]
-    },
-    ]
+      "skipFiles": ["<node_internals>/**/*.js"],
+      "sourceMaps": true
+    }
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,17 @@ You are very welcome here and any contribution is appreciated. :+1:
 
 The code is written in "plain" JavaScript and as a rule of thumb shouldn't require transpilation. (The glaring exception being browser's lack of support for bare imports.)
 
+## Dev-time scripts
+
+`yarn test` will do all build, then run all jest and karma tests. It can take a while.
+
+For faster iteration
+
+- rollup on every change `yarn rollup -c --no-treeshake --watch`
+- jest tests for a single file, in watch mode `yarn jest __tests__/test-statusMatrix.js --watch`
+
 ## New feature checklists :sparkles:️
+
 I'm honestly documenting these steps just so I don't forget them myself.
 
 To add a parameter to an existing command `X`:
@@ -83,6 +93,7 @@ parse[*]Request: (input: stream) -> Object
 write[*]Response: (input: Object) -> stream
 
 ### How git works
+
 If you want to contribute it may be usefull if you understand how git works under the hood.
 This is great article that shows the details:<br/>
 [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git/).<br/>
@@ -90,5 +101,6 @@ But as first the introduction you can watch this video:<br/>
 [![Link to Video: Inside the Hidden Git Folder - Computerphile](https://img.youtube.com/vi/bSA91XTzeuA/0.jpg)](http://www.youtube.com/watch?v=bSA91XTzeuA)
 
 Another resource is GitHub blog:
-* [Git’s database internals I: packed object store](https://github.blog/2022-08-29-gits-database-internals-i-packed-object-store/)
-* [Git’s database internals II: commit history queries](https://github.blog/2022-08-30-gits-database-internals-ii-commit-history-queries/)
+
+- [Git’s database internals I: packed object store](https://github.blog/2022-08-29-gits-database-internals-i-packed-object-store/)
+- [Git’s database internals II: commit history queries](https://github.blog/2022-08-30-gits-database-internals-ii-commit-history-queries/)

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -203,7 +203,9 @@ export async function statusMatrix({
           stage && stage.type(),
         ])
 
-        const isBlob = [headType, workdirType, stageType].includes('blob')
+        const isBlob = [headType, workdirType, stageType].some(
+          t => t === 'blob' || t === 'linkTree'
+        )
 
         // For now, bail on directories unless the file is also a blob in another tree
         if ((headType === 'tree' || headType === 'special') && !isBlob) return
@@ -221,13 +223,14 @@ export async function statusMatrix({
         let workdirOid
         if (
           headType !== 'blob' &&
-          workdirType === 'blob' &&
+          ['blob', 'linkTree'].includes(workdirType) &&
           stageType !== 'blob'
         ) {
           // We don't actually NEED the sha. Any sha will do
           // TODO: update this logic to handle N trees instead of just 3.
           workdirOid = '42'
-        } else if (workdirType === 'blob') {
+          // a symlink to a dir should be treated like a file by git
+        } else if (['blob', 'linkTree'].includes(workdirType)) {
           workdirOid = await workdir.oid()
         }
         const entry = [undefined, headOid, workdirOid, stageOid]

--- a/src/api/walk.js
+++ b/src/api/walk.js
@@ -86,6 +86,7 @@ import { join } from '../utils/join.js'
  * - `'blob'` file
  * - `'special'` used by `WORKDIR` to represent irregular files like sockets and FIFOs
  * - `'commit'` used by `TREE` to represent submodules
+ * - `'linkTree'` used by `WORKDIR` to represent a symlink to a directory.  This prevents unnecessary recursion into the directory.
  *
  * ```js
  * await entry.type()

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -92,7 +92,7 @@ import './typedefs-http.js'
  * The `WalkerEntry` is an interface that abstracts computing many common tree / blob stats.
  *
  * @typedef {Object} WalkerEntry
- * @property {function(): Promise<'tree'|'blob'|'special'|'commit'>} type
+ * @property {function(): Promise<'tree'|'blob'|'special'|'commit'|'linkTree'>} type
  * @property {function(): Promise<number>} mode
  * @property {function(): Promise<string>} oid
  * @property {function(): Promise<Uint8Array|void>} content


### PR DESCRIPTION
## I'm fixing a bug or typo

- [ ] squash merge the PR with commit message "fix: [Description of fix]"

repro:

pass statusMatrix a dir that is a symlink to a folder--you'll see all the files show up as changed

expected: one file (git status treats the symlink like a file)

actual: it shows all the files in the linked dir

what was happening
node fs.lstat was used in a few places. Callling isDirectory on that will return false when it's a symlink. This change

adds the stat methods to the FileSystem to get stats that report about the symlink's target, not the symlink itself.
the GitFsWalker will check blob types that are symlinks to determine if they're really directories (tree) so that StatusMatrix gets correct answers.
details:
this bug came to us from https://github.com/forcedotcom/cli/issues/1851