### PR TITLE
fix: support autocrlf input

### DIFF
--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -101,7 +101,7 @@ export class FileSystem {
   async read(filepath, options = {}) {
     try {
       let buffer = await this._readFile(filepath, options)
-      if (options.autocrlf === 'true') {
+      if (['true', 'input'].includes(options.autocrlf)) {
         try {
           buffer = new TextDecoder('utf8', { fatal: true }).decode(buffer)
           buffer = buffer.replace(/\r\n/g, '\n')


### PR DESCRIPTION
Add the missing handling for `core.autocrlf=input`