### PR TITLE
Fix race condition when reading/writing refs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -669,6 +669,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "alexvy86",
+      "name": "Alex Villarreal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/716334?v=4",
+      "profile": "https://alex-v.blog/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://api.github.com/users/hisco"><img src="https://avatars.githubusercontent.com/u/39222286?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Eyal Hisco</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Ahisco" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://github.com/scolladon"><img src="https://avatars.githubusercontent.com/u/522422?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Sebastien</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=scolladon" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/yarikoptic"><img src="https://avatars.githubusercontent.com/u/39889?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Yaroslav Halchenko</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=yarikoptic" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://alex-v.blog/"><img src="https://avatars.githubusercontent.com/u/716334?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Alex Villarreal</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=alexvy86" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/__tests__/test-GitRefManager.js
+++ b/__tests__/test-GitRefManager.js
@@ -246,44 +246,33 @@ describe('GitRefManager', () => {
     `)
   })
   it('concurrently reading/writing a ref should not cause a NotFoundError resolving it', async () => {
-    // There are some expect() calls below, but as of 2023-03-15, if this test fails it will do so by throwing
-    // 'NotFoundError: Could not find myRef', which should not happen.
+    // There are some expect() calls below, but as of 2023-03-15, if this test fails it will do so by logging instances
+    // of 'NotFoundError: Could not find myRef', which should not happen.
     const { fs, gitdir } = await makeFixture('test-GitRefManager')
     const ref = 'myRef'
     const value = '1234567890123456789012345678901234567890'
-    // Guarantee that the file for the ref exists on disk
-    await GitRefManager.writeRef({ fs, gitdir, ref, value })
+    await GitRefManager.writeRef({ fs, gitdir, ref, value }) // Guarantee that the file for the ref exists on disk
 
     const writePromises = []
     const resolvePromises = []
-    // Some arbitrary number of iterations that seems to guarantee that the error (pre-fix) is hit
-    const iterations = 100
+    // Some arbitrary number of iterations that seems to guarantee that the error (pre-fix) is hit.
+    // With 100 the test *mostly* failed but still passed every now and then.
+    const iterations = 500
 
-    // I was only able to cause the error to reproduce by mixing awaited and non-awaited versions of the calls to
-    // writeRef() and resolve().
     for (let i = 0; i < iterations; i++) {
+      // I was only able to cause the error to reproduce consistently by mixing awaited and non-awaited versions of the
+      // calls to writeRef() and resolve(). I tried several variations of the combination but none of them caused the
+      // error to happen as consistently.
       if (Math.random() < 0.5) {
         await GitRefManager.writeRef({ fs, gitdir, ref, value })
       } else {
         writePromises.push(GitRefManager.writeRef({ fs, gitdir, ref, value }))
       }
       if (Math.random() < 0.5) {
-        const resolvedRef = await GitRefManager.resolve({
-          fs,
-          gitdir,
-          ref,
-          depth: 1,
-        })
+        const resolvedRef = await GitRefManager.resolve({ fs, gitdir, ref })
         expect(resolvedRef).toMatch(value)
       } else {
-        resolvePromises.push(
-          GitRefManager.resolve({
-            fs,
-            gitdir,
-            ref,
-            depth: 1,
-          })
-        )
+        resolvePromises.push(GitRefManager.resolve({ fs, gitdir, ref }))
       }
     }
 

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -35,7 +35,7 @@ async function acquireRefLock(ref) {
     await refLock[0]
     refLock = refLocks.get(ref)
   }
-  let resolver = () => { }
+  let resolver = () => {}
   refLock = [
     new Promise(resolve => {
       resolver = resolve

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -56,7 +56,7 @@ class RefLock {
     try {
       return await callback()
     } finally {
-      lock.release()
+      lock._release()
     }
   }
 
@@ -86,9 +86,9 @@ class RefLock {
   }
 
   /**
-   * Releases the lock. This should only be called by the code that created this lock through RefLock.acquire().
+   * Releases the lock. This should only be called by the code that created this lock through RefLock._acquire().
    */
-  release() {
+  _release() {
     refLocks.delete(this.ref)
     if (this._resolver !== undefined) {
       this._resolver()

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -267,7 +267,7 @@ export class GitRefManager {
         return ref
       }
     }
-    let sha
+
     // Is it a ref pointer?
     if (ref.startsWith('ref: ')) {
       ref = ref.slice('ref: '.length)


### PR DESCRIPTION
## Description

Adds locking around filesystem operations when reading/writing refs to avoid race conditions.

Fixes https://github.com/isomorphic-git/isomorphic-git/issues/1881.

## I'm fixing a bug or typo

- [X] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"
