### PR TITLE
fix: isPromiseFs out-of-spec usage of readFile

### DIFF
--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -10,7 +10,7 @@ function isPromiseFs(fs) {
     try {
       // If readFile returns a promise then we can probably assume the other
       // commands do as well
-      return targetFs.readFile().catch(e => e)
+      return targetFs.readFile(undefined).catch(e => e)
     } catch (e) {
       return e
     }


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

This works around the odd Deno behavior described in #1851 by explicitly passing `undefined` to `readFile`, so the `promisify` wrapper works correctly.

This is arguably a Deno bug (denoland/deno#21795), but it's also an emergent behavior of isomorphic-git calling `readFile` out-of-spec + promisfy's inability to identify that because it is unaware of intended method signatures. This workaround gets `isPromsseFs` working on Deno, and that + manually adding `Buffer` to `globalThis` is enough to get isomorphic-git working on Deno for my use case.

Full Deno support (including running the tests) would be a much larger effort.

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"