### PR TITLE
Upgrade TypeScript to newest version

### DIFF
--- a/__tests__/__helpers__/find-unused-errors.cjs
+++ b/__tests__/__helpers__/find-unused-errors.cjs
@@ -1,11 +1,12 @@
-const { E } = require('../..')
+const { Errors } = require('../..')
 const replace = require('replace-in-file')
 
-const errors = Object.keys(E).map(name => `E.${name}`)
+const errors = Object.keys(Errors).map(name => `E.${name}`)
 const bal = []
 
 ;(async () => {
   for (const error of errors) {
+    // @ts-ignore
     let files = await replace({
       files: ['src/**/*.js'],
       from: error,

--- a/__tests__/__helpers__/karma-successful-browsers-reporter.cjs
+++ b/__tests__/__helpers__/karma-successful-browsers-reporter.cjs
@@ -12,7 +12,7 @@ const BrowsersReporter = function(
   this.successfulBrowsersFullNames = []
   this.successfulBrowsers = []
   this.failedBrowsers = []
-  this.onRunStart = function(browsers) {
+  this.onRunStart = (browsers) => {
     this.browserCount = browsers.length
     this.buildOk = true
     // Append to the existing list of successful browsers
@@ -20,7 +20,7 @@ const BrowsersReporter = function(
     this.successfulBrowsersFullNames = tmp[0]
     this.successfulBrowsers = tmp[1]
   }
-  this.onBrowserComplete = function(browser) {
+  this.onBrowserComplete = (browser) => {
     var results = browser.lastResult
     if (results.disconnected || results.error || results.failed) {
       this.buildOk = false
@@ -31,7 +31,7 @@ const BrowsersReporter = function(
       this.successfulBrowsersFullNames.push(browser.name)
     }
   }
-  this.onRunComplete = function() {
+  this.onRunComplete = () => {
     loadSuccessfulBrowsers.save(this.successfulBrowsersFullNames)
   }
 }

--- a/__tests__/test-addRemote.js
+++ b/__tests__/test-addRemote.js
@@ -26,7 +26,14 @@ describe('addRemote', () => {
     // Test
     let error = null
     try {
-      await addRemote({ fs, dir, gitdir, remote, url })
+      await addRemote({
+        fs,
+        dir,
+        gitdir,
+        remote,
+        // @ts-ignore
+        url,
+      })
     } catch (err) {
       error = err
     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '12.x'
+          versionSpec: '14.x'
         displayName: 'Install Node.js'
 
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreAndSaveCacheV1.RestoreAndSaveCache@1

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -82,16 +82,16 @@ module.exports = function (config) {
       sl_safari: {
         base: 'SauceLabs',
         browserName: 'safari',
-        platform: 'macOS 11',
-        version: '16',
+        platform: 'macOS 11.00',
+        version: '14',
       },
       sl_ios_safari: {
         base: 'SauceLabs',
         deviceName: 'iPhone 11 Pro Max Simulator',
         platformName: 'iOS',
-        platformVersion: '15.7',
+        platformVersion: '14.0',
         browserName: 'Safari',
-        appiumVersion: '1.15.0',
+        appiumVersion: '1.18.3',
       },
       XXXsl_android_chrome: {
         base: 'SauceLabs',

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -82,14 +82,14 @@ module.exports = function (config) {
       sl_safari: {
         base: 'SauceLabs',
         browserName: 'safari',
-        platform: 'macOS 10.15',
-        version: '13.1',
+        platform: 'macOS 11',
+        version: '16',
       },
       sl_ios_safari: {
         base: 'SauceLabs',
         deviceName: 'iPhone 11 Pro Max Simulator',
         platformName: 'iOS',
-        platformVersion: '13.0',
+        platformVersion: '15.7',
         browserName: 'Safari',
         appiumVersion: '1.15.0',
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "standard": "13.1.0",
         "timeout-cli": "0.3.2",
         "tweet-tweet": "1.0.4",
-        "typescript": "3.9.0-dev.20200223",
+        "typescript": "5.7.3",
         "webpack": "4.41.5",
         "webpack-bundle-analyzer": "3.4.1",
         "webpack-cli": "3.3.7"
@@ -28545,16 +28545,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.0-dev.20200223",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200223.tgz",
-      "integrity": "sha512-OIBSwsDxSe40AvMOZbSeq2HxCg2jjbxzsVHYhNnC4xvumzMq2Si4PY0SdZQcgVykNTmupOQLjT8ky48WjUYAjg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -52436,9 +52436,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.0-dev.20200223",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200223.tgz",
-      "integrity": "sha512-OIBSwsDxSe40AvMOZbSeq2HxCg2jjbxzsVHYhNnC4xvumzMq2Si4PY0SdZQcgVykNTmupOQLjT8ky48WjUYAjg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "standard": "13.1.0",
     "timeout-cli": "0.3.2",
     "tweet-tweet": "1.0.4",
-    "typescript": "3.9.0-dev.20200223",
+    "typescript": "5.7.3",
     "webpack": "4.41.5",
     "webpack-bundle-analyzer": "3.4.1",
     "webpack-cli": "3.3.7"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=12"
+    "node": ">=14.17"
   },
   "scripts": {
     "start": "nps",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "es2020",
     "module": "esnext",
     "lib": ["es2015", "es2016", "es2017", "es2018", "es2019", "dom"],
-    "suppressImplicitAnyIndexErrors": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
This pull request updates the dependency `typescript` to the newest version `5.7.3`.

It resolves the type checking issues mentioned in [#2035](https://github.com/isomorphic-git/isomorphic-git/pull/2035#issuecomment-2677593012), where new declaration files for some dependencies were not able to be parsed correctly by an old version of TypeScript.

> It's caused by a descendent dependency `@types/babel__traverse` being declared with version *, which downloads the newest type declaration file `index.d.ts`, whose syntax is not compatible with the old version of TypeScript used in this project (`3.9.0-dev.20200223`).

---

It also resolves new type errors that resulted from the update.


```
nps is executing `test.typecheck` : tsc -p tsconfig.json
__tests__/__helpers__/find-unused-errors.cjs:1:9 - error TS2614: Module '"../.."' has no exported member 'E'. Did you mean to use 'import E from "../.."' instead?

1 const { E } = require('../..')
          ~

__tests__/__helpers__/find-unused-errors.cjs:9:23 - error TS2349: This expression is not callable.
  Type 'typeof import("replace-in-file")' has no call signatures.

9     let files = await replace({
                        ~~~~~~~

__tests__/__helpers__/karma-successful-browsers-reporter.cjs:27:12 - error TS2339: Property 'failedBrowsers' does not exist on type 'onBrowserComplete'.

27       this.failedBrowsers.push(browser)
              ~~~~~~~~~~~~~~

__tests__/__helpers__/karma-successful-browsers-reporter.cjs:29:12 - error TS2339: Property 'successfulBrowsersFullNames' does not exist on type 'onBrowserComplete'.

29       this.successfulBrowsersFullNames.push('X ' + browser.name)
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~

__tests__/__helpers__/karma-successful-browsers-reporter.cjs:31:12 - error TS2339: Property 'successfulBrowsersFullNames' does not exist on type 'onBrowserComplete'.

31       this.successfulBrowsersFullNames.push(browser.name)
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~

__tests__/test-addRemote.js:29:50 - error TS2322: Type 'undefined' is not assignable to type 'string'.

29       await addRemote({ fs, dir, gitdir, remote, url })
                                                    ~~~

  index.d.ts:889:5
    889     url: string;
            ~~~
    The expected type comes from property 'url' which is declared here on type '{ fs: FsClient; dir?: string | undefined; gitdir?: string | undefined; remote: string; url: string; force?: boolean | undefined; }'


Found 6 errors in 3 files.

Errors  Files
     2  __tests__/__helpers__/find-unused-errors.cjs:1
     3  __tests__/__helpers__/karma-successful-browsers-reporter.cjs:27
     1  __tests__/test-addRemote.js:29
```
