### PR TITLE
fix #1650 - Added clarification in the api documentation.

### DIFF
--- a/src/api/listBranches.js
+++ b/src/api/listBranches.js
@@ -15,6 +15,9 @@ import { join } from '../utils/join.js'
  * If you want an up-to-date list, first do a `fetch` to that remote.
  * (Which branch you fetch doesn't matter - the list of branches available on the remote is updated during the fetch handshake.)
  *
+ * Also note, that a branch is a reference to a commit. If you initialize a new repository it has no commits, so the
+ * `listBranches` function will return an empty list, until you create the first commit.
+ *
  * @param {object} args
  * @param {FsClient} args.fs - a file system client
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path

--- a/website/versioned_docs/version-1.x/listBranches.md
+++ b/website/versioned_docs/version-1.x/listBranches.md
@@ -21,6 +21,9 @@ Note that specifying a remote does not actually contact the server and update th
 If you want an up-to-date list, first do a `fetch` to that remote.
 (Which branch you fetch doesn't matter - the list of branches available on the remote is updated during the fetch handshake.)
 
+Also note, that a branch is a reference to a commit. If you initialize a new repository it has no commits, so the
+`listBranches` function will return an empty list, until you create the first commit.
+
 Example Code:
 
 ```js live


### PR DESCRIPTION
I thought about the issue and I think returning an empty list when there is no initial commit is correct but unexpected, so I added a note in the api documentation.

