### PR TITLE
fix: make `commit` update detached `HEAD`

### DIFF
--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -61,7 +61,10 @@ export async function _commit({
 }) {
   // Determine ref and the commit pointed to by ref, and if it is the initial commit
   let initialCommit = false
+  let detachedHead = false
   if (!ref) {
+    const headContent = await fs.read(`${gitdir}/HEAD`, { encoding: 'utf8' })
+    detachedHead = !headContent.startsWith('ref:')
     ref = await GitRefManager.resolve({
       fs,
       gitdir,
@@ -167,11 +170,11 @@ export async function _commit({
         dryRun,
       })
       if (!noUpdateBranch && !dryRun) {
-        // Update branch pointer
+        // Update branch pointer (or HEAD directly if detached)
         await GitRefManager.writeRef({
           fs,
           gitdir,
-          ref,
+          ref: detachedHead ? 'HEAD' : ref,
           value: oid,
         })
       }


### PR DESCRIPTION
## I'm fixing a bug or typo

- [x] squash merge the PR with commit message "fix: [Description of fix]"

---

This matches the git's behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed commit handling to properly support detached HEAD state, ensuring HEAD updates correctly when making commits in this scenario.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->