### PR TITLE
Handle empty repos which return capabilities

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -678,6 +678,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "amrc-benmorrow",
+      "name": "Ben Morrow",
+      "avatar_url": "https://avatars.githubusercontent.com/u/120477944?v=4",
+      "profile": "https://github.com/amrc-benmorrow",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/scolladon"><img src="https://avatars.githubusercontent.com/u/522422?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Sebastien</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=scolladon" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/yarikoptic"><img src="https://avatars.githubusercontent.com/u/39889?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Yaroslav Halchenko</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=yarikoptic" title="Documentation">📖</a></td>
     <td align="center"><a href="https://alex-v.blog/"><img src="https://avatars.githubusercontent.com/u/716334?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Alex Villarreal</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=alexvy86" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/amrc-benmorrow"><img src="https://avatars.githubusercontent.com/u/120477944?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Ben Morrow</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=amrc-benmorrow" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/__tests__/test-wire.js
+++ b/__tests__/test-wire.js
@@ -171,6 +171,35 @@ describe('git wire protocol', () => {
       ['refs/heads/master5', 'e5c144897b64a44bd1164a0db60738452c9eaf87'],
     ])
   })
+  it('parseRefsAdResponse empty repo with capabilities', async () => {
+    const res = [
+      Buffer.from(`001e# service=git-upload-pack
+000000fa0000000000000000000000000000000000000000 capabilities^{}\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed no-done object-format=sha1 agent=git/2.43.0
+0000`),
+    ]
+    const result = await parseRefsAdResponse(res, {
+      service: 'git-upload-pack',
+    })
+    expect([...result.capabilities]).toEqual([
+      'multi_ack',
+      'thin-pack',
+      'side-band',
+      'side-band-64k',
+      'ofs-delta',
+      'shallow',
+      'deepen-since',
+      'deepen-not',
+      'deepen-relative',
+      'no-progress',
+      'include-tag',
+      'multi_ack_detailed',
+      'no-done',
+      'object-format=sha1',
+      'agent=git/2.43.0',
+    ])
+    expect([...result.symrefs]).toEqual([])
+    expect([...result.refs]).toEqual([])
+  })
   it('parseRefsAdResponse bad service', async () => {
     const res = [
       Buffer.from(`001e# noservice=git-upload-pack


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

The Git wire protocol has a special hack to support returning capabilities on empty repos. As of Git version 1.43 the git-http-backend is using this, which means we need to support it.