### PR TITLE
Fix header name in docs/onAuth.md

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -866,6 +866,15 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "fetsorn",
+      "name": "fetsorn",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12858105?v=4",
+      "profile": "https://github.com/fetsorn",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   <tr>
     <td align="center"><a href="https://github.com/hemanthkini"><img src="https://avatars.githubusercontent.com/u/3934055?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Hemanth Kini</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=hemanthkini" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/anish3333"><img src="https://avatars.githubusercontent.com/u/128889867?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Anish Awasthi</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=anish3333" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=anish3333" title="Documentation">📖</a> <a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=anish3333" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://github.com/fetsorn"><img src="https://avatars.githubusercontent.com/u/12858105?v=4?s=60" width="60px;" alt=""/><br /><sub><b>fetsorn</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=fetsorn" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/docs/onAuth.md
+++ b/docs/onAuth.md
@@ -102,7 +102,7 @@ To re-implement the default Basic Auth behavior, do something like this:
 ```js
 let auth = {
   headers: {
-    Authentication: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`
+    Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`
   }
 }
 ```


### PR DESCRIPTION
The doc string promises to reimplement default behaviour, and default header is called "Authorization", not "Authentication". User should expect this snippet to work exactly like the default onAuth.

The next doc string about "X-Authentication" is fine since it's clearly an example of a custom header.

<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [X] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [X] squash merge the PR with commit message "fix: [Description of fix]"