### PR TITLE
fix: rethrow error if error is encountered when reading git-upload-pack response

### DIFF
--- a/__tests__/test-GitPackIndex.js
+++ b/__tests__/test-GitPackIndex.js
@@ -70,6 +70,17 @@ describe('GitPackIndex', () => {
       20855
     )
   })
+  it('from .pack when pack is truncated', async () => {
+    const { fs, gitdir } = await makeFixture('test-GitPackIndex')
+    const pack = await fs.read(
+      path.join(
+        gitdir,
+        'objects/pack/pack-1a1e70d2f116e8cb0cb42d26019e5c7d0eb01888.pack'
+      )
+    )
+    const p = await GitPackIndex.fromPack({ pack: pack.slice(0, 12) })
+    expect(p.offsets.size).toBe(0)
+  })
   it('to .idx file from .pack', async () => {
     const { fs, gitdir } = await makeFixture('test-GitPackIndex')
     const idx = await fs.read(

--- a/__tests__/test-GitSideBand.js
+++ b/__tests__/test-GitSideBand.js
@@ -1,0 +1,78 @@
+/* eslint-env node, browser, jasmine */
+const { collect, GitSideBand } = require('isomorphic-git/internal-apis')
+
+describe('GitSideBand', () => {
+  it('demux - packetlines, packfile, and progress', async () => {
+    const data = `001e# service=git-upload-pack
+003dfb74ea1a9b6a9601df18c38d3de751c51f064bf7 refs/heads/main
+000e\x01packfile
+000e\x02hi there
+0000`
+    const expectedPacketlines = []
+    const expectedProgress = []
+    const expectedPackfile = []
+    const lines = data.split(/\n/)
+    const lastLineIdx = lines.length - 1
+    lines.forEach((it, idx) => {
+      it = it.slice(4) + (idx === lastLineIdx ? '' : '\n')
+      if (it.startsWith('\x01')) {
+        expectedPackfile.push(it.slice(1))
+      } else if (it.startsWith('\x02')) {
+        expectedProgress.push(it.slice(1))
+      } else {
+        expectedPacketlines.push(it)
+      }
+    })
+    const stream = [Buffer.from(data)]
+    const { packetlines, packfile, progress } = GitSideBand.demux(stream)
+    const collectedPacketlines = await collect(packetlines)
+    const collectedProgress = await collect(progress)
+    const collectedPackfile = await collect(packfile)
+    expect(collectedPacketlines.length > 0).toBe(true)
+    expect(Buffer.from(collectedPacketlines).toString()).toEqual(
+      expectedPacketlines.join('')
+    )
+    expect(collectedProgress.length > 0).toBe(true)
+    expect(Buffer.from(collectedProgress).toString()).toEqual(
+      expectedProgress.join('')
+    )
+    expect(collectedPackfile.length > 0).toBe(true)
+    expect(Buffer.from(collectedPackfile).toString()).toEqual(
+      expectedPackfile.join('')
+    )
+  })
+
+  it('demux - error line', async () => {
+    const data = `001e# service=git-upload-pack
+0015\x03error in stream
+0000`
+    const expectedPacketlines = []
+    const expectedProgress = []
+    const lines = data.split(/\n/)
+    const lastLineIdx = lines.length - 1
+    lines.forEach((it, idx) => {
+      it = it.slice(4) + (idx === lastLineIdx ? '' : '\n')
+      if (it.startsWith('\x03')) {
+        expectedProgress.push(it.slice(1))
+      } else {
+        expectedPacketlines.push(it)
+      }
+    })
+    const stream = [Buffer.from(data)]
+    const { packetlines, packfile, progress } = GitSideBand.demux(stream)
+    const collectedPacketlines = await collect(packetlines)
+    const collectedProgress = await collect(progress)
+    const collectedPackfile = await collect(packfile)
+    expect(collectedPacketlines.length > 0).toBe(true)
+    expect(Buffer.from(collectedPacketlines).toString()).toEqual(
+      expectedPacketlines.join('')
+    )
+    expect(collectedProgress.length > 0).toBe(true)
+    expect(Buffer.from(collectedProgress).toString()).toEqual(
+      expectedProgress.join('')
+    )
+    expect(collectedPackfile.length === 0).toBe(true)
+    expect('error' in packfile).toBe(true)
+    expect(packfile.error.message).toEqual('error in stream\n')
+  })
+})

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -387,6 +387,11 @@ access it.
     const result = await parseUploadPackResponse(res)
     expect(result.nak).toBe(true)
   })
+  it('parseUploadPackResponse - no packetlines', async () => {
+    const res = [Buffer.from(`0000`)]
+    const result = await parseUploadPackResponse(res)
+    expect(result.nak).toBe(false)
+  })
   it('parseUploadPackResponse - incremental update (fetch)', async () => {
     const res = [
       Buffer.from(`003aACK 7e47fe2bd8d01d481f44d7af0531bd93d3b21c01 continue

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -343,6 +343,7 @@ export async function _fetch({
     })
   }
   const packfile = Buffer.from(await collect(response.packfile))
+  if (raw.body.error) throw raw.body.error
   const packfileSha = packfile.slice(-20).toString('hex')
   const res = {
     defaultBranch: response.HEAD,

--- a/src/models/GitPktLine.js
+++ b/src/models/GitPktLine.js
@@ -86,7 +86,7 @@ export class GitPktLine {
         if (buffer == null) return true
         return buffer
       } catch (err) {
-        console.log('error', err)
+        stream.error = err
         return true
       }
     }

--- a/src/models/GitSideBand.js
+++ b/src/models/GitSideBand.js
@@ -58,6 +58,8 @@ export class GitSideBand {
           // fatal error message just before stream aborts
           const error = line.slice(1)
           progress.write(error)
+          packetlines.end()
+          progress.end()
           packfile.destroy(new Error(error.toString('utf8')))
           return
         }

--- a/src/models/GitSideBand.js
+++ b/src/models/GitSideBand.js
@@ -39,7 +39,7 @@ export class GitSideBand {
       if (line === true) {
         packetlines.end()
         progress.end()
-        packfile.end()
+        input.error ? packfile.destroy(input.error) : packfile.end()
         return
       }
       // Examine first byte to determine which output "stream" to use

--- a/src/models/GitSideBand.js
+++ b/src/models/GitSideBand.js
@@ -65,7 +65,7 @@ export class GitSideBand {
         }
         default: {
           // Not part of the side-band-64k protocol
-          packetlines.write(line.slice(0))
+          packetlines.write(line)
         }
       }
       // Careful not to blow up the stack.

--- a/src/utils/FIFO.js
+++ b/src/utils/FIFO.js
@@ -26,8 +26,8 @@ export class FIFO {
   }
 
   destroy(err) {
-    this._ended = true
     this.error = err
+    this.end()
   }
 
   async next() {

--- a/src/utils/StreamReader.js
+++ b/src/utils/StreamReader.js
@@ -72,6 +72,7 @@ export class StreamReader {
     let { done, value } = await this.stream.next()
     if (done) {
       this._ended = true
+      if (!value) return Buffer.alloc(0)
     }
     if (value) {
       value = Buffer.from(value)

--- a/src/wire/parseUploadPackResponse.js
+++ b/src/wire/parseUploadPackResponse.js
@@ -37,7 +37,15 @@ export async function parseUploadPackResponse(stream) {
         nak = true
       }
       if (done) {
-        resolve({ shallows, unshallows, acks, nak, packfile, progress })
+        stream.error
+          ? reject(stream.error)
+          : resolve({ shallows, unshallows, acks, nak, packfile, progress })
+      }
+    }).finally(() => {
+      if (!done) {
+        stream.error
+          ? reject(stream.error)
+          : resolve({ shallows, unshallows, acks, nak, packfile, progress })
       }
     })
   })


### PR DESCRIPTION
resolves #1847

* rethrow error if error is encountered when reading git-upload-pack response
* don't fail if packfile passed to GitPackIndex.fromPack is truncated
* avoid unnecessary copy of buffer when writing line to packetlines FIFO
* properly close FIFO objects after encountering error line in sideband response
* capture error in GitPktLine#read instead of logging to stdout