### PR TITLE
perf: improve hashblob performance up to 100%

### DIFF
--- a/src/api/hashBlob.js
+++ b/src/api/hashBlob.js
@@ -38,14 +38,14 @@ export async function hashBlob({ object }) {
 
     // Convert object to buffer
     if (typeof object === 'string') {
-      object = Buffer.from(object, 'utf8')
-    } else {
       object = Buffer.from(object)
+    } else if (!(object instanceof Uint8Array)) {
+      object = new Uint8Array(object)
     }
 
     const type = 'blob'
     const { oid, object: _object } = await hashObject({
-      type: 'blob',
+      type,
       format: 'content',
       object,
     })

--- a/src/api/hashBlob.js
+++ b/src/api/hashBlob.js
@@ -49,7 +49,8 @@ export async function hashBlob({ object }) {
       format: 'content',
       object,
     })
-    return { oid, type, object: new Uint8Array(_object), format: 'wrapped' }
+
+    return { oid, type, object: _object, format: 'wrapped' }
   } catch (err) {
     err.caller = 'git.hashBlob'
     throw err

--- a/src/models/GitObject.js
+++ b/src/models/GitObject.js
@@ -1,13 +1,40 @@
 import { InternalError } from '../errors/InternalError.js'
 
+/**
+ * Represents a Git object and provides methods to wrap and unwrap Git objects
+ * according to the Git object format.
+ */
 export class GitObject {
+  /**
+   * Wraps a raw object with a Git header.
+   *
+   * @param {Object} params - The parameters for wrapping.
+   * @param {string} params.type - The type of the Git object (e.g., 'blob', 'tree', 'commit').
+   * @param {Uint8Array} params.object - The raw object data to wrap.
+   * @returns {Uint8Array} The wrapped Git object as a single buffer.
+   */
   static wrap({ type, object }) {
-    return Buffer.concat([
-      Buffer.from(`${type} ${object.byteLength.toString()}\x00`),
-      Buffer.from(object),
-    ])
+    const header = `${type} ${object.length}\x00`
+    const headerLen = header.length
+    const totalLength = headerLen + object.length
+
+    // Allocate a single buffer for the header and object, rather than create multiple buffers
+    const wrappedObject = new Uint8Array(totalLength)
+    for (let i = 0; i < headerLen; i++) {
+      wrappedObject[i] = header.charCodeAt(i)
+    }
+    wrappedObject.set(object, headerLen)
+
+    return wrappedObject
   }
 
+  /**
+   * Unwraps a Git object buffer into its type and raw object data.
+   *
+   * @param {Buffer|Uint8Array} buffer - The buffer containing the wrapped Git object.
+   * @returns {{ type: string, object: Buffer }} An object containing the type and the raw object data.
+   * @throws {InternalError} If the length specified in the header does not match the actual object length.
+   */
   static unwrap(buffer) {
     const s = buffer.indexOf(32) // first space
     const i = buffer.indexOf(0) // first null value

--- a/src/utils/shasum.js
+++ b/src/utils/shasum.js
@@ -29,7 +29,7 @@ async function testSubtleSHA1() {
   // some browsers that have crypto.subtle.digest don't actually implement SHA-1.
   try {
     const hash = await subtleSHA1(new Uint8Array([]))
-    if (hash === 'da39a3ee5e6b4b0d3255bfef95601890afd80709') return true
+    return hash === 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
   } catch (_) {
     // no bother
   }


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## performance improvement for hashBlob

## 50k Promises (Promise.all)

|            | **before (ms)** | **after (ms)** |
| ---------- | --------------- | -------------- |
| **Buffer** | 3822.918        | 1872.766       |
| **string** | 4072.27         | 2300           |


Buffer = 104.13% faster
string = 77.06% faster

### 50k Promises sequential

|            | **before (ms)** | **after (ms)** |
| ---------- | --------------- | -------------- |
| **Buffer** | 2821.764        | 1811.034       |
| **string** | 2509.682        | 1790           |


Buffer = 55.81 % faster
string = 40.21 % faster


- hashObject return a `Uint8Array`, no need to create another.
- hashBlob skip wrapping object in `Buffer` if it is already a `Uint8Array`
- `GitObject.wrap` : Create only 1 buffer instead of 3