### PR TITLE
feat: updateindex in bulk 

### DIFF
--- a/src/api/updateIndex.js
+++ b/src/api/updateIndex.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 import { InvalidFilepathError } from '../errors/InvalidFilepathError.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
 import { GitIndexManager } from '../managers/GitIndexManager.js'
@@ -8,13 +9,19 @@ import { assertParameter } from '../utils/assertParameter.js'
 import { join } from '../utils/join.js'
 
 /**
+ * @typedef {object} FileInfo
+ * @property {string} filepath - The path to the file.
+ * @property {string} [oid] - OID of the object in the object database to add to the index with the specified filepath.
+ */
+
+/**
  * Register file contents in the working tree or object database to the git index (aka staging area).
  *
  * @param {object} args
  * @param {FsClient} args.fs - a file system client
  * @param {string} args.dir - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
- * @param {string} args.filepath - File to act upon.
+ * @param {string | Array<FileInfo>} args.filepath - File to act upon.
  * @param {string} [args.oid] - OID of the object in the object database to add to the index with the specified filepath.
  * @param {number} [args.mode = 100644] - The file mode to add the file to the index.
  * @param {boolean} [args.add] - Adds the specified file to the index if it does not yet exist in the index.
@@ -22,7 +29,7 @@ import { join } from '../utils/join.js'
  * @param {boolean} [args.force] - Remove the specified file from the index, even if it still exists in the workspace.
  * @param {object} [args.cache] - a [cache](cache.md) object
  *
- * @returns {Promise<string | void>} Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed.
+ * @returns {Promise<string | string[] | void>} Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed.
  *
  * @example
  * await git.updateIndex({
@@ -44,8 +51,7 @@ import { join } from '../utils/join.js'
  *   fs,
  *   dir: '/tutorial',
  *   add: true,
- *   filepath: 'readme.md',
- *   oid
+ *   filepath: [{filepath:'readme.md', oid}]
  * })
  */
 export async function updateIndex({
@@ -65,83 +71,80 @@ export async function updateIndex({
     assertParameter('gitdir', gitdir)
     assertParameter('filepath', filepath)
 
+    const pathIsArray = Array.isArray(filepath)
+    const filepaths = pathIsArray ? filepath : [{ filepath, oid }]
+
     const fs = new FileSystem(_fs)
 
     if (remove) {
       return await GitIndexManager.acquire(
         { fs, gitdir, cache },
         async function(index) {
+          let pathsToRemove = []
           if (!force) {
             // Check if the file is still present in the working directory
-            const fileStats = await fs.lstat(join(dir, filepath))
-
-            if (fileStats) {
-              if (fileStats.isDirectory()) {
-                // Removing directories should not work
-                throw new InvalidFilepathError('directory')
-              }
-
-              // Do nothing if we don't force and the file still exists in the workdir
-              return
-            }
+            await Promise.all(
+              filepaths.map(async filepath => {
+                const stats = await fs.lstat(join(dir, filepath.filepath))
+                // Do nothing if we don't force and the file still exists in the workdir
+                if (stats) {
+                  if (stats.isDirectory()) {
+                    // Removing directories should not work
+                    throw new InvalidFilepathError('directory')
+                  }
+                } else {
+                  pathsToRemove.push(filepath)
+                }
+              })
+            )
+          } else {
+            pathsToRemove = filepaths
           }
 
-          // Directories are not allowed, so we make sure the provided filepath exists in the index
-          if (index.has({ filepath })) {
-            index.delete({
-              filepath,
-            })
+          for (const { filepath } of pathsToRemove) {
+            if (index.has({ filepath })) {
+              index.delete({
+                filepath,
+              })
+            }
           }
         }
       )
     }
 
-    // Test if it is a file and exists on disk if `remove` is not provided, only of no oid is provided
-    let fileStats
+    // Test if it is a file and exists on disk if `remove` is not provided, only if no oid is provided
+    for (const { oid: fileOid, filepath } of filepaths) {
+      if (!fileOid) {
+        const fileStats = await fs.lstat(join(dir, filepath))
 
-    if (!oid) {
-      fileStats = await fs.lstat(join(dir, filepath))
+        if (!fileStats) {
+          throw new NotFoundError(
+            `file at "${filepath}" on disk and "remove" not set`
+          )
+        }
 
-      if (!fileStats) {
-        throw new NotFoundError(
-          `file at "${filepath}" on disk and "remove" not set`
-        )
-      }
-
-      if (fileStats.isDirectory()) {
-        throw new InvalidFilepathError('directory')
+        if (fileStats.isDirectory()) {
+          throw new InvalidFilepathError('directory')
+        }
       }
     }
 
-    return await GitIndexManager.acquire({ fs, gitdir, cache }, async function(
-      index
-    ) {
-      if (!add && !index.has({ filepath })) {
-        // If the index does not contain the filepath yet and `add` is not set, we should throw
-        throw new NotFoundError(
-          `file at "${filepath}" in index and "add" not set`
-        )
-      }
+    return await GitIndexManager.acquire(
+      { fs, gitdir, cache, allowUnmerged: false },
+      async function(index) {
+        if (!add) {
+          for (const { filepath } of filepaths) {
+            if (!index.has({ filepath })) {
+              // If the index does not contain the filepath yet and `add` is not set, we should throw
+              throw new NotFoundError(
+                `file at "${filepath}" in index and "add" not set`
+              )
+            }
+          }
+        }
 
-      let stats
-      if (!oid) {
-        stats = fileStats
-
-        // Write the file to the object database
-        const object = stats.isSymbolicLink()
-          ? await fs.readlink(join(dir, filepath))
-          : await fs.read(join(dir, filepath))
-
-        oid = await _writeObject({
-          fs,
-          gitdir,
-          type: 'blob',
-          format: 'content',
-          object,
-        })
-      } else {
         // By default we use 0 for the stats of the index file
-        stats = {
+        const defaultStats = {
           ctime: new Date(0),
           mtime: new Date(0),
           dev: 0,
@@ -151,16 +154,41 @@ export async function updateIndex({
           gid: 0,
           size: 0,
         }
+
+        const oids = []
+        for (const { oid: oldOid, filepath } of filepaths) {
+          let oid = oldOid
+          let stats
+          if (!oid) {
+            // Write the file to the object database
+            stats = await fs.lstat(join(dir, filepath))
+            const object = stats.isSymbolicLink()
+              ? await fs.readlink(join(dir, filepath))
+              : await fs.read(join(dir, filepath))
+
+            oid = await _writeObject({
+              fs,
+              gitdir,
+              type: 'blob',
+              format: 'content',
+              object,
+            })
+          }
+
+          if (!stats) {
+            stats = defaultStats
+          }
+          index.insert({
+            filepath,
+            oid: oid,
+            stats,
+          })
+
+          oids.push(oid)
+        }
+        return pathIsArray ? oids : oids[0] || undefined
       }
-
-      index.insert({
-        filepath,
-        oid: oid,
-        stats,
-      })
-
-      return oid
-    })
+    )
   } catch (err) {
     err.caller = 'git.updateIndex'
     throw err

--- a/website/versioned_docs/version-1.x/updateIndex.md
+++ b/website/versioned_docs/version-1.x/updateIndex.md
@@ -7,19 +7,19 @@ original_id: updateIndex
 
 Register file contents in the working tree or object database to the git index (aka staging area).
 
-| param          | type [= default]                                   | description                                                                                                                       |
-| -------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                                           | a file system client                                                                                                              |
-| **dir**        | string                                             | The [working tree](dir-vs-gitdir.md) directory path                                                                               |
-| **gitdir**     | string = join(dir, '.git')                         | The [git directory](dir-vs-gitdir.md) path                                                                                        |
-| **filepath**   | string &#124; Array<{filepath:string, oid:string}> | File to act upon.                                                                                                                 |
-| oid            | string                                             | OID of the object in the object database to add to the index with the specified filepath.                                         |
-| mode           | number = 100644                                    | The file mode to add the file to the index.                                                                                       |
-| add            | boolean                                            | Adds the specified file to the index if it does not yet exist in the index.                                                       |
-| remove         | boolean                                            | Remove the specified file from the index if it does not exist in the workspace anymore.                                           |
-| force          | boolean                                            | Remove the specified file from the index, even if it still exists in the workspace.                                               |
-| cache          | object                                             | a [cache](cache.md) object                                                                                                        |
-| return         | Promise\<(string &#124; void)\>                    | Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed. |
+| param          | type [= default]                                       | description                                                                                                                       |
+| -------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                                               | a file system client                                                                                                              |
+| **dir**        | string                                                 | The [working tree](dir-vs-gitdir.md) directory path                                                                               |
+| **gitdir**     | string = join(dir, '.git')                             | The [git directory](dir-vs-gitdir.md) path                                                                                        |
+| **filepath**   | string  &#124;  Array\<FileInfo\>                      | File to act upon.                                                                                                                 |
+| oid            | string                                                 | OID of the object in the object database to add to the index with the specified filepath.                                         |
+| mode           | number = 100644                                        | The file mode to add the file to the index.                                                                                       |
+| add            | boolean                                                | Adds the specified file to the index if it does not yet exist in the index.                                                       |
+| remove         | boolean                                                | Remove the specified file from the index if it does not exist in the workspace anymore.                                           |
+| force          | boolean                                                | Remove the specified file from the index, even if it still exists in the workspace.                                               |
+| cache          | object                                                 | a [cache](cache.md) object                                                                                                        |
+| return         | Promise\<(string &#124; Array\<string\> &#124; void)\> | Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed. |
 
 Example Code:
 
@@ -44,10 +44,7 @@ await git.updateIndex({
   fs,
   dir: '/tutorial',
   add: true,
-  filepath: [
-    { filepath: 'readme.md', oid },
-    { filepath: 'changelog.md', oid }
-  ]
+  filepath: [{filepath:'readme.md', oid}]
 })
 ```
 

--- a/website/versioned_docs/version-1.x/updateIndex.md
+++ b/website/versioned_docs/version-1.x/updateIndex.md
@@ -7,19 +7,19 @@ original_id: updateIndex
 
 Register file contents in the working tree or object database to the git index (aka staging area).
 
-| param          | type [= default]                | description                                                                                                                       |
-| -------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [**fs**](./fs) | FsClient                        | a file system client                                                                                                              |
-| **dir**        | string                          | The [working tree](dir-vs-gitdir.md) directory path                                                                               |
-| **gitdir**     | string = join(dir, '.git')      | The [git directory](dir-vs-gitdir.md) path                                                                                        |
-| **filepath**   | string                          | File to act upon.                                                                                                                 |
-| oid            | string                          | OID of the object in the object database to add to the index with the specified filepath.                                         |
-| mode           | number = 100644                 | The file mode to add the file to the index.                                                                                       |
-| add            | boolean                         | Adds the specified file to the index if it does not yet exist in the index.                                                       |
-| remove         | boolean                         | Remove the specified file from the index if it does not exist in the workspace anymore.                                           |
-| force          | boolean                         | Remove the specified file from the index, even if it still exists in the workspace.                                               |
-| cache          | object                          | a [cache](cache.md) object                                                                                                        |
-| return         | Promise\<(string &#124; void)\> | Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed. |
+| param          | type [= default]                                   | description                                                                                                                       |
+| -------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                                           | a file system client                                                                                                              |
+| **dir**        | string                                             | The [working tree](dir-vs-gitdir.md) directory path                                                                               |
+| **gitdir**     | string = join(dir, '.git')                         | The [git directory](dir-vs-gitdir.md) path                                                                                        |
+| **filepath**   | string &#124; Array<{filepath:string, oid:string}> | File to act upon.                                                                                                                 |
+| oid            | string                                             | OID of the object in the object database to add to the index with the specified filepath.                                         |
+| mode           | number = 100644                                    | The file mode to add the file to the index.                                                                                       |
+| add            | boolean                                            | Adds the specified file to the index if it does not yet exist in the index.                                                       |
+| remove         | boolean                                            | Remove the specified file from the index if it does not exist in the workspace anymore.                                           |
+| force          | boolean                                            | Remove the specified file from the index, even if it still exists in the workspace.                                               |
+| cache          | object                                             | a [cache](cache.md) object                                                                                                        |
+| return         | Promise\<(string &#124; void)\>                    | Resolves successfully with the SHA-1 object id of the object written or updated in the index, or nothing if the file was removed. |
 
 Example Code:
 
@@ -44,8 +44,10 @@ await git.updateIndex({
   fs,
   dir: '/tutorial',
   add: true,
-  filepath: 'readme.md',
-  oid
+  filepath: [
+    { filepath: 'readme.md', oid },
+    { filepath: 'changelog.md', oid }
+  ]
 })
 ```
 


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

Modifies the `filepath`  argument  for `updateIndex` to enable bulk updates of the index.
The function now support a string opr array arg e.g `filepath: string | {filepath: string, oid: string}`
example usage
```
  await git.updateIndex({
    fs,
    dir: '/tutorial',
    add: true,
    filepath: [ {filepath:'readme.md', oid}, {filepath:'changelog.md', oid2} ]
 * })
```

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [X] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [X] document the parameter in the JSDoc comment above the function
- [X] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
