### PR TITLE
feat: add 'create' operation to stash API

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -855,6 +855,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "anish3333",
+      "name": "Anish Awasthi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/128889867?v=4",
+      "profile": "https://github.com/anish3333",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -392,7 +392,10 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/gnillev"><img src="https://avatars.githubusercontent.com/u/8965094?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Mathias Nisted Velling</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=gnillev" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=gnillev" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/acandoo"><img src="https://avatars.githubusercontent.com/u/117209328?v=4?s=60" width="60px;" alt=""/><br /><sub><b>acandoo</b></sub></a><br /><a href="#platform-acandoo" title="Packaging/porting to new platform">📦</a> <a href="#userTesting-acandoo" title="User Testing">📓</a></td>
     <td align="center"><a href="https://github.com/bekatan"><img src="https://avatars.githubusercontent.com/u/19550476?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Bekatan Satyev</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=bekatan" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=bekatan" title="Tests">⚠️</a></td>
+  </tr>
+  <tr>
     <td align="center"><a href="https://github.com/hemanthkini"><img src="https://avatars.githubusercontent.com/u/3934055?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Hemanth Kini</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=hemanthkini" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/anish3333"><img src="https://avatars.githubusercontent.com/u/128889867?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Anish Awasthi</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=anish3333" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=anish3333" title="Documentation">📖</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=anish3333" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/__tests__/test-stash.js
+++ b/__tests__/test-stash.js
@@ -262,14 +262,14 @@ describe('stash create', () => {
 
     const aOriginalContent = 'staged changes - a'
     const bOriginalContent = 'staged changes - b'
-    
+
     await fs.write(`${dir}/a.txt`, aOriginalContent)
     await fs.write(`${dir}/b.js`, bOriginalContent)
     await add({ fs, dir, gitdir, filepath: ['a.txt', 'b.js'] })
 
-    let aStatusBefore = await status({ fs, dir, gitdir, filepath: 'a.txt' })
+    const aStatusBefore = await status({ fs, dir, gitdir, filepath: 'a.txt' })
     expect(aStatusBefore).toBe('modified')
-    let bStatusBefore = await status({ fs, dir, gitdir, filepath: 'b.js' })
+    const bStatusBefore = await status({ fs, dir, gitdir, filepath: 'b.js' })
     expect(bStatusBefore).toBe('modified')
 
     let stashCommitHash = null
@@ -292,9 +292,9 @@ describe('stash create', () => {
     expect(bContent.toString()).toEqual(bOriginalContent)
 
     // Verify status is still modified
-    let aStatusAfter = await status({ fs, dir, gitdir, filepath: 'a.txt' })
+    const aStatusAfter = await status({ fs, dir, gitdir, filepath: 'a.txt' })
     expect(aStatusAfter).toBe('modified')
-    let bStatusAfter = await status({ fs, dir, gitdir, filepath: 'b.js' })
+    const bStatusAfter = await status({ fs, dir, gitdir, filepath: 'b.js' })
     expect(bStatusAfter).toBe('modified')
 
     // Verify stash ref is NOT created
@@ -319,7 +319,13 @@ describe('stash create', () => {
     let error = null
     let stashCommitHash = null
     try {
-      stashCommitHash = await stash({ fs, dir, gitdir, op: 'create', message: 'custom message' })
+      stashCommitHash = await stash({
+        fs,
+        dir,
+        gitdir,
+        op: 'create',
+        message: 'custom message',
+      })
     } catch (e) {
       error = e
     }
@@ -414,12 +420,14 @@ describe('stash create', () => {
   })
 
   it('stash create with untracked files - with other changes', async () => {
-    const { fs, dir, gitdir } = await makeFixtureStash('createUntrackedWithChanges')
+    const { fs, dir, gitdir } = await makeFixtureStash(
+      'createUntrackedWithChanges'
+    )
 
     await addUserConfig(fs, dir, gitdir)
     const aOriginalContent = 'staged changes - a'
     const bOriginalContent = 'staged changes - b'
-    
+
     await fs.write(`${dir}/a.txt`, aOriginalContent)
     await fs.write(`${dir}/b.js`, bOriginalContent)
     await add({ fs, dir, gitdir, filepath: ['a.txt', 'b.js'] })
@@ -537,12 +545,24 @@ describe('stash create', () => {
     await fs.write(`${dir}/a.txt`, 'first change')
     await add({ fs, dir, gitdir, filepath: ['a.txt'] })
 
-    const firstHash = await stash({ fs, dir, gitdir, op: 'create', message: 'first' })
+    const firstHash = await stash({
+      fs,
+      dir,
+      gitdir,
+      op: 'create',
+      message: 'first',
+    })
 
     await fs.write(`${dir}/a.txt`, 'second change')
     await add({ fs, dir, gitdir, filepath: ['a.txt'] })
 
-    const secondHash = await stash({ fs, dir, gitdir, op: 'create', message: 'second' })
+    const secondHash = await stash({
+      fs,
+      dir,
+      gitdir,
+      op: 'create',
+      message: 'second',
+    })
 
     expect(firstHash).not.toBeNull()
     expect(secondHash).not.toBeNull()
@@ -568,7 +588,13 @@ describe('stash create', () => {
     // Now use stash create
     await fs.write(`${dir}/b.js`, 'create change')
     await add({ fs, dir, gitdir, filepath: ['b.js'] })
-    const createHash = await stash({ fs, dir, gitdir, op: 'create', message: 'create stash' })
+    const createHash = await stash({
+      fs,
+      dir,
+      gitdir,
+      op: 'create',
+      message: 'create stash',
+    })
 
     expect(createHash).not.toBeNull()
 
@@ -590,12 +616,12 @@ describe('stash create', () => {
     let error = null
 
     try {
-      stashCommitHash = await stash({ 
-        fs, 
-        dir, 
-        gitdir, 
-        op: 'create', 
-        message: customMessage 
+      stashCommitHash = await stash({
+        fs,
+        dir,
+        gitdir,
+        op: 'create',
+        message: customMessage,
       })
     } catch (e) {
       error = e
@@ -607,7 +633,12 @@ describe('stash create', () => {
     expect(stashCommitHash.length).toBe(40)
 
     // Read the commit to verify message format
-    const commitObj = await readCommit({ fs, dir, gitdir, oid: stashCommitHash })
+    const commitObj = await readCommit({
+      fs,
+      dir,
+      gitdir,
+      oid: stashCommitHash,
+    })
     expect(commitObj.commit.message).toContain(customMessage)
   })
 })

--- a/src/api/stash.js
+++ b/src/api/stash.js
@@ -64,7 +64,7 @@ import { join } from '../utils/join.js'
  *
  * console.log(await git.status({ fs, dir, filepath: 'a.txt' })) // 'modified'
  * console.log(await git.status({ fs, dir, filepath: 'b.txt' })) // '*modified'
- * 
+ *
  * // create a stash commit without modifying working directory
  * const stashCommitHash = await git.stash({ fs, dir, op: 'create', message: 'my stash' })
  * console.log(stashCommitHash) // returns the stash commit hash

--- a/src/api/stash.js
+++ b/src/api/stash.js
@@ -6,6 +6,7 @@ import {
   _stashList,
   _stashClear,
   _stashPop,
+  _stashCreate,
 } from '../commands/stash.js'
 import { InvalidRefNameError } from '../errors/InvalidRefNameError.js'
 import { FileSystem } from '../models/FileSystem.js'
@@ -13,21 +14,22 @@ import { assertParameter } from '../utils/assertParameter.js'
 import { join } from '../utils/join.js'
 
 /**
- * stash api, supports  {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear'} StashOp
+ * stash api, supports  {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear' | 'create'} StashOp
  * _note_,
  * - all stash operations are done on tracked files only with loose objects, no packed objects
  * - when op === 'push', both working directory and index (staged) changes will be stashed, tracked files only
  * - when op === 'push', message is optional, and only applicable when op === 'push'
  * - when op === 'apply | pop', the stashed changes will overwrite the working directory, no abort when conflicts
+ * - when op === 'create', creates a stash commit without modifying working directory or refs, returns the commit hash
  *
  * @param {object} args
  * @param {FsClient} args.fs - [required] a file system client
  * @param {string} [args.dir] - [required] The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [optional] The [git directory](dir-vs-gitdir.md) path
- * @param {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear'} [args.op = 'push'] - [optional] name of stash operation, default to 'push'
- * @param {string} [args.message = ''] - [optional] message to be used for the stash entry, only applicable when op === 'push'
+ * @param {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear' | 'create'} [args.op = 'push'] - [optional] name of stash operation, default to 'push'
+ * @param {string} [args.message = ''] - [optional] message to be used for the stash entry, only applicable when op === 'push' or 'create'
  * @param {number} [args.refIdx = 0] - [optional - Number] stash ref index of entry, only applicable when op === ['apply' | 'drop' | 'pop'], refIdx >= 0 and < num of stash pushed
- * @returns {Promise<string | void>}  Resolves successfully when stash operations are complete
+ * @returns {Promise<string | void>}  Resolves successfully when stash operations are complete. Returns commit hash for 'create' operation.
  *
  * @example
  * // stash changes in the working directory and index
@@ -62,6 +64,10 @@ import { join } from '../utils/join.js'
  *
  * console.log(await git.status({ fs, dir, filepath: 'a.txt' })) // 'modified'
  * console.log(await git.status({ fs, dir, filepath: 'b.txt' })) // '*modified'
+ * 
+ * // create a stash commit without modifying working directory
+ * const stashCommitHash = await git.stash({ fs, dir, op: 'create', message: 'my stash' })
+ * console.log(stashCommitHash) // returns the stash commit hash
  */
 
 export async function stash({
@@ -84,6 +90,7 @@ export async function stash({
     list: _stashList,
     clear: _stashClear,
     pop: _stashPop,
+    create: _stashCreate,
   }
 
   const opsNeedRefIdx = ['apply', 'drop', 'pop']

--- a/src/commands/stash.js
+++ b/src/commands/stash.js
@@ -17,105 +17,11 @@ import { TREE } from './TREE.js'
 import { _currentBranch } from './currentBranch.js'
 import { _readCommit } from './readCommit.js'
 
-export async function _stashPush({ fs, dir, gitdir, message = '' }) {
-  const stashMgr = new GitStashManager({ fs, dir, gitdir })
-
-  await stashMgr.getAuthor() // ensure there is an author
-  const branch = await _currentBranch({
-    fs,
-    gitdir,
-    fullname: false,
-  })
-
-  // prepare the stash commit: first parent is the current branch HEAD
-  const headCommit = await GitRefManager.resolve({
-    fs,
-    gitdir,
-    ref: 'HEAD',
-  })
-
-  const headCommitObj = await readCommit({ fs, dir, gitdir, oid: headCommit })
-  const headMsg = headCommitObj.commit.message
-
-  const stashCommitParents = [headCommit]
-  let stashCommitTree = null
-  let workDirCompareBase = TREE({ ref: 'HEAD' })
-
-  const indexTree = await writeTreeChanges({
-    fs,
-    dir,
-    gitdir,
-    treePair: [TREE({ ref: 'HEAD' }), 'stage'],
-  })
-  if (indexTree) {
-    // this indexTree will be the tree of the stash commit
-    // create a commit from the index tree, which has one parent, the current branch HEAD
-    const stashCommitOne = await stashMgr.writeStashCommit({
-      message: `stash-Index: WIP on ${branch} - ${new Date().toISOString()}`,
-      tree: indexTree, // stashCommitTree
-      parent: stashCommitParents,
-    })
-    stashCommitParents.push(stashCommitOne)
-    stashCommitTree = indexTree
-    workDirCompareBase = STAGE()
-  }
-
-  const workingTree = await writeTreeChanges({
-    fs,
-    dir,
-    gitdir,
-    treePair: [workDirCompareBase, 'workdir'],
-  })
-  if (workingTree) {
-    // create a commit from the working directory tree, which has one parent, either the one we just had, or the headCommit
-    const workingHeadCommit = await stashMgr.writeStashCommit({
-      message: `stash-WorkDir: WIP on ${branch} - ${new Date().toISOString()}`,
-      tree: workingTree,
-      parent: [stashCommitParents[stashCommitParents.length - 1]],
-    })
-
-    stashCommitParents.push(workingHeadCommit)
-    stashCommitTree = workingTree
-  }
-
-  if (!stashCommitTree || (!indexTree && !workingTree)) {
-    throw new NotFoundError('changes, nothing to stash')
-  }
-
-  // create another commit from the tree, which has three parents: HEAD and the commit we just made:
-  const stashMsg =
-    (message.trim() || `WIP on ${branch}`) +
-    `: ${headCommit.substring(0, 7)} ${headMsg}`
-
-  const stashCommit = await stashMgr.writeStashCommit({
-    message: stashMsg,
-    tree: stashCommitTree,
-    parent: stashCommitParents,
-  })
-
-  // next, write this commit into .git/refs/stash:
-  await stashMgr.writeStashRef(stashCommit)
-
-  // write the stash commit to the logs
-  await stashMgr.writeStashReflogEntry({
-    stashCommit,
-    message: stashMsg,
-  })
-
-  // finally, go back to a clean working directory
-  await checkout({
-    fs,
-    dir,
-    gitdir,
-    ref: branch,
-    track: false,
-    force: true, // force checkout to discard changes
-  })
-
-  return stashCommit
-}
-
-export async function _stashCreate({ fs, dir, gitdir, message = '' }) {
+/**
+ * Common logic for creating a stash commit
+ * @private
+ */
+async function _createStashCommit({ fs, dir, gitdir, message = '' }) {
   const stashMgr = new GitStashManager({ fs, dir, gitdir })
 
   await stashMgr.getAuthor() // ensure there is an author
@@ -189,6 +95,47 @@ export async function _stashCreate({ fs, dir, gitdir, message = '' }) {
     message: stashMsg,
     tree: stashCommitTree,
     parent: stashCommitParents,
+  })
+
+  return { stashCommit, stashMsg, branch, stashMgr }
+}
+
+export async function _stashPush({ fs, dir, gitdir, message = '' }) {
+  const { stashCommit, stashMsg, branch, stashMgr } = await _createStashCommit({
+    fs,
+    dir,
+    gitdir,
+    message,
+  })
+
+  // next, write this commit into .git/refs/stash:
+  await stashMgr.writeStashRef(stashCommit)
+
+  // write the stash commit to the logs
+  await stashMgr.writeStashReflogEntry({
+    stashCommit,
+    message: stashMsg,
+  })
+
+  // finally, go back to a clean working directory
+  await checkout({
+    fs,
+    dir,
+    gitdir,
+    ref: branch,
+    track: false,
+    force: true, // force checkout to discard changes
+  })
+
+  return stashCommit
+}
+
+export async function _stashCreate({ fs, dir, gitdir, message = '' }) {
+  const { stashCommit } = await _createStashCommit({
+    fs,
+    dir,
+    gitdir,
+    message,
   })
 
   // Return the stash commit hash without modifying refs or working directory

--- a/src/managers/GitStashManager.js
+++ b/src/managers/GitStashManager.js
@@ -208,8 +208,7 @@ export class GitStashManager {
       return []
     }
 
-    const reflogBuffer = await this.fs.read(this.refLogsStashPath)
-    const reflogString = reflogBuffer.toString()
+    const reflogString = await this.fs.read(this.refLogsStashPath, 'utf8')
 
     return GitRefStash.getStashReflogEntry(reflogString, parsed)
   }

--- a/website/versioned_docs/version-1.x/stash.md
+++ b/website/versioned_docs/version-1.x/stash.md
@@ -5,22 +5,23 @@ id: version-1.x-stash
 original_id: stash
 ---
 
-stash api, supports  {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear'} StashOp
+stash api, supports  {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear' | 'create'} StashOp
 
 | param              | type [= default]                                                                                 | description                                                                                                                                                 |
 | ------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [****fs****](./fs) | FsClient                                                                                         | a file system client                                                                                                                                        |
+| [**fs**](./fs)     | FsClient                                                                                         | a file system client                                                                                                                                        |
 | **dir**            | string                                                                                           | The [working tree](dir-vs-gitdir.md) directory path                                                                                                         |
 | gitdir             | string = join(dir,'.git')                                                                        | [optional] The [git directory](dir-vs-gitdir.md) path                                                                                                       |
-| op                 | 'push'  &#124;  'pop'  &#124;  'apply'  &#124;  'drop'  &#124;  'list'  &#124;  'clear' = 'push' | [optional] name of stash operation, default to 'push'                                                                                                       |
-| message            | string = ''                                                                                      | [optional] message to be used for the stash entry, only applicable when op === 'push'                                                                       |
-| refIdx             | number = 0                                                                                       | [optional - Number] stash ref index of entry, only applicable when op === ['apply'  &#124;  'drop'  &#124;  'pop'], refIdx \>= 0 and \< num of stash pushed |
-| return             | Promise\<(string &#124; void)\>                                                                  | Resolves successfully when stash operations are complete                                                                                                    |
+| op                 | 'push'  \| 'pop'  \| 'apply'  \| 'drop'  \| 'list'  \| 'clear' \| 'create'              | [optional] name of stash operation, default to 'push'                                                                                                       |
+| message            | string = ''                                                                                      | [optional] message to be used for the stash entry, only applicable when op === 'push' or 'create'                                                           |
+| refIdx             | number = 0                                                                                       | [optional] stash ref index of entry, only applicable when op === ['apply' \| 'drop' \| 'pop'], refIdx ≥ 0 and < num of stash pushed                         |
+| return             | Promise<(string \| void)>                                                                        | Resolves successfully when stash operations are complete. For `create`, resolves to the stash commit SHA.                                                   |
 
 _note_,
 - all stash operations are done on tracked files only with loose objects, no packed objects
 - when op === 'push', both working directory and index (staged) changes will be stashed, tracked files only
 - when op === 'push', message is optional, and only applicable when op === 'push'
+- when op === 'create', it works like `push` but does **not** update refs or clean the working directory — it just returns the commit SHA of the stash  
 - when op === 'apply | pop', the stashed changes will overwrite the working directory, no abort when conflicts
 
 Example Code:

--- a/website/versioned_docs/version-1.x/stash.md
+++ b/website/versioned_docs/version-1.x/stash.md
@@ -5,23 +5,24 @@ id: version-1.x-stash
 original_id: stash
 ---
 
-stash api, supports  {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear' | 'create'} StashOp
+stash api, supports {'push' | 'pop' | 'apply' | 'drop' | 'list' | 'clear' | 'create'} StashOp
 
-| param              | type [= default]                                                                                 | description                                                                                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**fs**](./fs)     | FsClient                                                                                         | a file system client                                                                                                                                        |
-| **dir**            | string                                                                                           | The [working tree](dir-vs-gitdir.md) directory path                                                                                                         |
-| gitdir             | string = join(dir,'.git')                                                                        | [optional] The [git directory](dir-vs-gitdir.md) path                                                                                                       |
-| op                 | 'push'  \| 'pop'  \| 'apply'  \| 'drop'  \| 'list'  \| 'clear' \| 'create'              | [optional] name of stash operation, default to 'push'                                                                                                       |
-| message            | string = ''                                                                                      | [optional] message to be used for the stash entry, only applicable when op === 'push' or 'create'                                                           |
-| refIdx             | number = 0                                                                                       | [optional] stash ref index of entry, only applicable when op === ['apply' \| 'drop' \| 'pop'], refIdx ≥ 0 and < num of stash pushed                         |
-| return             | Promise<(string \| void)>                                                                        | Resolves successfully when stash operations are complete. For `create`, resolves to the stash commit SHA.                                                   |
+| param          | type [= default]                                                      | description                                                                                                                         |
+| -------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [**fs**](./fs) | FsClient                                                              | a file system client                                                                                                                |
+| **dir**        | string                                                                | The [working tree](dir-vs-gitdir.md) directory path                                                                                 |
+| gitdir         | string = join(dir,'.git')                                             | [optional] The [git directory](dir-vs-gitdir.md) path                                                                               |
+| op             | 'push' \| 'pop' \| 'apply' \| 'drop' \| 'list' \| 'clear' \| 'create' | [optional] name of stash operation, default to 'push'                                                                               |
+| message        | string = ''                                                           | [optional] message to be used for the stash entry, only applicable when op === 'push' or 'create'                                   |
+| refIdx         | number = 0                                                            | [optional] stash ref index of entry, only applicable when op === ['apply' \| 'drop' \| 'pop'], refIdx ≥ 0 and < num of stash pushed |
+| return         | Promise<(string \| void)>                                             | Resolves successfully when stash operations are complete. For `create`, resolves to the stash commit SHA.                           |
 
 _note_,
+
 - all stash operations are done on tracked files only with loose objects, no packed objects
 - when op === 'push', both working directory and index (staged) changes will be stashed, tracked files only
 - when op === 'push', message is optional, and only applicable when op === 'push'
-- when op === 'create', it works like `push` but does **not** update refs or clean the working directory — it just returns the commit SHA of the stash  
+- when op === 'create', it works like `push` but does **not** update refs or clean the working directory — it just returns the commit SHA of the stash
 - when op === 'apply | pop', the stashed changes will overwrite the working directory, no abort when conflicts
 
 Example Code:
@@ -31,7 +32,7 @@ Example Code:
 let dir = '/tutorial'
 await fs.promises.writeFile(`${dir}/a.txt`, 'original content - a')
 await fs.promises.writeFile(`${dir}/b.js`, 'original content - b')
-await git.add({ fs, dir, filepath: [`a.txt`,`b.txt`] })
+await git.add({ fs, dir, filepath: [`a.txt`, `b.txt`] })
 let sha = await git.commit({
   fs,
   dir,
@@ -39,7 +40,7 @@ let sha = await git.commit({
     name: 'Mr. Stash',
     email: 'mstasher@stash.com',
   },
-  message: 'add a.txt and b.txt to test stash'
+  message: 'add a.txt and b.txt to test stash',
 })
 console.log(sha)
 
@@ -61,7 +62,6 @@ console.log(await git.status({ fs, dir, filepath: 'a.txt' })) // 'modified'
 console.log(await git.status({ fs, dir, filepath: 'b.txt' })) // '*modified'
 ```
 
-
 ---
 
 <details>
@@ -72,6 +72,7 @@ window.fs = new LightningFS('fs', { wipe: true })
 window.pfs = window.fs.promises
 console.log('done')
 ```
+
 </details>
 
 <script>


### PR DESCRIPTION
## PR Checklist

* [x] Update `src/api/stash.js` to add `_stashCreate`
* [x] Update `src/commands/stash.js` to support `op: 'create'`
* [x] Add test for `create` in `__tests__/test-stash.js`
* [x] Update docs to include `create` operation

---

### PR Description

**feat:** add `create` operation to `stash`

Adds `op: 'create'` to the `stash` command, which **creates a stash commit without modifying refs or the working directory**.
Updated command, tests, and documentation to include this operation.
