### PR TITLE
chore: Improve BrowserStack test stability in the pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
         # This is a comma-separated list of Karma launchers
         karma-launcher: ${{ fromJSON(format('[{0}]', '"ChromeHeadlessNoSandbox","FirefoxHeadless","sl_edge","sl_safari","sl_ios_safari","bs_android_chrome"')) }}
 
+      # Our BrowserStack plan allows up to 5 parallel tests. We limit each workflow to 2 to avoid the limit.
+      max-parallel: 2
+
     steps:
       - uses: actions/checkout@v4
 
@@ -124,12 +127,15 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
-        env:
-          # Puppeteer is only used to install Chromium and get the executable path from CHROME_BIN.
-          # This is only required when running the karma-chrome-launcher.
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && '' || 'true' }}
-          PUPPETEER_SKIP_DOWNLOAD: ${{ (matrix.karma-launcher == 'ChromeHeadlessNoSandbox') && '' || 'true' }}
+        run: |
+          # Only install Chromium when we are running a test using the Chrome browser.
+          # Otherwise, do not install it to save ~10 seconds.
+          if [[ "${{ matrix.karma-launcher }}" != "ChromeHeadlessNoSandbox" ]]; then
+            export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+            export PUPPETEER_SKIP_DOWNLOAD=true
+          fi
+
+          npm ci
 
       - name: Run build
         run: |


### PR DESCRIPTION
This pull request:

- Limits the number of parallel BrowserStack tests to avoid hitting the account limit
- Fixes the conditional Chromium download. The download is skipped if the environment variables are set to anything (`null`, `''`, or `'false`).

### Test Plan

This had been tested and works:

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/71404c27-f765-4187-ad7e-e96c1f0a8d81" />

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/a8fa0ddf-52b8-47ed-a847-6b5d8976d704" />
