### PR TITLE
Refactor `FileSystem` and add support for `fs/promises`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ And node and browsers have different APIs for making HTTP requests!
 So rather than relying on the `fs` and `http` modules, `isomorphic-git` lets you bring your own file system
 and HTTP client.
 
-If you're using `isomorphic-git` in node, you use the native `fs` module and the provided node HTTP client. Note: `fs/promises` won't work out of the box, you'll have to pass in the raw `fs` module.
+If you're using `isomorphic-git` in node, you use the native `fs` module and the provided node HTTP client.
 
 ```js
 // node.js example

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -4,6 +4,57 @@ import { compareStrings } from '../utils/compareStrings.js'
 import { dirname } from '../utils/dirname.js'
 import { rmRecursive } from '../utils/rmRecursive.js'
 
+function isPromiseFs(fs) {
+  const test = targetFs => {
+    try {
+      // If readFile returns a promise then we can probably assume the other
+      // commands do as well
+      return targetFs.readFile().catch(e => e)
+    } catch (e) {
+      return e
+    }
+  }
+  return test(fs).constructor.name === 'Promise'
+}
+
+// List of commands all filesystems are expected to provide. `rm` is not
+// included since it may not exist and must be handled as a special case
+const commands = [
+  'readFile',
+  'writeFile',
+  'mkdir',
+  'rmdir',
+  'unlink',
+  'stat',
+  'lstat',
+  'readdir',
+  'readlink',
+  'symlink',
+]
+
+function bindFs(target, fs) {
+  if (isPromiseFs(fs)) {
+    for (const command of commands) {
+      target[`_${command}`] = fs[command].bind(fs)
+    }
+  } else {
+    for (const command of commands) {
+      target[`_${command}`] = pify(fs[command].bind(fs))
+    }
+  }
+
+  // Handle the special case of `rm`
+  if (isPromiseFs(fs)) {
+    if (fs.rm) target._rm = fs.rm.bind(fs)
+    else if (fs.rmdir.length > 1) target._rm = fs.rmdir.bind(fs)
+    else target._rm = rmRecursive.bind(null, target)
+  } else {
+    if (fs.rm) target._rm = pify(fs.rm.bind(fs))
+    else if (fs.rmdir.length > 2) target._rm = pify(fs.rmdir.bind(fs))
+    else target._rm = rmRecursive.bind(null, target)
+  }
+}
+
 /**
  * This is just a collection of helper functions really. At least that's how it started.
  */
@@ -13,41 +64,9 @@ export class FileSystem {
 
     const promises = Object.getOwnPropertyDescriptor(fs, 'promises')
     if (promises && promises.enumerable) {
-      this._readFile = fs.promises.readFile.bind(fs.promises)
-      this._writeFile = fs.promises.writeFile.bind(fs.promises)
-      this._mkdir = fs.promises.mkdir.bind(fs.promises)
-      if (fs.promises.rm) {
-        this._rm = fs.promises.rm.bind(fs.promises)
-      } else if (fs.promises.rmdir.length > 1) {
-        this._rm = fs.promises.rmdir.bind(fs.promises)
-      } else {
-        this._rm = rmRecursive.bind(null, this)
-      }
-      this._rmdir = fs.promises.rmdir.bind(fs.promises)
-      this._unlink = fs.promises.unlink.bind(fs.promises)
-      this._stat = fs.promises.stat.bind(fs.promises)
-      this._lstat = fs.promises.lstat.bind(fs.promises)
-      this._readdir = fs.promises.readdir.bind(fs.promises)
-      this._readlink = fs.promises.readlink.bind(fs.promises)
-      this._symlink = fs.promises.symlink.bind(fs.promises)
+      bindFs(this, fs.promises)
     } else {
-      this._readFile = pify(fs.readFile.bind(fs))
-      this._writeFile = pify(fs.writeFile.bind(fs))
-      this._mkdir = pify(fs.mkdir.bind(fs))
-      if (fs.rm) {
-        this._rm = pify(fs.rm.bind(fs))
-      } else if (fs.rmdir.length > 2) {
-        this._rm = pify(fs.rmdir.bind(fs))
-      } else {
-        this._rm = rmRecursive.bind(null, this)
-      }
-      this._rmdir = pify(fs.rmdir.bind(fs))
-      this._unlink = pify(fs.unlink.bind(fs))
-      this._stat = pify(fs.stat.bind(fs))
-      this._lstat = pify(fs.lstat.bind(fs))
-      this._readdir = pify(fs.readdir.bind(fs))
-      this._readlink = pify(fs.readlink.bind(fs))
-      this._symlink = pify(fs.symlink.bind(fs))
+      bindFs(this, fs)
     }
     this._original_unwrapped_fs = fs
   }

--- a/website/versioned_docs/version-1.x/branch.md
+++ b/website/versioned_docs/version-1.x/branch.md
@@ -7,14 +7,16 @@ original_id: branch
 
 Create a branch
 
-| param          | type [= default]          | description                                                   |
-| -------------- | ------------------------- | ------------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                  | a file system implementation                                  |
-| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path           |
-| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path                    |
-| **ref**        | string                    | What to name the branch                                       |
-| checkout       | boolean = false           | Update `HEAD` to point at the newly created branch            |
-| return         | Promise\<void\>           | Resolves successfully when filesystem operations are complete |
+| param          | type [= default]          | description                                                                                           |
+| -------------- | ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                  | a file system implementation                                                                          |
+| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path                                                   |
+| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path                                                            |
+| **ref**        | string                    | What to name the branch                                                                               |
+| object         | string = 'HEAD'           | What oid to use as the start point. Accepts a symbolic ref.                                           |
+| checkout       | boolean = false           | Update `HEAD` to point at the newly created branch                                                    |
+| force          | boolean = false           | Instead of throwing an error if a branched named `ref` already exists, overwrite the existing branch. |
+| return         | Promise\<void\>           | Resolves successfully when filesystem operations are complete                                         |
 
 Example Code:
 

--- a/website/versioned_docs/version-1.x/walk.md
+++ b/website/versioned_docs/version-1.x/walk.md
@@ -193,12 +193,14 @@ async function map(filepath, [head, workdir]) {
 
 Example 2: Return the difference between the working directory and the HEAD commit
 ```js
-const diff = require('diff-lines')
-async function map(filepath, [head, workdir]) {
+const map = async (filepath, [head, workdir]) => {
   return {
     filepath,
-    oid: await head.oid(),
-    diff: diff((await head.content()).toString('utf8'), (await workdir.content()).toString('utf8'))
+    oid: await head?.oid(),
+    diff: diff(
+      (await head?.content())?.toString('utf8') || '',
+      (await workdir?.content())?.toString('utf8') || ''
+    )
   }
 }
 ```


### PR DESCRIPTION
These commits allow isomorphic-git to work natively with node's `fs/promises` module as well as any filesystems which only provide promise-based functions, and do not expose a `.promises` object. Fixes the issue seen in #1751.

When `fs.promises` does not exist, we now check to see if an arbitrary command (in this case`fs.readFile`) returns a promise. If it does, the filesystem is identified as a promise-based filesystem and treated accordingly. Otherwise, it is treated as a callback-based filesystem and wrapped using `pify` as before.

These changes result from of a refactor of the code, which hopefully should make extending `FileSystem` easier in the future.

Additionally, I've updated the website docs to match with the ones generated by `jsdoc`.