### PR TITLE
feat: add refresh option to status and statusMatrix

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -937,6 +937,15 @@
         "code",
         "bug"
       ]
+    },
+    {
+      "login": "toxik",
+      "name": "Alexandru Georoceanu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/235319?v=4",
+      "profile": "http://toxik.us/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "angular"

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   <tr>
     <td align="center"><a href="https://github.com/N0zoM1z0"><img src="https://avatars.githubusercontent.com/u/161784452?v=4?s=60" width="60px;" alt=""/><br /><sub><b>N0zoM1z0</b></sub></a><br /><a href="#security-N0zoM1z0" title="Security">🛡️</a></td>
     <td align="center"><a href="https://github.com/amxmln"><img src="https://avatars.githubusercontent.com/u/15271679?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Amadeus Maximilian</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=amxmln" title="Code">💻</a> <a href="https://github.com/isomorphic-git/isomorphic-git/issues?q=author%3Aamxmln" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="http://toxik.us/"><img src="https://avatars.githubusercontent.com/u/235319?v=4?s=60" width="60px;" alt=""/><br /><sub><b>Alexandru Georoceanu</b></sub></a><br /><a href="https://github.com/isomorphic-git/isomorphic-git/commits?author=toxik" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/__tests__/test-status-in-submodule.js
+++ b/__tests__/test-status-in-submodule.js
@@ -78,4 +78,26 @@ describe('status', () => {
     const b = await status({ fs, dir, gitdir, filepath: 'b.txt' })
     expect(b).toEqual('added')
   })
+
+  it('does not modify .git/index when refresh is false', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-status')
+    // Take an unmodified tracked file and bump its workdir mtime without
+    // changing contents, so the racy stat-cache refresh would normally fire.
+    const original = await fs.read(path.join(dir, 'a.txt'))
+    await fs.write(path.join(dir, 'a.txt'), original)
+    // Snapshot the index file
+    const indexBefore = await fs.read(path.join(gitdir, 'index'))
+    // Read-only status call
+    const a = await status({
+      fs,
+      dir,
+      gitdir,
+      filepath: 'a.txt',
+      refresh: false,
+    })
+    expect(a).toEqual('unmodified')
+    const indexAfter = await fs.read(path.join(gitdir, 'index'))
+    expect(indexAfter).toEqual(indexBefore)
+  })
 })

--- a/__tests__/test-status.js
+++ b/__tests__/test-status.js
@@ -78,4 +78,26 @@ describe('status', () => {
     const b = await status({ fs, dir, gitdir, filepath: 'b.txt' })
     expect(b).toEqual('added')
   })
+
+  it('does not modify .git/index when refresh is false', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-status')
+    // Take an unmodified tracked file and bump its workdir mtime without
+    // changing contents, so the racy stat-cache refresh would normally fire.
+    const original = await fs.read(path.join(dir, 'a.txt'))
+    await fs.write(path.join(dir, 'a.txt'), original)
+    // Snapshot the index file
+    const indexBefore = await fs.read(path.join(gitdir, 'index'))
+    // Read-only status call
+    const a = await status({
+      fs,
+      dir,
+      gitdir,
+      filepath: 'a.txt',
+      refresh: false,
+    })
+    expect(a).toEqual('unmodified')
+    const indexAfter = await fs.read(path.join(gitdir, 'index'))
+    expect(indexAfter).toEqual(indexBefore)
+  })
 })

--- a/__tests__/test-statusMatrix-in-submodule.js
+++ b/__tests__/test-statusMatrix-in-submodule.js
@@ -404,4 +404,27 @@ describe('statusMatrix', () => {
       ['b/b.txt', 0, 2, 2],
     ])
   })
+
+  it('does not modify .git/index when refresh is false', async () => {
+    // Setup
+    const { fs, dir, gitdir } =
+      await makeFixtureAsSubmodule('test-statusMatrix')
+    // Take an unmodified tracked file and bump its workdir mtime without
+    // changing contents, so the racy stat-cache refresh would normally fire.
+    const original = await fs.read(path.join(dir, 'a.txt'))
+    await fs.write(path.join(dir, 'a.txt'), original)
+    // Snapshot the index file
+    const indexBefore = await fs.read(path.join(gitdir, 'index'))
+    // Read-only statusMatrix call
+    const matrix = await statusMatrix({
+      fs,
+      dir,
+      gitdir,
+      filepaths: ['a.txt'],
+      refresh: false,
+    })
+    expect(matrix).toEqual([['a.txt', 1, 1, 1]])
+    const indexAfter = await fs.read(path.join(gitdir, 'index'))
+    expect(indexAfter).toEqual(indexBefore)
+  })
 })

--- a/__tests__/test-statusMatrix.js
+++ b/__tests__/test-statusMatrix.js
@@ -394,4 +394,26 @@ describe('statusMatrix', () => {
       ['b/b.txt', 0, 2, 2],
     ])
   })
+
+  it('does not modify .git/index when refresh is false', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-statusMatrix')
+    // Take an unmodified tracked file and bump its workdir mtime without
+    // changing contents, so the racy stat-cache refresh would normally fire.
+    const original = await fs.read(path.join(dir, 'a.txt'))
+    await fs.write(path.join(dir, 'a.txt'), original)
+    // Snapshot the index file
+    const indexBefore = await fs.read(path.join(gitdir, 'index'))
+    // Read-only statusMatrix call
+    const matrix = await statusMatrix({
+      fs,
+      dir,
+      gitdir,
+      filepaths: ['a.txt'],
+      refresh: false,
+    })
+    expect(matrix).toEqual([['a.txt', 1, 1, 1]])
+    const indexAfter = await fs.read(path.join(gitdir, 'index'))
+    expect(indexAfter).toEqual(indexBefore)
+  })
 })

--- a/src/api/status.js
+++ b/src/api/status.js
@@ -41,6 +41,11 @@ import { join } from '../utils/join.js'
  * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string} args.filepath - The path to the file to query
  * @param {object} [args.cache] - a [cache](cache.md) object
+ * @param {boolean} [args.refresh = true] - when false, do not refresh the
+ *   `.git/index` stat cache when the working-tree file's contents still match
+ *   the staged blob. The call becomes read-only with respect to the index, at
+ *   the cost of recomputing the SHA1 on subsequent calls for files whose
+ *   stat info has drifted.
  *
  * @returns {Promise<'ignored'|'unmodified'|'*modified'|'*deleted'|'*added'|'absent'|'modified'|'deleted'|'added'|'*unmodified'|'*absent'|'*undeleted'|'*undeletemodified'>} Resolves successfully with the file's git status
  *
@@ -55,6 +60,7 @@ export async function status({
   gitdir = join(dir, '.git'),
   filepath,
   cache = {},
+  refresh = true,
 }) {
   try {
     assertParameter('fs', _fs)
@@ -106,7 +112,7 @@ export async function status({
           object,
         })
         // If the oid in the index === working dir oid but stats differed update cache
-        if (I && indexEntry.oid === workdirOid) {
+        if (refresh && I && indexEntry.oid === workdirOid) {
           // and as long as our fs.stats aren't bad.
           // size of -1 happens over a BrowserFS HTTP Backend that doesn't serve Content-Length headers
           // (like the Karma webserver) because BrowserFS HTTP Backend uses HTTP HEAD requests to do fs.stat

--- a/src/api/statusMatrix.js
+++ b/src/api/statusMatrix.js
@@ -151,6 +151,11 @@ import { worthWalking } from '../utils/worthWalking.js'
  * @param {function(string): boolean} [args.filter] - Filter the results to only those whose filepath matches a function.
  * @param {object} [args.cache] - a [cache](cache.md) object
  * @param {boolean} [args.ignored = false] - include ignored files in the result
+ * @param {boolean} [args.refresh = true] - when false, do not refresh the
+ *   `.git/index` stat cache for files whose contents still match the staged
+ *   blob. The call becomes read-only with respect to the index, at the cost
+ *   of recomputing the SHA1 on subsequent calls for files whose stat info
+ *   has drifted.
  *
  * @returns {Promise<Array<StatusRow>>} Resolves with a status matrix, described below.
  * @see StatusRow
@@ -164,6 +169,7 @@ export async function statusMatrix({
   filter,
   cache = {},
   ignored: shouldIgnore = false,
+  refresh = true,
 }) {
   try {
     assertParameter('fs', _fs)
@@ -177,7 +183,7 @@ export async function statusMatrix({
       cache,
       dir,
       gitdir: updatedGitdir,
-      trees: [TREE({ ref }), WORKDIR(), STAGE()],
+      trees: [TREE({ ref }), WORKDIR({ refresh }), STAGE()],
       map: async function (filepath, [head, workdir, stage]) {
         // Ignore ignored files, but only if they are not already tracked.
         if (!head && !stage && workdir) {

--- a/src/commands/WORKDIR.js
+++ b/src/commands/WORKDIR.js
@@ -5,13 +5,17 @@ import { GitWalkerFs } from '../models/GitWalkerFs.js'
 import { GitWalkSymbol } from '../utils/symbols.js'
 
 /**
+ * @param {object} [opts]
+ * @param {boolean} [opts.refresh=true] - When false, suppress the stat-cache
+ *   refresh that would rewrite `.git/index` when a working-tree file's stat
+ *   info has drifted but its content still matches the staged blob.
  * @returns {Walker}
  */
-export function WORKDIR() {
+export function WORKDIR({ refresh = true } = {}) {
   const o = Object.create(null)
   Object.defineProperty(o, GitWalkSymbol, {
     value: function ({ fs, dir, gitdir, cache }) {
-      return new GitWalkerFs({ fs, dir, gitdir, cache })
+      return new GitWalkerFs({ fs, dir, gitdir, cache, refresh })
     },
   })
   Object.freeze(o)

--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -8,11 +8,12 @@ import { shasum } from '../utils/shasum.js'
 import { GitObject } from './GitObject.js'
 
 export class GitWalkerFs {
-  constructor({ fs, dir, gitdir, cache }) {
+  constructor({ fs, dir, gitdir, cache, refresh = true }) {
     this.fs = fs
     this.cache = cache
     this.dir = dir
     this.gitdir = gitdir
+    this.refresh = refresh
 
     this.config = null
     const walker = this
@@ -148,7 +149,9 @@ export class GitWalkerFs {
               // Update the stats in the index so we will get a "cache hit" next time
               // 1) if we can (because the oid and mode are the same)
               // 2) and only if we need to (because other stats differ)
+              // 3) and only if the caller opted in to refreshing the index
               if (
+                self.refresh &&
                 stage &&
                 oid === stage.oid &&
                 (!filemode || stats.mode === stage.mode) &&


### PR DESCRIPTION
`status` and `statusMatrix` currently rewrite `.git/index` when a working-tree file's stat info has drifted but its content still matches the staged blob (the racy-git stat cache refresh). For callers that need read-only behavior with respect to the index, this adds an opt-in `refresh: false` parameter that gates the `index.insert` in both code paths. Existing callers default to `refresh: true`, preserving today's behavior.

The option is threaded through `WORKDIR({ refresh })` and `GitWalkerFs`, so any consumer of the walker API can opt out too.

## I'm adding a parameter to an existing commands `status`, `statusMatrix`:

- [x] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [x] document the parameter in the JSDoc comment above the function
- [x] add a test case in `__tests__/test-X.js` if possible
- [x] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [x] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

Workaround for #2314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional refresh flag to status operations to allow read-only checks that avoid updating repository cache by default.

* **Tests**
  * Added tests ensuring status/statusMatrix calls with refresh: false do not modify the repository index.

* **Chores**
  * Added contributor Alexandru Georoceanu (toxik) to the contributors list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isomorphic-git/isomorphic-git/pull/2313)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->