### PR TITLE
Improve internal error reporting guidance

### DIFF
--- a/__tests__/test-GitError-in-submodule.js
+++ b/__tests__/test-GitError-in-submodule.js
@@ -33,4 +33,15 @@ describe('Errors', () => {
       }
     `)
   })
+  it('create an InternalError with actionable reporting guidance', async () => {
+    const e = new Errors.InternalError('Something unexpected happened.')
+
+    expect(e.message).toContain(
+      "If you're using an application that depends on isomorphic-git"
+    )
+    expect(e.message).toContain(
+      "If you're a developer and you believe this is a bug in isomorphic-git"
+    )
+    expect(e.message).toContain('Something unexpected happened.')
+  })
 })

--- a/__tests__/test-GitError.js
+++ b/__tests__/test-GitError.js
@@ -33,4 +33,15 @@ describe('Errors', () => {
       }
     `)
   })
+  it('create an InternalError with actionable reporting guidance', async () => {
+    const e = new Errors.InternalError('Something unexpected happened.')
+
+    expect(e.message).toContain(
+      "If you're using an application that depends on isomorphic-git"
+    )
+    expect(e.message).toContain(
+      "If you're a developer and you believe this is a bug in isomorphic-git"
+    )
+    expect(e.message).toContain('Something unexpected happened.')
+  })
 })

--- a/src/errors/InternalError.js
+++ b/src/errors/InternalError.js
@@ -6,7 +6,7 @@ export class InternalError extends BaseError {
    */
   constructor(message) {
     super(
-      `An internal error caused this command to fail.\n\nIf you're not a developer, report the bug to the developers of the application you're using. If this is a bug in isomorphic-git then you should create a proper bug yourselves. The bug should include a minimal reproduction and details about the version and environment.\n\nPlease file a bug report at https://github.com/isomorphic-git/isomorphic-git/issues with this error message: ${message}`
+      `An internal error caused this command to fail.\n\nIf you're using an application that depends on isomorphic-git, please report this error to that application's developers.\n\nIf you're a developer and you believe this is a bug in isomorphic-git, please file an issue at https://github.com/isomorphic-git/isomorphic-git/issues with a minimal reproduction, version and environment details, and this error message: ${message}`
     )
     this.code = this.name = InternalError.code
     this.data = { message }


### PR DESCRIPTION
## Summary
- clarify InternalError guidance for application users vs developers
- keep isomorphic-git issue reporting guidance targeted to developers with reproduction details
- add error-message coverage in GitError tests

Closes #2216

## Tests
- npx nps lint
- npx prettier --check src/errors/InternalError.js __tests__/test-GitError.js __tests__/test-GitError-in-submodule.js
- $env:NODE_OPTIONS='--experimental-vm-modules --max-old-space-size-percentage=80'; npx jest __tests__/test-GitError.js __tests__/test-GitError-in-submodule.js --runInBand --ci --coverage=false
- npx nps test.typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages with clearer, actionable guidance for users regarding issue reporting and for developers regarding required information for bug reports, including version, environment details, and reproduction steps.

* **Tests**
  * Added test cases to verify error message formatting and ensure proper guidance text is included for both end-users and developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/isomorphic-git/isomorphic-git/pull/2345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->