### PR TITLE
Fix issue: The file “index” couldn’t be opened because there is no such file on iOS device

### DIFF
--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -81,7 +81,11 @@ export class FileSystem {
       await this._stat(filepath)
       return true
     } catch (err) {
-      if (err.code === 'ENOENT' || err.code === 'ENOTDIR' || (err?.code || '').includes('ENS')) {
+      if (
+        err.code === 'ENOENT' ||
+        err.code === 'ENOTDIR' ||
+        (err?.code || '').includes('ENS')
+      ) {
         return false
       } else {
         console.log('Unhandled error in "FileSystem.exists()" function', err)

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -81,7 +81,7 @@ export class FileSystem {
       await this._stat(filepath)
       return true
     } catch (err) {
-      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR' || (err?.code || '').includes('ENS')) {
         return false
       } else {
         console.log('Unhandled error in "FileSystem.exists()" function', err)
@@ -234,7 +234,7 @@ export class FileSystem {
       const stats = await this._lstat(filename)
       return stats
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (err.code === 'ENOENT' || (err?.code || '').includes('ENS')) {
         return null
       }
       throw err
@@ -252,7 +252,7 @@ export class FileSystem {
       const link = await this._readlink(filename, opts)
       return Buffer.isBuffer(link) ? link : Buffer.from(link)
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (err.code === 'ENOENT' || (err?.code || '').includes('ENS')) {
         return null
       }
       throw err

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -84,7 +84,7 @@ export class FileSystem {
       if (
         err.code === 'ENOENT' ||
         err.code === 'ENOTDIR' ||
-        (err?.code || '').includes('ENS')
+        (err.code || '').includes('ENS')
       ) {
         return false
       } else {
@@ -238,7 +238,7 @@ export class FileSystem {
       const stats = await this._lstat(filename)
       return stats
     } catch (err) {
-      if (err.code === 'ENOENT' || (err?.code || '').includes('ENS')) {
+      if (err.code === 'ENOENT' || (err.code || '').includes('ENS')) {
         return null
       }
       throw err
@@ -256,7 +256,7 @@ export class FileSystem {
       const link = await this._readlink(filename, opts)
       return Buffer.isBuffer(link) ? link : Buffer.from(link)
     } catch (err) {
-      if (err.code === 'ENOENT' || (err?.code || '').includes('ENS')) {
+      if (err.code === 'ENOENT' || (err.code || '').includes('ENS')) {
         return null
       }
       throw err


### PR DESCRIPTION

## I'm fixing a bug
Error when clone a new repo: `Error: The file “index” couldn’t be opened because there is no such file.`

When using in react native with IOS device, the FileSystem missing error code when file not exist, will make an exception. I believe new iOS version return different code: `ENSCOCOAERRORDOMAIN260`
So I added more condition to check status code.

