### PR TITLE
chore: Improve the GitHub Workflow performance and warn when uncommitted changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
         env:
           # Puppeteer is only used to install Chromium and get the executable path from CHROME_BIN.
           # This is only required when running the karma-chrome-launcher.
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher != 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
-          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher != 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && '' || 'true' }}
+          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && '' || 'true' }}
 
       - name: Run build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    # The BrowserStack test running Android 10 on a Pixel 4 timed out after 15 minutes.
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
           # Warn when there are uncommitted changes to documentation
           if ! git diff --quiet --exit-code; then
-            echo "::warning::There are uncommitted changes to the documentation. Please run `nps build.docs` and commit the changes."
+            echo "::warning title=Uncommitted Changes to Documentation::There are uncommitted changes to the documentation. Please run \`nps build.docs\` and commit the changes."
           fi
 
       - name: Save npm-tarball.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           # Puppeteer is only used to install Chromium and get the executable path from CHROME_BIN.
           # This is only required when running the karma-chrome-launcher.
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
-          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}  
+          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
 
       - name: Run build
         run: |
@@ -200,7 +200,7 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-          PUPPETEER_SKIP_DOWNLOAD: true  
+          PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel in-progress runs for the current workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build (Node.js v14)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
         env:
           # Puppeteer is only used to install Chromium and get the executable path from CHROME_BIN.
           # This is only required when running the karma-chrome-launcher.
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
-          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher != 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
+          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher != 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
 
       - name: Run build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+          PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Run lint
         run: |
@@ -73,6 +76,11 @@ jobs:
             build.docs \
             build.pack
 
+          # Warn when there are uncommitted changes to documentation
+          if ! git diff --quiet --exit-code; then
+            echo "::warning::There are uncommitted changes to the documentation. Please run `nps build.docs` and commit the changes."
+          fi
+
       - name: Save npm-tarball.tgz
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork }}
         uses: actions/upload-artifact@v4
@@ -111,6 +119,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          # Puppeteer is only used to install Chromium and get the executable path from CHROME_BIN.
+          # This is only required when running the karma-chrome-launcher.
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}
+          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && 'true' || 'false' }}  
 
       - name: Run build
         run: |
@@ -148,11 +161,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
 
+    timeout-minutes: 5
+
     steps:
       - name: Download test results
         if: ${{ !cancelled() }}
         uses: actions/download-artifact@v4
-
 
       # Problem: GitHub does not support Test Results reports like Azure Pipelines.
       # TODO:    Update the workflow to combine and "Publish test results" somewhere.
@@ -171,6 +185,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'main' || github.ref_name == 'beta' }}
 
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -182,6 +198,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+          PUPPETEER_SKIP_DOWNLOAD: true  
 
       - name: Publish to npm
         run: |


### PR DESCRIPTION
This pull request improves the GitHub Workflow:

- Reduce the runtime by ~20s by only downloading Chromium when required
- Warn when there are uncommitted changes to the documentation
  <img width="1423" alt="image" src="https://github.com/user-attachments/assets/f367f660-004e-47a9-b44f-d0303384f55c" />
- Add timeouts to the remaining jobs
- Cancel in-progress runs for the current workflow

### Test Plan

- If the GitHub Workflow passes, it should be ready to merge