### PR TITLE
feat(config): Added support for `global` git config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -707,6 +707,17 @@
         "doc",
         "bug"
       ]
+    },
+    {
+      "login": "vigan-abd",
+      "name": "Vigan Abdurrahmani",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20401969?v=4",
+      "profile": "https://github.com/vigan-abd",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/lsegurado"><img src="https://avatars.githubusercontent.com/u/27731047?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Lucas Martin Segurado</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=lsegurado" title="Documentation">📖</a> <a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Alsegurado" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://github.com/vigan-abd"><img src="https://avatars.githubusercontent.com/u/20401969?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Vigan Abdurrahmani</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=vigan-abd" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=vigan-abd" title="Documentation">📖</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=vigan-abd" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/__tests__/__fixtures__/test-hosting-providers.git/config
+++ b/__tests__/__fixtures__/test-hosting-providers.git/config
@@ -8,7 +8,7 @@
 	url = https://github.com/isomorphic-git/test.empty.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "gitlab"]
-	url = https://gitlab.com/isomorphic-git/test.empty.git
+	url = https://gitlab.com/isomorphic-git1/isomorphic-git-test-push.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "awscc"]
 	url = https://git-codecommit.us-west-2.amazonaws.com/v1/repos/test.empty

--- a/__tests__/test-hosting-providers.js
+++ b/__tests__/test-hosting-providers.js
@@ -194,12 +194,12 @@ describe('Hosting Providers', () => {
   })
 
   describe('GitLab', () => {
-    // This Personal Access Token is for a test account (https://gitlab.com/isomorphic-git-test-push)
+    // This Personal Access Token is for a test account (https://gitlab.com/vigan.isomorphic-git)
     // with "read_repository" and "write_repository" access. However the only repo it has write access to is
-    // https://gitlab.com/isomorphic-git/test.empty
+    // https://gitlab.com/isomorphic-git1/isomorphic-git-test-push
     // It is stored reversed because the GitHub one is stored reversed and I like being consistent.
-    const password = reverse('vjNzgKP7acS6e6vb2Q6g')
-    const username = 'isomorphic-git-test-push'
+    const password = reverse('8LNhvf8fVnBiL9nw_Cxh-taplg')
+    const username = 'vigan.isomorphic-git'
     it('fetch', async () => {
       // Setup
       const { fs, gitdir } = await makeFixture('test-hosting-providers')

--- a/src/api/getConfig.js
+++ b/src/api/getConfig.js
@@ -10,13 +10,14 @@ import { join } from '../utils/join.js'
  * Read an entry from the git config files.
  *
  * *Caveats:*
- * - Currently only the local `$GIT_DIR/config` file can be read or written. However support for the global `~/.gitconfig` and system `$(prefix)/etc/gitconfig` will be added in the future.
+ * - Currently only the local `$GIT_DIR/config` file and global `~/.gitconfig` can be read or written. However support for system `$(prefix)/etc/gitconfig` will be added in the future.
  * - The current parser does not support the more exotic features of the git-config file format such as `[include]` and `[includeIf]`.
  *
  * @param {Object} args
  * @param {FsClient} args.fs - a file system implementation
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
- * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} [args.gitdir=join(dir,'.git')] - The [git directory](dir-vs-gitdir.md) path, required if global is not true and dir is missing
+ * @param {boolean} [args.global=false] - Use global git directory
  * @param {string} args.path - The key of the git config entry
  *
  * @returns {Promise<any>} Resolves with the config value
@@ -31,15 +32,24 @@ import { join } from '../utils/join.js'
  * console.log(value)
  *
  */
-export async function getConfig({ fs, dir, gitdir = join(dir, '.git'), path }) {
+export async function getConfig({
+  fs,
+  dir,
+  gitdir = join(dir, '.git'),
+  global = false,
+  path,
+}) {
   try {
     assertParameter('fs', fs)
-    assertParameter('gitdir', gitdir)
+    if (global !== true) {
+      assertParameter('gitdir', gitdir)
+    }
     assertParameter('path', path)
 
     return await _getConfig({
       fs: new FileSystem(fs),
       gitdir,
+      global,
       path,
     })
   } catch (err) {

--- a/src/api/getConfigAll.js
+++ b/src/api/getConfigAll.js
@@ -10,13 +10,14 @@ import { join } from '../utils/join.js'
  * Read a multi-valued entry from the git config files.
  *
  * *Caveats:*
- * - Currently only the local `$GIT_DIR/config` file can be read or written. However support for the global `~/.gitconfig` and system `$(prefix)/etc/gitconfig` will be added in the future.
+ * - Currently only the local `$GIT_DIR/config` file and global `~/.gitconfig` can be read or written. However support for system `$(prefix)/etc/gitconfig` will be added in the future.
  * - The current parser does not support the more exotic features of the git-config file format such as `[include]` and `[includeIf]`.
  *
  * @param {Object} args
  * @param {FsClient} args.fs - a file system implementation
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
- * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} [args.gitdir=join(dir,'.git')] - The [git directory](dir-vs-gitdir.md) path, required if global is not true and dir is missing
+ * @param {boolean} [args.global=false] - Use global git directory
  * @param {string} args.path - The key of the git config entry
  *
  * @returns {Promise<Array<any>>} Resolves with the config value
@@ -26,16 +27,20 @@ export async function getConfigAll({
   fs,
   dir,
   gitdir = join(dir, '.git'),
+  global = false,
   path,
 }) {
   try {
     assertParameter('fs', fs)
-    assertParameter('gitdir', gitdir)
+    if (global !== true) {
+      assertParameter('gitdir', gitdir)
+    }
     assertParameter('path', path)
 
     return await _getConfigAll({
       fs: new FileSystem(fs),
       gitdir,
+      global,
       path,
     })
   } catch (err) {

--- a/src/api/setConfig.js
+++ b/src/api/setConfig.js
@@ -10,13 +10,14 @@ import { join } from '../utils/join.js'
  * Write an entry to the git config files.
  *
  * *Caveats:*
- * - Currently only the local `$GIT_DIR/config` file can be read or written. However support for the global `~/.gitconfig` and system `$(prefix)/etc/gitconfig` will be added in the future.
+ * - Currently only the local `$GIT_DIR/config` file and global `~/.gitconfig` can be read or written. However support for system `$(prefix)/etc/gitconfig` will be added in the future.
  * - The current parser does not support the more exotic features of the git-config file format such as `[include]` and `[includeIf]`.
  *
  * @param {Object} args
  * @param {FsClient} args.fs - a file system implementation
  * @param {string} [args.dir] - The [working tree](dir-vs-gitdir.md) directory path
- * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+ * @param {string} [args.gitdir=join(dir,'.git')] - The [git directory](dir-vs-gitdir.md) path, required if global is not true and dir is missing
+ * @param {boolean} [args.global=false] - Use global git directory
  * @param {string} args.path - The key of the git config entry
  * @param {string | boolean | number | void} args.value - A value to store at that path. (Use `undefined` as the value to delete a config entry.)
  * @param {boolean} [args.append = false] - If true, will append rather than replace when setting (use with multi-valued config options).
@@ -52,24 +53,27 @@ export async function setConfig({
   fs: _fs,
   dir,
   gitdir = join(dir, '.git'),
+  global = false,
   path,
   value,
   append = false,
 }) {
   try {
     assertParameter('fs', _fs)
-    assertParameter('gitdir', gitdir)
+    if (global !== true) {
+      assertParameter('gitdir', gitdir)
+    }
     assertParameter('path', path)
     // assertParameter('value', value) // We actually allow 'undefined' as a value to unset/delete
 
     const fs = new FileSystem(_fs)
-    const config = await GitConfigManager.get({ fs, gitdir })
+    const config = await GitConfigManager.get({ fs, gitdir, global })
     if (append) {
       await config.append(path, value)
     } else {
       await config.set(path, value)
     }
-    await GitConfigManager.save({ fs, gitdir, config })
+    await GitConfigManager.save({ fs, gitdir, config, global })
   } catch (err) {
     err.caller = 'git.setConfig'
     throw err

--- a/src/commands/getConfig.js
+++ b/src/commands/getConfig.js
@@ -6,7 +6,8 @@ import { GitConfigManager } from '../managers/GitConfigManager.js'
 /**
  * @param {Object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
- * @param {string} args.gitdir
+ * @param {string} [args.gitdir]
+ * @param {boolean} [args.global]
  * @param {string} args.path
  *
  * @returns {Promise<any>} Resolves with the config value
@@ -20,7 +21,7 @@ import { GitConfigManager } from '../managers/GitConfigManager.js'
  * console.log(value)
  *
  */
-export async function _getConfig({ fs, gitdir, path }) {
-  const config = await GitConfigManager.get({ fs, gitdir })
+export async function _getConfig({ fs, gitdir, path, global }) {
+  const config = await GitConfigManager.get({ fs, gitdir, global })
   return config.get(path)
 }

--- a/src/commands/getConfigAll.js
+++ b/src/commands/getConfigAll.js
@@ -6,13 +6,14 @@ import { GitConfigManager } from '../managers/GitConfigManager.js'
 /**
  * @param {Object} args
  * @param {import('../models/FileSystem.js').FileSystem} args.fs
- * @param {string} args.gitdir
+ * @param {string} [args.gitdir]
+ * @param {boolean} [args.global]
  * @param {string} args.path
  *
  * @returns {Promise<Array<any>>} Resolves with an array of the config value
  *
  */
-export async function _getConfigAll({ fs, gitdir, path }) {
-  const config = await GitConfigManager.get({ fs, gitdir })
+export async function _getConfigAll({ fs, gitdir, path, global }) {
+  const config = await GitConfigManager.get({ fs, gitdir, global })
   return config.getall(path)
 }

--- a/src/managers/GitConfigManager.js
+++ b/src/managers/GitConfigManager.js
@@ -1,17 +1,26 @@
+import { homedir } from 'os'
+import { join } from 'path'
+
 import { GitConfig } from '../models/GitConfig.js'
 
 export class GitConfigManager {
-  static async get({ fs, gitdir }) {
+  static async get({ fs, gitdir, global = false }) {
     // We can improve efficiency later if needed.
     // TODO: read from full list of git config files
-    const text = await fs.read(`${gitdir}/config`, { encoding: 'utf8' })
+    const configPath = global
+      ? join(homedir(), '.gitconfig')
+      : join(gitdir, 'config')
+    const text = await fs.read(configPath, { encoding: 'utf8' })
     return GitConfig.from(text)
   }
 
-  static async save({ fs, gitdir, config }) {
+  static async save({ fs, gitdir, config, global = false }) {
     // We can improve efficiency later if needed.
     // TODO: handle saving to the correct global/user/repo location
-    await fs.write(`${gitdir}/config`, config.toString(), {
+    const configPath = global
+      ? join(homedir(), '.gitconfig')
+      : join(gitdir, 'config')
+    await fs.write(configPath, config.toString(), {
       encoding: 'utf8',
     })
   }

--- a/website/versioned_docs/version-1.x/getConfig.md
+++ b/website/versioned_docs/version-1.x/getConfig.md
@@ -7,16 +7,17 @@ original_id: getConfig
 
 Read an entry from the git config files.
 
-| param          | type [= default]          | description                                         |
-| -------------- | ------------------------- | --------------------------------------------------- |
-| [**fs**](./fs) | FsClient                  | a file system implementation                        |
-| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path |
-| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path          |
-| **path**       | string                    | The key of the git config entry                     |
-| return         | Promise\<any\>            | Resolves with the config value                      |
+| param          | type [= default]          | description                                                                                   |
+| -------------- | ------------------------- | --------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                  | a file system implementation                                                                  |
+| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path                                           |
+| gitdir         | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path, required if global is not true and dir is missing |
+| global         | boolean = false           | Use global git directory                                                                      |
+| **path**       | string                    | The key of the git config entry                                                               |
+| return         | Promise\<any\>            | Resolves with the config value                                                                |
 
 *Caveats:*
-- Currently only the local `$GIT_DIR/config` file can be read or written. However support for the global `~/.gitconfig` and system `$(prefix)/etc/gitconfig` will be added in the future.
+- Currently only the local `$GIT_DIR/config` file and global `~/.gitconfig` can be read or written. However support for system `$(prefix)/etc/gitconfig` will be added in the future.
 - The current parser does not support the more exotic features of the git-config file format such as `[include]` and `[includeIf]`.
 
 Example Code:

--- a/website/versioned_docs/version-1.x/getConfigAll.md
+++ b/website/versioned_docs/version-1.x/getConfigAll.md
@@ -7,16 +7,17 @@ original_id: getConfigAll
 
 Read a multi-valued entry from the git config files.
 
-| param          | type [= default]          | description                                         |
-| -------------- | ------------------------- | --------------------------------------------------- |
-| [**fs**](./fs) | FsClient                  | a file system implementation                        |
-| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path |
-| **gitdir**     | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path          |
-| **path**       | string                    | The key of the git config entry                     |
-| return         | Promise\<Array\<any\>\>   | Resolves with the config value                      |
+| param          | type [= default]          | description                                                                                   |
+| -------------- | ------------------------- | --------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                  | a file system implementation                                                                  |
+| dir            | string                    | The [working tree](dir-vs-gitdir.md) directory path                                           |
+| gitdir         | string = join(dir,'.git') | The [git directory](dir-vs-gitdir.md) path, required if global is not true and dir is missing |
+| global         | boolean = false           | Use global git directory                                                                      |
+| **path**       | string                    | The key of the git config entry                                                               |
+| return         | Promise\<Array\<any\>\>   | Resolves with the config value                                                                |
 
 *Caveats:*
-- Currently only the local `$GIT_DIR/config` file can be read or written. However support for the global `~/.gitconfig` and system `$(prefix)/etc/gitconfig` will be added in the future.
+- Currently only the local `$GIT_DIR/config` file and global `~/.gitconfig` can be read or written. However support for system `$(prefix)/etc/gitconfig` will be added in the future.
 - The current parser does not support the more exotic features of the git-config file format such as `[include]` and `[includeIf]`.
 
 

--- a/website/versioned_docs/version-1.x/setConfig.md
+++ b/website/versioned_docs/version-1.x/setConfig.md
@@ -11,14 +11,15 @@ Write an entry to the git config files.
 | -------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | [**fs**](./fs) | FsClient                                              | a file system implementation                                                                  |
 | dir            | string                                                | The [working tree](dir-vs-gitdir.md) directory path                                           |
-| **gitdir**     | string = join(dir,'.git')                             | The [git directory](dir-vs-gitdir.md) path                                                    |
+| gitdir         | string = join(dir,'.git')                             | The [git directory](dir-vs-gitdir.md) path, required if global is not true and dir is missing |
+| global         | boolean = false                                       | Use global git directory                                                                      |
 | **path**       | string                                                | The key of the git config entry                                                               |
 | **value**      | string  &#124;  boolean  &#124;  number  &#124;  void | A value to store at that path. (Use `undefined` as the value to delete a config entry.)       |
 | append         | boolean = false                                       | If true, will append rather than replace when setting (use with multi-valued config options). |
 | return         | Promise\<void\>                                       | Resolves successfully when operation completed                                                |
 
 *Caveats:*
-- Currently only the local `$GIT_DIR/config` file can be read or written. However support for the global `~/.gitconfig` and system `$(prefix)/etc/gitconfig` will be added in the future.
+- Currently only the local `$GIT_DIR/config` file and global `~/.gitconfig` can be read or written. However support for system `$(prefix)/etc/gitconfig` will be added in the future.
 - The current parser does not support the more exotic features of the git-config file format such as `[include]` and `[includeIf]`.
 
 Example Code:


### PR DESCRIPTION
## I'm adding a parameter to an existing command X:

- [x] add parameter `global` to the function in `src/api/getConfig.js`, `src/api/getConfigAll.js`, `src/api/setConfig.js`,  `src/commands/getConfig.js`, `src/commands/getConfigAll.js`, and `src/managers/GitConfigManager.js`
- [x] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] squash merge the PR with commit message "feat(X): Added 'bar' parameter"
