### PR TITLE
fix: close the test compression stream

### DIFF
--- a/src/utils/deflate.js
+++ b/src/utils/deflate.js
@@ -22,12 +22,12 @@ async function browserDeflate(buffer) {
 function testCompressionStream() {
   try {
     const cs = new CompressionStream('deflate')
+    cs.writable.close()
     // Test if `Blob.stream` is present. React Native does not have the `stream` method
     const stream = new Blob([]).stream()
     stream.cancel()
-    return !!cs
+    return true
   } catch (_) {
-    // no bother
+    return false
   }
-  return false
 }


### PR DESCRIPTION
Turns out that resources are still reported as leaking in Deno if the Compression stream is not closed also.