### PR TITLE
Support windows file paths in utils/join.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Build artifacts
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork }}
+        shell: bash
         run: |
           # Run the subset of the `test` necessary to test from the CLI.
           npx nps build.docs build.pack

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "isogit": "cli.cjs"
       },
       "devDependencies": {
-        "@isomorphic-git/cors-proxy": "^3.0.0",
+        "@isomorphic-git/cors-proxy": "^3.0.2",
         "@isomorphic-git/lightning-fs": "^3.3.0",
         "@isomorphic-git/pgp-plugin": "0.0.7",
         "@semantic-release/exec": "5.0.0",
@@ -877,7 +877,7 @@
       }
     },
     "node_modules/@isomorphic-git/cors-proxy": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-scripts.cjs
+++ b/package-scripts.cjs
@@ -188,14 +188,8 @@ module.exports = {
       ),
       browsers: series.nps('test.chrome', 'test.firefox'),
       typecheck: 'tsc -p tsconfig.json',
-      setup:
-        process.platform === 'win32'
-          ? series.nps('gitserver.start')
-          : series.nps('proxy.start', 'gitserver.start'),
-      teardown:
-        process.platform === 'win32'
-          ? series.nps('gitserver.stop')
-          : series.nps('proxy.stop', 'gitserver.stop'),
+      setup: series.nps('proxy.start', 'gitserver.start'),
+      teardown: series.nps('proxy.stop', 'gitserver.stop'),
       node: process.env.CI
         ? (process.platform === 'win32'
             ? `cross-env ${jestEnv} ${retry3(jestCommand)}`

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "simple-get": "^4.0.1"
   },
   "devDependencies": {
-    "@isomorphic-git/cors-proxy": "^3.0.0",
+    "@isomorphic-git/cors-proxy": "^3.0.2",
     "@isomorphic-git/lightning-fs": "^3.3.0",
     "@isomorphic-git/pgp-plugin": "0.0.7",
     "@semantic-release/exec": "5.0.0",

--- a/src/utils/join.js
+++ b/src/utils/join.js
@@ -2,6 +2,18 @@
  * This code for `path.join` is directly copied from @zenfs/core/path for bundle size improvements.
  * SPDX-License-Identifier: LGPL-3.0-or-later
  * Copyright (c) James Prevett and other ZenFS contributors.
+ *
+ * Windows support added:
+ *   - Backslashes are normalised to forward slashes before processing.
+ *   - Drive-letter prefixes (e.g. "C:") are detected and preserved through
+ *     normalisation, so absolute Windows paths are handled correctly.
+ *   - An absolute argument passed to join() resets the accumulated path,
+ *     matching Node behaviour and handling worktree gitdir paths properly.
+ *
+ * Limitation: UNC paths (e.g. \\server\share) are not supported. The leading
+ *   backslashes are normalised to forward slashes and then collapsed by
+ *   normalizeString, losing the UNC root. Git on Windows works with
+ *   drive-letter paths, so this is not expected to be a practical issue.
  */
 
 function normalizeString(path, aar) {
@@ -65,29 +77,67 @@ function normalizeString(path, aar) {
   return res
 }
 
+// Returns the Windows drive prefix ("C:") if present, otherwise null.
+function getWindowsDrivePrefix(path) {
+  if (path.length >= 2 && /^[a-zA-Z]:/.test(path)) {
+    return path.slice(0, 2) // e.g. "C:"
+  }
+  return null
+}
+
 function normalize(path) {
   if (!path.length) return '.'
 
-  const isAbsolute = path[0] === '/'
+  // Normalise backslashes to forward slashes before any other processing.
+  path = path.replace(/\\/g, '/')
+
+  const drivePrefix = getWindowsDrivePrefix(path)
+  // isAbsolute: Unix root ('/foo') OR Windows drive+slash ('C:/foo').
+  const isAbsolute =
+    path[0] === '/' || (drivePrefix !== null && path[2] === '/')
   const trailingSeparator = path.at(-1) === '/'
 
-  path = normalizeString(path, !isAbsolute)
+  // Strip the drive prefix before feeding into normalizeString so that the
+  // core algorithm only ever sees a plain POSIX-style string.
+  const pathBody = drivePrefix ? path.slice(2) : path
 
-  if (!path.length) {
-    if (isAbsolute) return '/'
-    return trailingSeparator ? './' : '.'
+  let normalized = normalizeString(pathBody, !isAbsolute)
+
+  if (!normalized.length) {
+    const root = drivePrefix
+      ? isAbsolute
+        ? drivePrefix + '/'
+        : drivePrefix
+      : isAbsolute
+        ? '/'
+        : '.'
+    return trailingSeparator && !isAbsolute ? root + '/' : root
   }
-  if (trailingSeparator) path += '/'
+  if (trailingSeparator) normalized += '/'
 
-  return isAbsolute ? `/${path}` : path
+  if (drivePrefix) {
+    return isAbsolute
+      ? `${drivePrefix}/${normalized}`
+      : `${drivePrefix}${normalized}`
+  }
+  return isAbsolute ? `/${normalized}` : normalized
 }
 
 export function join(...args) {
   if (args.length === 0) return '.'
   let joined
   for (let i = 0; i < args.length; ++i) {
-    const arg = args[i]
-    if (arg.length > 0) {
+    // Normalise separators before processing.
+    const arg = args[i].replace(/\\/g, '/')
+    if (arg.length === 0) continue
+
+    // A Windows drive-letter path (e.g. "C:/worktrees/foo") cannot be
+    // meaningfully appended to any base, so it resets the accumulator.
+    // Unix absolute paths (leading '/') are NOT reset here — that would be
+    // path.resolve() semantics; path.join('foo', '/bar') must yield 'foo/bar'.
+    if (/^[a-zA-Z]:\//.test(arg)) {
+      joined = arg
+    } else {
       if (joined === undefined) joined = arg
       else joined += '/' + arg
     }


### PR DESCRIPTION
Dan at Antora reported that discoverGitdir failed on Windows. That script depends on `join.js`.  
Update `join.js` to process Microsoft Windows file paths which use backslashes.
Please be sure all CI passes, although that is always done. In this case, I have not extensively tested the changes, observing the Azure results are important.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Windows-style paths and drive prefixes (e.g., C:), preserving drive roots and reattaching drive letters after normalization.
  * Consistent separator normalization (backslashes → forward slashes) with preservation of trailing separators.
  * Path joining ignores empty segments and treats absolute arguments (including drive-letter absolutes) as resets, yielding Node-like absolute-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->