### PR TITLE
fix: transform response from deflate compression stream to work with Node.js 22.3.0

### DIFF
--- a/__tests__/test-writeObject.js
+++ b/__tests__/test-writeObject.js
@@ -1,5 +1,5 @@
 /* eslint-env node, browser, jasmine */
-const { writeObject } = require('isomorphic-git')
+const { readObject, writeObject } = require('isomorphic-git')
 
 const { makeFixture } = require('./__helpers__/FixtureFS.js')
 
@@ -102,11 +102,12 @@ Qixh2bmPgr3h9nxq2Dmn
     // Setup
     const { fs, gitdir } = await makeFixture('test-writeObject')
     // Test
+    let expectedContents
     const oid = await writeObject({
       fs,
       gitdir,
       type: 'blob',
-      object: `#!/usr/bin/env node
+      object: (expectedContents = `#!/usr/bin/env node
 const minimisted = require('minimisted')
 const git = require('.')
 
@@ -133,11 +134,13 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
   if (result === undefined) return
   console.log(JSON.stringify(result, null, 2))
 })
-`,
+`),
       format: 'parsed',
       encoding: 'utf8',
     })
     expect(oid).toEqual('4551a1856279dde6ae9d65862a1dff59a5f199d8')
+    const result = await readObject({ fs, gitdir, oid })
+    expect(Buffer.from(result.object).toString()).toEqual(expectedContents)
   })
   it('tree', async () => {
     // Setup

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,6 +8,12 @@ module.exports = {
   },
   collectCoverageFrom: ['src/*.js', 'src/**/*.js'],
   testEnvironment: 'node',
+  globals: {
+    Blob: global.Blob,
+    CompressionStream: global.CompressionStream,
+    DecompressionStream: global.DecompressionStream,
+    Response: global.Response,
+  },
   reporters: [
     'default',
     [

--- a/src/utils/deflate.js
+++ b/src/utils/deflate.js
@@ -16,7 +16,10 @@ export async function deflate(buffer) {
 async function browserDeflate(buffer) {
   const cs = new CompressionStream('deflate')
   const c = new Blob([buffer]).stream().pipeThrough(cs)
-  return new Uint8Array(await new Response(c).arrayBuffer())
+  return new Response(c)
+    .blob()
+    .then(b => new Response(b).arrayBuffer())
+    .then(ab => new Uint8Array(ab))
 }
 
 function testCompressionStream() {


### PR DESCRIPTION
resolves #1933

This PR also exposes the Node.js globals related to compression to the Jest runtime so that these APIs get used if available. Without the code fix, the Node.js tests will now fail when using 22.3.0 with this modified Jest configuration.