### PR TITLE
fix: replace simple-get with native Node.js HTTP modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
     "pako": "^1.0.10",
     "pify": "^4.0.1",
     "readable-stream": "^4.0.0",
-    "sha.js": "^2.4.12",
-    "simple-get": "^4.0.1"
+    "sha.js": "^2.4.12"
   },
   "devDependencies": {
     "@isomorphic-git/cors-proxy": "^3.0.0",

--- a/src/http/node/index.js
+++ b/src/http/node/index.js
@@ -1,9 +1,74 @@
-import get from 'simple-get'
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
 
 import '../../typedefs-http.js'
 import { asyncIteratorToStream } from '../../utils/asyncIteratorToStream.js'
 import { collect } from '../../utils/collect.js'
 import { fromNodeStream } from '../../utils/fromNodeStream.js'
+
+const MAX_REDIRECTS = 10
+
+/**
+ * @param {string} targetUrl
+ * @param {object} options
+ * @param {number} [redirectCount]
+ * @returns {Promise<import('node:http').IncomingMessage>}
+ */
+function doRequest(targetUrl, options, redirectCount = 0) {
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(targetUrl)
+    const transport = parsedUrl.protocol === 'https:' ? httpsRequest : httpRequest
+
+    const reqOptions = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || undefined,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: options.method,
+      headers: options.headers,
+      agent: options.agent,
+    }
+
+    const req = transport(reqOptions, res => {
+      const statusCode = res.statusCode || 0
+      if (
+        statusCode >= 300 &&
+        statusCode < 400 &&
+        res.headers.location &&
+        redirectCount < MAX_REDIRECTS
+      ) {
+        res.resume()
+        const redirectUrl = new URL(res.headers.location, targetUrl).href
+        const redirectHeaders = { ...options.headers }
+        const redirectHost = new URL(redirectUrl).hostname
+        if (redirectHost !== parsedUrl.hostname) {
+          delete redirectHeaders.cookie
+          delete redirectHeaders.authorization
+        }
+        resolve(
+          doRequest(
+            redirectUrl,
+            { ...options, headers: redirectHeaders },
+            redirectCount + 1
+          )
+        )
+        return
+      }
+      resolve(res)
+    })
+
+    req.on('error', reject)
+
+    if (options.body) {
+      if (typeof options.body.pipe === 'function') {
+        options.body.pipe(req)
+      } else {
+        req.end(options.body)
+      }
+    } else {
+      req.end()
+    }
+  })
+}
 
 /**
  * HttpClient
@@ -25,33 +90,25 @@ export async function request({
   } else if (body) {
     body = asyncIteratorToStream(body)
   }
-  return new Promise((resolve, reject) => {
-    get(
-      {
-        url,
-        method,
-        headers,
-        agent,
-        body,
-      },
-      (err, res) => {
-        if (err) return reject(err)
-        try {
-          const iter = fromNodeStream(res)
-          resolve({
-            url: res.url,
-            method: res.method,
-            statusCode: res.statusCode,
-            statusMessage: res.statusMessage,
-            body: iter,
-            headers: res.headers,
-          })
-        } catch (e) {
-          reject(e)
-        }
-      }
-    )
-  })
+
+  if (body && !Buffer.isBuffer(body) && typeof body.pipe !== 'function') {
+    body = Buffer.from(body)
+  }
+
+  if (body && Buffer.isBuffer(body)) {
+    headers['content-length'] = body.length
+  }
+
+  const res = await doRequest(url, { method, headers, agent, body })
+
+  return {
+    url: res.url,
+    method: res.method,
+    statusCode: res.statusCode,
+    statusMessage: res.statusMessage,
+    body: fromNodeStream(res),
+    headers: res.headers,
+  }
 }
 
 export default { request }


### PR DESCRIPTION
Fixes #2308

## Summary

Replace the `simple-get` dependency in the Node HTTP client with Node's native `http`/`https` modules. This removes an unnecessary layer between isomorphic-git and Node's HTTP stack.

## Why

The Node HTTP client (`src/http/node/index.js`) uses `simple-get` to make HTTP requests. `simple-get` is a thin wrapper around `http.request()`/`https.request()` that adds URL parsing, redirect following, and gzip decompression. For git's smart HTTP protocol, only URL parsing and redirect following are needed — gzip decompression is not used because git pack data has its own compression.

By replacing `simple-get` with direct use of Node's native modules:

- **Removes a dependency** (and its transitive deps: `decompress-response`, `simple-concat`, `once`)
- **Direct control** over the request lifecycle — no middleware between isomorphic-git and Node's HTTP stack
- **Better proxy compatibility** — works directly with `NODE_USE_ENV_PROXY` without any intermediate layer

## What changed

- `src/http/node/index.js` — replaced `simple-get` import with `node:http` and `node:https`. Implemented URL parsing with `URL`, redirect following (up to 10), and body streaming using native APIs
- `package.json` — removed `simple-get` from dependencies

## Testing

Tested clone, commit, and push against GitHub using the new HTTP client. All operations work correctly.