### PR TITLE
fix: `normalizePath` performance

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -651,6 +651,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "scolladon",
+      "name": "Sebastien",
+      "avatar_url": "https://avatars.githubusercontent.com/u/522422?v=4",
+      "profile": "https://github.com/scolladon",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/DanilKazanov"><img src="https://avatars.githubusercontent.com/u/139755256?v=4?s=60" width="60px;" alt=""/><br /><sub><b>DanilKazanov</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=DanilKazanov" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=DanilKazanov" title="Documentation">📖</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=DanilKazanov" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://api.github.com/users/hisco"><img src="https://avatars.githubusercontent.com/u/39222286?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Eyal Hisco</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Ahisco" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://github.com/scolladon"><img src="https://avatars.githubusercontent.com/u/522422?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Sebastien</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=scolladon" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/utils/normalizePath.js
+++ b/src/utils/normalizePath.js
@@ -1,4 +1,14 @@
 export function normalizePath(path) {
+  let normalizedPath = normalizePathCache.get(path)
+  if (!normalizedPath) {
+    normalizedPath = normalizePathInternal(path)
+    normalizePathCache.set(path, normalizedPath)
+  }
+  return normalizedPath
+}
+
+const normalizePathCache = new Map()
+function normalizePathInternal(path) {
   path = path
     .split('/./')
     .join('/') // Replace '/./' with '/'

--- a/src/utils/normalizePath.js
+++ b/src/utils/normalizePath.js
@@ -1,11 +1,14 @@
 export function normalizePath(path) {
-  return path
-    .replace(/\/\.\//g, '/') // Replace '/./' with '/'
+  path = path
+    .split('/./')
+    .join('/') // Replace '/./' with '/'
     .replace(/\/{2,}/g, '/') // Replace consecutive '/'
-    .replace(/^\/\.$/, '/') // if path === '/.' return '/'
-    .replace(/^\.\/$/, '.') // if path === './' return '.'
-    .replace(/^\.\//, '') // Remove leading './'
-    .replace(/\/\.$/, '') // Remove trailing '/.'
-    .replace(/(.+)\/$/, '$1') // Remove trailing '/'
-    .replace(/^$/, '.') // if path === '' return '.'
+
+  if (path === '/.') return '/' // if path === '/.' return '/'
+  if (path === './') return '.' // if path === './' return '.'
+  if (path.startsWith('./')) path = path.slice(2) // Remove leading './'
+  if (path.endsWith('/.')) path = path.slice(0, -2) // Remove trailing '/.'
+  if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1) // Remove trailing '/'
+
+  return path || '.' // if path === '' return '.'
 }

--- a/src/utils/normalizePath.js
+++ b/src/utils/normalizePath.js
@@ -1,13 +1,13 @@
+const memo = new Map()
 export function normalizePath(path) {
-  let normalizedPath = normalizePathCache.get(path)
+  let normalizedPath = memo.get(path)
   if (!normalizedPath) {
     normalizedPath = normalizePathInternal(path)
-    normalizePathCache.set(path, normalizedPath)
+    memo.set(path, normalizedPath)
   }
   return normalizedPath
 }
 
-const normalizePathCache = new Map()
 function normalizePathInternal(path) {
   path = path
     .split('/./')
@@ -16,9 +16,12 @@ function normalizePathInternal(path) {
 
   if (path === '/.') return '/' // if path === '/.' return '/'
   if (path === './') return '.' // if path === './' return '.'
+
   if (path.startsWith('./')) path = path.slice(2) // Remove leading './'
   if (path.endsWith('/.')) path = path.slice(0, -2) // Remove trailing '/.'
   if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1) // Remove trailing '/'
 
-  return path || '.' // if path === '' return '.'
+  if (path === '') return '.' // if path === '' return '.'
+
+  return path
 }


### PR DESCRIPTION
I propose a performance optimization for the `normalizePath` function.

I use `isomorphic-git` to refactor a sfdx plugin I maintained and I was very happy with it as it was running 3 times faster for small to medium repository.
Then I tried with a very big one and I found the performances were dropping.
So I looked at what happened to see where I could tweak my implementation (maybe I can have a smarter `iterate` or `walk` method tailored made).
This is how I discovered that 70% of the time were spent inside the `normalizePath` function.

This PR tries to have a very simple approach and to avoid using regex for this code massively used by the library.
There may be a smarter way to deal with it (do multiple things at the same time, skip things), please advise !

On my specific use cases, this `normalizePath` implementation made my refactoring 800% faster than without

closes #1852 