### PR TITLE
Point "jsdelivr" field to minified browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       }
     }
   },
+  "jsdelivr": "./index.umd.min.js",
   "unpkg": "./index.umd.min.js",
   "bin": {
     "isogit": "./cli.cjs"


### PR DESCRIPTION
As discussed previously, this PR adds a `jsdelivr` field to `package.json` so importing `isomorphic-git` in the browser via JsDelivr works without specifying a file path.

This is the same as is done for Unpkg.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added jsDelivr CDN configuration to package metadata, enabling users to load the library via CDN instead of traditional package manager installation methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isomorphic-git/isomorphic-git/pull/2312)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->