### PR TITLE
replace "unset" string value of gitattributes with 'unset' syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 * eol=lf
-__tests__/__fixtures__/** binary eol=unset linguist-vendored
-__tests__/__snapshots__/** binary eol=unset
+__tests__/__fixtures__/** binary -eol linguist-vendored
+__tests__/__snapshots__/** binary -eol
 __tests__/__snapshots__/test-exports.js.snap text eol=lf
-**/*.png binary eol=unset
-**/*.webp binary eol=unset
-**/*.zip binary eol=unset
+**/*.png binary -eol
+**/*.webp binary -eol
+**/*.zip binary -eol


### PR DESCRIPTION
The string "unset" doesn't actually unset them, but sets them to an invalid value.
With this change the attributes will be unset which should have the same effect as before.

----

Please feel free to close this PR if `eol=unset` is entirely intentional. The reason I am proposing this change is merely to help my `gitoxide` validation tool to succeed, and it arrives at 'the wrong' conclusion as it only interprets strings when running `git` on the command-line and "unset" always has to mean "an unset attribute".
