### PR TITLE
fix: reduce pack verification memory use on Node

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,23 @@ const external = [
   ...Object.keys(pkg.dependencies),
 ]
 
+const nodeAliases = {
+  [path.resolve(__dirname, 'src/utils/shasumRange.js')]: path.resolve(
+    __dirname,
+    'src/utils/shasumRange.node.js'
+  ),
+}
+
+const alias = aliases => ({
+  name: 'alias',
+  resolveId(source, importer) {
+    if (aliases[source]) return aliases[source]
+    if (!importer || !source.startsWith('.')) return null
+    const resolved = path.resolve(path.dirname(importer), source)
+    return aliases[resolved] || null
+  },
+})
+
 // Modern modules
 const ecmaConfig = (input, output) => ({
   input: `src/${input}`,
@@ -30,6 +47,7 @@ const ecmaConfig = (input, output) => ({
 const nodeConfig = (input, output) => ({
   input: `src/${input}`,
   external: [...external],
+  plugins: [alias(nodeAliases)],
   output: [
     {
       format: 'cjs',

--- a/src/storage/readObjectPacked.js
+++ b/src/storage/readObjectPacked.js
@@ -1,7 +1,7 @@
 import { InternalError } from '../errors/InternalError.js'
 import { readPackIndex } from '../storage/readPackIndex.js'
 import { join } from '../utils/join.js'
-import { shasum } from '../utils/shasum.js'
+import { shasumRange } from '../utils/shasumRange.js'
 
 export async function readObjectPacked({
   fs,
@@ -56,11 +56,12 @@ export async function readObjectPacked({
           )
         }
 
-        // 2. Deep Integrity Check: Calculate actual SHA-1 of packfile payload
-        // This ensures true data integrity by verifying the entire packfile content
-        // Use subarray for zero-copy reading of large files
-        const payload = pack.subarray(0, -20)
-        const actualPayloadSha = await shasum(payload)
+        // 2. Deep Integrity Check: Calculate actual SHA-1 of packfile payload.
+        // The Node package build swaps in a chunked implementation for large packs.
+        const actualPayloadSha = await shasumRange(pack, {
+          start: 0,
+          end: pack.length - 20,
+        })
         if (actualPayloadSha !== expectedShaFromIndex) {
           throw new InternalError(
             `Packfile payload corrupted: calculated ${actualPayloadSha} but expected ${expectedShaFromIndex}. The packfile may have been tampered with.`

--- a/src/utils/shasumRange.js
+++ b/src/utils/shasumRange.js
@@ -1,0 +1,8 @@
+import { shasum } from './shasum.js'
+
+export async function shasumRange(
+  buffer,
+  { start = 0, end = buffer.length } = {}
+) {
+  return shasum(buffer.subarray(start, end))
+}

--- a/src/utils/shasumRange.node.js
+++ b/src/utils/shasumRange.node.js
@@ -1,0 +1,14 @@
+import { createHash } from 'crypto'
+
+const SHA1_CHUNK_SIZE = 8 * 1024 * 1024
+
+export async function shasumRange(
+  buffer,
+  { start = 0, end = buffer.length } = {}
+) {
+  const hash = createHash('sha1')
+  for (let i = start; i < end; i += SHA1_CHUNK_SIZE) {
+    hash.update(buffer.subarray(i, Math.min(i + SHA1_CHUNK_SIZE, end)))
+  }
+  return hash.digest('hex')
+}


### PR DESCRIPTION
Fixes https://github.com/isomorphic-git/isomorphic-git/issues/2298 by using chunked hashing in node envs.

This would be one idea on how to fix the memory regression for our usage, another idea would be to add a flag in methods like `statusMatrix` to just 'trust' the repo and then not go down the pack integrity validation code path.

The regression comes from the verification path added in `readObjectPacked()`:
```js
const payload = pack.subarray(0, -20)
await shasum(payload)
```
That means we load the pack into memory and then hash the entire thing. On very large packs this is much more expensive than it was before 1.37.2, both in runtime and peak RSS.
This PR keeps the same verification behavior, but changes the hashing implementation used for the pack check in Node builds: Node builds use crypto.createHash('sha1') and the payload is fed incrementally in 8 MiB chunks.

What do you think @jcubic ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster, chunked SHA-1 checksum calculation for large payloads in Node.js, improving integrity verification speed and memory usage.
  * Node-targeted builds now use the optimized checksum implementation when running in Node environments.

* **New Features**
  * Added a range-capable checksum utility to compute digests over specified slices of binary data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->