### PR TITLE
In FileSystem.js, special-case the cp command

### DIFF
--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -20,8 +20,8 @@ function isPromiseFs(fs) {
 
 // List of commands all filesystems are expected to provide. `rm` is not
 // included since it may not exist and must be handled as a special case
+// Likewise with `cp`.
 const commands = [
-  'cp',
   'readFile',
   'writeFile',
   'mkdir',
@@ -45,12 +45,14 @@ function bindFs(target, fs) {
     }
   }
 
-  // Handle the special case of `rm`
+  // Handle the special cases of `rm` and `cp`
   if (isPromiseFs(fs)) {
+    if (fs.cp) target._cp = fs.cp.bind(fs)
     if (fs.rm) target._rm = fs.rm.bind(fs)
     else if (fs.rmdir.length > 1) target._rm = fs.rmdir.bind(fs)
     else target._rm = rmRecursive.bind(null, target)
   } else {
+    if (fs.cp) target._cp = pify(fs.cp.bind(fs))
     if (fs.rm) target._rm = pify(fs.rm.bind(fs))
     else if (fs.rmdir.length > 2) target._rm = pify(fs.rmdir.bind(fs))
     else target._rm = rmRecursive.bind(null, target)


### PR DESCRIPTION
The Quick Start Guide uses LightningFS.  That filesystem doesn't support `cp`. The new submodule feature added the `cp` command for testing purposes. It's only for preliminary test case setup, not during the real api calls, or in production. Therefore if an end-user has a filesystem such as LightningFS which is missing `cp`, they shouldn't be adversely affected.     

FileSystem.js already special-cases the `rm` command. In this PR, handle `cp` the same way.  

The Quick Start Guide was failing on 1.36.0 with a "bind" error.  That should be solved here. Going back to 1.35, there are different errors about "Missing Buffer dependency".   That's connected to the "Migrate from BrowserFS to ZenFS" commits, and are a separate problem.

Please test with the Quick Start Guide.  If the "bind" error is solved, and it falls back to 1.35 "Missing Buffer dependency", at least that's progress, and it might be enough to solve end-user issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling and consistency of file-copy operations across different file system implementations (promise-based and callback-style).
  * Treats copy as a distinct special case alongside remove to ensure reliable binding behavior.
  * No public API changes; external interfaces remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->