### PR TITLE
Fix browser entrypoint not being used in some non-node build contexts

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -998,6 +998,16 @@
       "contributions": [
         "security"
       ]
+    },
+    {
+      "login": "amxmln",
+      "name": "Amadeus Maximilian",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15271679?v=4",
+      "profile": "https://github.com/amxmln",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/N0zoM1z0"><img src="https://avatars.githubusercontent.com/u/161784452?v=4?s=60" width="60px;" alt=""/><br /><sub><b>N0zoM1z0</b></sub></a><br /><a href="#security-N0zoM1z0" title="Security">🛡️</a></td>
+    <td align="center"><a href="https://github.com/amxmln"><img src="https://avatars.githubusercontent.com/u/15271679?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Amadeus Maximilian</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=amxmln" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Aamxmln" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,14 @@
   "module": "./index.js",
   "exports": {
     ".": {
-      "types": "./index.d.cts",
-      "default": "./index.cjs"
+      "node": {
+        "types": "./index.d.cts",
+        "default": "./index.cjs"
+      },
+      "default": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
     },
     "./http/node": {
       "import": {


### PR DESCRIPTION
As discussed in #2301, this PR sets the base import to only import the `.cjs` versions in `node` contexts and  defaults to the `.js` versions of the code otherwise.

The `.js` versions don’t include any Node-only APIs and thus run in browsers as intended.

Like I mentioned before, it’s a bit of a shot in the dark, but it seems to work on my setup and I’m hoping the existing tests can confirm that it doesn’t break anywhere else.

## I'm fixing a bug or typo

- [X] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new contributor to acknowledgments
  * Updated package export configuration for improved compatibility

* **Documentation**
  * Updated contributors list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->