### PR TITLE
Github Actions: windows-latest

### DIFF
--- a/.config/jest.js
+++ b/.config/jest.js
@@ -20,6 +20,6 @@ export default function commonConfig(outputName) {
       ],
     ],
     testTimeout: 60000,
-    workerIdleMemoryLimit: '200MB',
+    workerIdleMemoryLimit: '200MB'
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: Build
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      - feature/**
 
 # Cancel in-progress runs for the current workflow
 concurrency:
@@ -12,9 +16,16 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -38,29 +49,20 @@ jobs:
       - name: Run build
         run: |
           # Run the subset of the `build` necessary to run the tests.
-          npx nps \
-            build.rollup \
-            build.typings \
-            build.webpack \
-            build.indexjson \
-            build.treeshake \
-            build.size
+          npx nps build.rollup build.typings build.webpack build.indexjson build.treeshake build.size
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
 
       - name: Run tests (CLI)
         run: |
           # `test.typecheck` must be run after `build.rollup` and `build.typings`
-          npx nps \
-            test.typecheck \
-            test.setup \
-            test.node
+          npx nps test.typecheck test.setup test.node
 
       - name: Save test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-jest
+          name: test-results-jest-${{ matrix.os }}
           path: junit/*.xml
 
       # Problem: GitHub does not support Code Coverage reports like Azure Pipelines.
@@ -70,16 +72,14 @@ jobs:
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork }}
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-results
+          name: code-coverage-results-${{ matrix.os }}
           path: coverage/
 
       - name: Build artifacts
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork }}
         run: |
           # Run the subset of the `test` necessary to test from the CLI.
-          npx nps \
-            build.docs \
-            build.pack
+          npx nps build.docs build.pack
 
           # Warn when there are uncommitted changes to documentation
           if ! git diff --quiet --exit-code; then
@@ -90,14 +90,14 @@ jobs:
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork }}
         uses: actions/upload-artifact@v4
         with:
-          name: npm-tarball.tgz
+          name: npm-tarball.tgz-${{ matrix.os }}
           path: isomorphic-git-0.0.0-development.tgz
 
       - name: Save index.umd.min.js
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork }}
         uses: actions/upload-artifact@v4
         with:
-          name: index.umd.min.js
+          name: index.umd.min.js-${{ matrix.os }}
           path: index.umd.min.js
 
   test-in-browser:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
 
+    env:
+      TEST_PUSH_GITHUB_TOKEN: ${{ secrets.TEST_PUSH_GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -102,7 +105,6 @@ jobs:
 
   test-in-browser:
     name: Test (${{ matrix.karma-launcher }})
-    needs: build
     runs-on: ubuntu-latest
 
     # The BrowserStack test running Android 10 on a Pixel 4 timed out after 15 minutes.
@@ -169,7 +171,7 @@ jobs:
 
   publish-test-results:
     name: Publish Test Results
-    needs: test-in-browser
+    needs: [build, test-in-browser]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
 

--- a/__tests__/test-hosting-providers-in-submodule.js
+++ b/__tests__/test-hosting-providers-in-submodule.js
@@ -156,13 +156,20 @@ describe('Hosting Providers', () => {
     })
   })
 
-  describe('GitHub', () => {
+  const githubPassword = process.env.TEST_PUSH_GITHUB_TOKEN
+  if (!githubPassword) {
+    console.warn(
+      "\n\nTEST_PUSH_GITHUB_TOKEN is MISSING. Please set this as a secret in github so that it's available. Skipping the test.\n\n"
+    )
+  }
+  const describeGitHub = githubPassword ? describe : describe.skip
+  describeGitHub('GitHub', () => {
     // This Personal OAuth token is for a test account (https://github.com/isomorphic-git-test-push)
     // with "public_repo" access. The only repo it has write access to is
     // https://github.com/isomorphic-git/test.empty
     // It is stored reversed to avoid Github's auto-revoking feature.
     // Can be overridden via TEST_PUSH_GITHUB_TOKEN env var (token must have write access to the test repo).
-    const password = process.env.TEST_PUSH_GITHUB_TOKEN
+    const password = githubPassword
     const username =
       process.env.GITHUB_TEST_USERNAME || 'isomorphic-git-test-push'
     it('fetch', async () => {

--- a/__tests__/test-hosting-providers.js
+++ b/__tests__/test-hosting-providers.js
@@ -144,13 +144,20 @@ describe('Hosting Providers', () => {
     })
   })
 
-  describe('GitHub', () => {
+  const githubPassword = process.env.TEST_PUSH_GITHUB_TOKEN
+  if (!githubPassword) {
+    console.warn(
+      "\n\nTEST_PUSH_GITHUB_TOKEN is MISSING. Please set this as a secret in github so that it's available. Skipping the test.\n\n"
+    )
+  }
+  const describeGitHub = githubPassword ? describe : describe.skip
+  describeGitHub('GitHub', () => {
     // This Personal OAuth token is for a test account (https://github.com/isomorphic-git-test-push)
     // with "public_repo" access. The only repo it has write access to is
     // https://github.com/isomorphic-git/test.empty
     // It is stored reversed to avoid Github's auto-revoking feature.
     // Can be overridden via TEST_PUSH_GITHUB_TOKEN env var (token must have write access to the test repo).
-    const password = process.env.TEST_PUSH_GITHUB_TOKEN
+    const password = githubPassword
     const username =
       process.env.GITHUB_TEST_USERNAME || 'isomorphic-git-test-push'
     it('fetch', async () => {

--- a/package-scripts.cjs
+++ b/package-scripts.cjs
@@ -15,8 +15,10 @@ const optional = cmd =>
   `(${cmd}) || echo "Optional command '${quote(cmd)}' failed".`
 
 const timeout = n => cmd => `timeout -t ${n}m -- ${cmd}`
-// const timeout5 = timeout(5)
-const timeout15 = timeout(15)
+// const timeout15 = timeout(15)
+const timeout15 = (command) =>
+  process.platform === 'win32' ? command : `timeout -t 15m -- ${command}`
+
 
 /**
  * Returns the environment variables to configure bundlewatch for the current CI provider.
@@ -61,17 +63,28 @@ const bundlewatchEnvironmentVariables = () => {
 }
 
 const jestEnv =
-  'NODE_OPTIONS="--experimental-vm-modules --max-old-space-size-percentage=80"'
+  'NODE_OPTIONS="--experimental-vm-modules --max-old-space-size-percentage=80" TEST_ENV=node'
 
-const jestCommand = 'jest --ci --coverage'
+const jestCommand = 'node --experimental-vm-modules --max-old-space-size-percentage=80 node_modules/jest/bin/jest.js --ci --coverage'
+// const jestCommand = 'jest --ci --coverage'
 // const jestCommand = 'jest --ci --coverage --runInBand --logHeapUsage'
 
 const jestBrowser = browserName => {
   const cmd = `${jestCommand} --config jest-browser.config.js`
 
-  return process.env.CI
-    ? `export ${jestEnv}\nexport JEST_BROWSER=${browserName}\nexport JEST_PUPPETEER_CONFIG=.config/jest-puppeteer.js\n${retry3(timeout15(cmd))}`
-    : `cross-env ${jestEnv} JEST_BROWSER=${browserName} JEST_PUPPETEER_CONFIG=.config/jest-puppeteer.js ${cmd}`
+  if (process.env.CI) {
+    // On CI we need to set environment variables differently depending on the shell
+    if (process.platform === 'win32') {
+      // PowerShell / cmd.exe compatible version using cross-env
+      return `cross-env ${jestEnv} JEST_BROWSER=${browserName} JEST_PUPPETEER_CONFIG=.config/jest-puppeteer.js ${retry3(cmd)}`
+    } else {
+      // Unix-like shells (bash, sh, etc.) – keep the original export style
+      return `export ${jestEnv}\nexport JEST_BROWSER=${browserName}\nexport JEST_PUPPETEER_CONFIG=.config/jest-puppeteer.js\n${retry3(timeout15(cmd))}`
+    }
+  }
+
+  // Non-CI case (local development) – already cross-platform via cross-env
+  return `cross-env ${jestEnv} JEST_BROWSER=${browserName} JEST_PUPPETEER_CONFIG=.config/jest-puppeteer.js ${cmd}`
 }
 
 module.exports = {
@@ -175,10 +188,18 @@ module.exports = {
       ),
       browsers: series.nps('test.chrome', 'test.firefox'),
       typecheck: 'tsc -p tsconfig.json',
-      setup: series.nps('proxy.start', 'gitserver.start'),
-      teardown: series.nps('proxy.stop', 'gitserver.stop'),
+      setup:
+        process.platform === 'win32'
+          ? series.nps('gitserver.start')
+          : series.nps('proxy.start', 'gitserver.start'),
+      teardown:
+        process.platform === 'win32'
+          ? series.nps('gitserver.stop')
+          : series.nps('proxy.stop', 'gitserver.stop'),
       node: process.env.CI
-        ? `export ${jestEnv}\n${retry3(timeout15(jestCommand))}`
+        ? (process.platform === 'win32'
+            ? `cross-env ${jestEnv} ${retry3(jestCommand)}`
+            : `export ${jestEnv}\n${retry3(timeout15(jestCommand))}`)
         : `cross-env-shell ${jestEnv} ${jestCommand}`,
       chrome: jestBrowser('chrome'),
       firefox: jestBrowser('firefox'),


### PR DESCRIPTION
Adds windows-latest nodejs tests on Github Actions.

This is a somewhat messy process. Windows still hits a few errors.

However that is far better than when I started earlier today, and windows definitely failed to build. It hit blocker after blocker, no tests ran at all.  

Going from zero to 95% passing tests is progress, and I think this ci.yml should be merged, with this mid-level of functionality, and then debug the remaining issues.

A note about a section of ci.yml, since it caused confusion before:

```
  push:
    branches:
      - main
      - feature/**
```

Without that section, pushes do not trigger Github Actions. 

Before, pushes to isomorphic-git did not cause ci.yml to run.  Nothing happened.

By adding that section, a positive effect takes place: a git push to "main" will run ci.yml.   A git push to "feature/mytest" will run ci.yml.

Next, comparing different versions of `join.js`.

I am seeing 30 failed tests in the status quo, compared to 22 failed tests when using the newer join.js from PR 2302.  It fixes 8 tests.  An improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs on pushes to main and feature branches, builds on Windows and Linux with OS-specific artifact names, and allows browser tests to run without waiting for the build  
  * Platform-aware test scripts for CI and minor test-runner command cleanup
  * Minor formatting cleanup in Jest configuration

* **Tests**
  * GitHub hosting-provider tests auto-skip and emit a warning when the required token is not provided

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isomorphic-git/isomorphic-git/pull/2305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->