### PR TITLE
implement cherry-pick

### DIFF
--- a/__tests__/test-cherryPick.js
+++ b/__tests__/test-cherryPick.js
@@ -1,0 +1,46 @@
+/* eslint-env node, browser, jasmine */
+const { cherryPick, log } = require('isomorphic-git')
+
+const { makeFixture } = require('./__helpers__/FixtureFS.js')
+
+describe('cherry-pick', () => {
+  it("cherry-pick commit from b into a (no conflict)'", async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-cherryPick')
+
+    // Test
+    const cpCommitExpected = (
+      await log({
+        fs,
+        dir,
+        depth: 1,
+        ref: 'v',
+      })
+    )[0].commit
+
+    const report = await cherryPick({
+      fs,
+      dir,
+      ours: 'a',
+      theirs: 'd7676dfe102cd28ec794b25f9a6231af0cdfd16d',
+      author: {
+        name: 'Mr. Test',
+        email: 'mrtest@example.com',
+        timestamp: 1262356920,
+        timezoneOffset: -0,
+      },
+    })
+    const cpCommitActual = (
+      await log({
+        fs,
+        dir,
+        ref: 'a',
+        depth: 1,
+      })
+    )[0].commit
+
+    expect(report.tree).toBe(cpCommitExpected.tree)
+    expect(cpCommitExpected.tree).toEqual(cpCommitActual.tree)
+    expect(cpCommitExpected.message).toEqual(cpCommitActual.message)
+  })
+})

--- a/src/api/cherryPick.js
+++ b/src/api/cherryPick.js
@@ -1,0 +1,187 @@
+// @ts-check
+import '../typedefs.js'
+
+import { _cherryPick } from '../commands/cherryPick.js'
+import { MissingNameError } from '../errors/MissingNameError.js'
+import { FileSystem } from '../models/FileSystem.js'
+import { assertParameter } from '../utils/assertParameter.js'
+import { join } from '../utils/join.js'
+import { normalizeAuthorObject } from '../utils/normalizeAuthorObject.js'
+import { normalizeCommitterObject } from '../utils/normalizeCommitterObject.js'
+
+/**
+ *
+ * @typedef {Object} MergeResult - Returns an object with a schema like this:
+ * @property {string} [oid] - The SHA-1 object id that is now at the head of the branch. Absent only if `dryRun` was specified and `mergeCommit` is true.
+ * @property {boolean} [alreadyMerged] - True if the branch was already merged so no changes were made
+ * @property {boolean} [fastForward] - True if it was a fast-forward merge
+ * @property {boolean} [mergeCommit] - True if merge resulted in a merge commit
+ * @property {string} [tree] - The SHA-1 object id of the tree resulting from a merge commit
+ *
+ */
+
+/**
+ * Merge two branches
+ *
+ * Currently it will fail if multiple candidate merge bases are found. (It doesn't yet implement the recursive merge strategy.)
+ *
+ * Currently it does not support selecting alternative merge strategies.
+ *
+ * Currently it is not possible to abort an incomplete merge. To restore the worktree to a clean state, you will need to checkout an earlier commit.
+ *
+ * Currently it does not directly support the behavior of `git merge --continue`. To complete a merge after manual conflict resolution, you will need to add and commit the files manually, and specify the appropriate parent commits.
+ *
+ * ## Manually resolving merge conflicts
+ * By default, if isomorphic-git encounters a merge conflict it cannot resolve using the builtin diff3 algorithm or provided merge driver, it will abort and throw a `MergeNotSupportedError`.
+ * This leaves the index and working tree untouched.
+ *
+ * When `abortOnConflict` is set to `false`, and a merge conflict cannot be automatically resolved, a `MergeConflictError` is thrown and the results of the incomplete merge will be written to the working directory.
+ * This includes conflict markers in files with unresolved merge conflicts.
+ *
+ * To complete the merge, edit the conflicting files as you see fit, and then add and commit the resolved merge.
+ *
+ * For a proper merge commit, be sure to specify the branches or commits you are merging in the `parent` argument to `git.commit`.
+ * For example, say we are merging the branch `feature` into the branch `main` and there is a conflict we want to resolve manually.
+ * The flow would look like this:
+ *
+ * ```
+ * await git.merge({
+ *   fs,
+ *   dir,
+ *   ours: 'main',
+ *   theirs: 'feature',
+ *   abortOnConflict: false,
+ * }).catch(e => {
+ *   if (e instanceof Errors.MergeConflictError) {
+ *     console.log(
+ *       'Automatic merge failed for the following files: '
+ *       + `${e.data}. `
+ *       + 'Resolve these conflicts and then commit your changes.'
+ *     )
+ *   } else throw e
+ * })
+ *
+ * // This is the where we manually edit the files that have been written to the working directory
+ * // ...
+ * // Files have been edited and we are ready to commit
+ *
+ * await git.add({
+ *   fs,
+ *   dir,
+ *   filepath: '.',
+ * })
+ *
+ * await git.commit({
+ *   fs,
+ *   dir,
+ *   ref: 'main',
+ *   message: "Merge branch 'feature' into main",
+ *   parent: ['main', 'feature'], // Be sure to specify the parents when creating a merge commit
+ * })
+ * ```
+ *
+ * @param {object} args
+ * @param {FsClient} args.fs - a file system client
+ * @param {SignCallback} [args.onSign] - a PGP signing implementation
+ * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
+ * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} [args.ours] - The branch receiving the merge. If undefined, defaults to the current branch.
+ * @param {string} args.theirs - The branch to be merged
+ * @param {boolean} [args.fastForward = true] - If false, create a merge commit in all cases.
+ * @param {boolean} [args.fastForwardOnly = false] - If true, then non-fast-forward merges will throw an Error instead of performing a merge.
+ * @param {boolean} [args.dryRun = false] - If true, simulates a merge so you can test whether it would succeed.
+ * @param {boolean} [args.noUpdateBranch = false] - If true, does not update the branch pointer after creating the commit.
+ * @param {boolean} [args.abortOnConflict = true] - If true, merges with conflicts will not update the worktree or index.
+ * @param {string} [args.message] - Overrides the default auto-generated merge commit message
+ * @param {Object} [args.author] - passed to [commit](commit.md) when creating a merge commit
+ * @param {string} [args.author.name] - Default is `user.name` config.
+ * @param {string} [args.author.email] - Default is `user.email` config.
+ * @param {number} [args.author.timestamp=Math.floor(Date.now()/1000)] - Set the author timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
+ * @param {number} [args.author.timezoneOffset] - Set the author timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
+ * @param {Object} [args.committer] - passed to [commit](commit.md) when creating a merge commit
+ * @param {string} [args.committer.name] - Default is `user.name` config.
+ * @param {string} [args.committer.email] - Default is `user.email` config.
+ * @param {number} [args.committer.timestamp=Math.floor(Date.now()/1000)] - Set the committer timestamp field. This is the integer number of seconds since the Unix epoch (1970-01-01 00:00:00).
+ * @param {number} [args.committer.timezoneOffset] - Set the committer timezone offset field. This is the difference, in minutes, from the current timezone to UTC. Default is `(new Date()).getTimezoneOffset()`.
+ * @param {string} [args.signingKey] - passed to [commit](commit.md) when creating a merge commit
+ * @param {object} [args.cache] - a [cache](cache.md) object
+ * @param {MergeDriverCallback} [args.mergeDriver] - a [merge driver](mergeDriver.md) implementation
+ *
+ * @returns {Promise<MergeResult>} Resolves to a description of the merge operation
+ * @see MergeResult
+ *
+ * @example
+ * let m = await git.merge({
+ *   fs,
+ *   dir: '/tutorial',
+ *   ours: 'main',
+ *   theirs: 'remotes/origin/main'
+ * })
+ * console.log(m)
+ *
+ */
+export async function cherryPick({
+  fs: _fs,
+  onSign,
+  dir,
+  gitdir = join(dir, '.git'),
+  ours,
+  theirs,
+  fastForward = true,
+  fastForwardOnly = false,
+  dryRun = false,
+  noUpdateBranch = false,
+  abortOnConflict = true,
+  message,
+  author: _author,
+  committer: _committer,
+  signingKey,
+  cache = {},
+  mergeDriver,
+}) {
+  try {
+    assertParameter('fs', _fs)
+    if (signingKey) {
+      assertParameter('onSign', onSign)
+    }
+    const fs = new FileSystem(_fs)
+
+    const author = await normalizeAuthorObject({ fs, gitdir, author: _author })
+    if (!author && (!fastForwardOnly || !fastForward)) {
+      throw new MissingNameError('author')
+    }
+
+    const committer = await normalizeCommitterObject({
+      fs,
+      gitdir,
+      author,
+      committer: _committer,
+    })
+    if (!committer && (!fastForwardOnly || !fastForward)) {
+      throw new MissingNameError('committer')
+    }
+
+    return await _cherryPick({
+      fs,
+      cache,
+      dir,
+      gitdir,
+      ours,
+      theirs,
+      fastForward,
+      fastForwardOnly,
+      dryRun,
+      noUpdateBranch,
+      abortOnConflict,
+      message,
+      author,
+      committer,
+      signingKey,
+      onSign,
+      mergeDriver,
+    })
+  } catch (err) {
+    err.caller = 'git.merge'
+    throw err
+  }
+}

--- a/src/commands/cherryPick.js
+++ b/src/commands/cherryPick.js
@@ -1,0 +1,170 @@
+// @ts-check
+import '../typedefs.js'
+
+import { _commit } from '../commands/commit'
+import { _currentBranch } from '../commands/currentBranch.js'
+import { _findMergeBase } from '../commands/findMergeBase.js'
+import { FastForwardError } from '../errors/FastForwardError.js'
+import { MergeConflictError } from '../errors/MergeConflictError.js'
+import { MergeNotSupportedError } from '../errors/MergeNotSupportedError.js'
+import { GitIndexManager } from '../managers/GitIndexManager.js'
+import { GitRefManager } from '../managers/GitRefManager.js'
+import { abbreviateRef } from '../utils/abbreviateRef.js'
+import { mergeTree } from '../utils/mergeTree.js'
+import { expandOid } from '../api/expandOid.js'
+import { _readObject } from '../storage/readObject.js'
+import { _readCommit } from './readCommit.js'
+
+// import diff3 from 'node-diff3'
+/**
+ *
+ * @typedef {Object} MergeResult - Returns an object with a schema like this:
+ * @property {string} [oid] - The SHA-1 object id that is now at the head of the branch. Absent only if `dryRun` was specified and `mergeCommit` is true.
+ * @property {boolean} [alreadyMerged] - True if the branch was already merged so no changes were made
+ * @property {boolean} [fastForward] - True if it was a fast-forward merge
+ * @property {boolean} [mergeCommit] - True if merge resulted in a merge commit
+ * @property {string} [tree] - The SHA-1 object id of the tree resulting from a merge commit
+ *
+ */
+
+/**
+ * @param {object} args
+ * @param {import('../models/FileSystem.js').FileSystem} args.fs
+ * @param {object} args.cache
+ * @param {string} args.gitdir
+ * @param {string} [args.ours]
+ * @param {string} args.theirs
+ * @param {boolean} args.fastForward
+ * @param {boolean} args.fastForwardOnly
+ * @param {boolean} args.dryRun
+ * @param {boolean} args.noUpdateBranch
+ * @param {boolean} args.abortOnConflict
+ * @param {string} [args.message]
+ * @param {Object} args.author
+ * @param {string} args.author.name
+ * @param {string} args.author.email
+ * @param {number} args.author.timestamp
+ * @param {number} args.author.timezoneOffset
+ * @param {Object} args.committer
+ * @param {string} args.committer.name
+ * @param {string} args.committer.email
+ * @param {number} args.committer.timestamp
+ * @param {number} args.committer.timezoneOffset
+ * @param {string} [args.signingKey]
+ * @param {SignCallback} [args.onSign] - a PGP signing implementation
+ * @param {MergeDriverCallback} [args.mergeDriver]
+ *
+ * @returns {Promise<MergeResult>} Resolves to a description of the merge operation
+ *
+ */
+export async function _cherryPick({
+  fs,
+  cache,
+  dir,
+  gitdir,
+  ours,
+  theirs,
+  fastForward = true,
+  fastForwardOnly = false,
+  dryRun = false,
+  noUpdateBranch = false,
+  abortOnConflict = true,
+  message = '',
+  author,
+  committer,
+  signingKey,
+  onSign,
+  mergeDriver,
+}) {
+  if (ours === undefined) {
+    ours = await _currentBranch({ fs, gitdir, fullname: true })
+  }
+  ours = await GitRefManager.expand({
+    fs,
+    gitdir,
+    ref: ours,
+  })
+  const ourOid = await GitRefManager.resolve({
+    fs,
+    gitdir,
+    ref: ours,
+  })
+
+  const theirOid = theirs
+
+  // TODO: 
+  // - check if passed string is an oid
+  // - support picking multiple commits
+
+  // find most recent common ancestor of ref a and ref b
+  const baseOids = await _findMergeBase({
+    fs,
+    cache,
+    gitdir,
+    oids: [ourOid, theirOid],
+  })
+  if (baseOids.length !== 1) {
+    // TODO: Recursive Merge strategy
+    throw new MergeNotSupportedError()
+  }
+  const baseOid = baseOids[0]
+  // handle fast-forward case
+  if (baseOid === theirOid) {
+    return {
+      oid: ourOid,
+      alreadyMerged: true,
+    }
+  }
+
+  // try a fancier merge
+  const tree = await GitIndexManager.acquire(
+    { fs, gitdir, cache, allowUnmerged: false },
+    async index => {
+      return mergeTree({
+        fs,
+        cache,
+        dir,
+        gitdir,
+        index,
+        ourOid,
+        theirOid,
+        baseOid,
+        ourName: abbreviateRef(ours),
+        baseName: 'base',
+        theirName: theirs,
+        dryRun,
+        abortOnConflict,
+        mergeDriver,
+      })
+    }
+  )
+
+  // Defer throwing error until the index lock is relinquished and index is
+  // written to filsesystem
+  if (tree instanceof MergeConflictError) throw tree
+
+  // get the commit message of the commit being cherry-picked
+  const commitObj = await _readCommit({fs, gitdir, oid: theirOid, cache})
+  message = commitObj.commit.message
+
+  const oid = await _commit({
+    fs,
+    cache,
+    gitdir,
+    message,
+    ref: ours,
+    tree,
+    parent: [ourOid],
+    author,
+    committer,
+    signingKey,
+    onSign,
+    dryRun,
+    noUpdateBranch,
+  })
+  return {
+    oid,
+    tree,
+    mergeCommit: true,
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { addRemote } from './api/addRemote.js'
 import { annotatedTag } from './api/annotatedTag.js'
 import { branch } from './api/branch.js'
 import { checkout } from './api/checkout.js'
+import { cherryPick } from './api/cherryPick.js'
 import { clone } from './api/clone.js'
 import { commit } from './api/commit.js'
 import { currentBranch } from './api/currentBranch.js'
@@ -82,6 +83,7 @@ export {
   annotatedTag,
   branch,
   checkout,
+  cherryPick,
   clone,
   commit,
   getConfig,
@@ -154,6 +156,7 @@ export default {
   annotatedTag,
   branch,
   checkout,
+  cherryPick,
   clone,
   commit,
   getConfig,


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm adding a parameter to an existing command X:

- [x] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [x] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat(X): Added 'bar' parameter"

## I'm adding a new command:

- [x] add as a new file in `src/api` (and `src/commands` if necessary)
- [x] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [x] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"

Hey guys, at the moment this is a very basic and initial implementation of cherry-pick. I am yet to complete the implementation and update the documentation, but before that just wanted to get an opinion from you if the approach is indeed correct. I didn't want to spend effort in adding the tests and updating the documentation just to find out in the end that the basic approach itself is incorrect 😅.
I have added the cherryPick command in `api` and `command`, and have also added a very simple and basic test case. I would really appreciate your feedback on the implementation so far.
Thanks.