### PR TITLE
fix: pass credential config username to auth callbacks

### DIFF
--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -27,6 +27,7 @@ describe('fetch', () => {
     })
     const requests = []
     const onAuthArgs = []
+    const emptyBody = async function* () {}
     const mockHttp = {
       request: async request => {
         requests.push(request)
@@ -36,14 +37,14 @@ describe('fetch', () => {
               statusCode: 401,
               statusMessage: 'Unauthorized',
               headers: {},
-              body: [],
+              body: emptyBody(),
             }
           : {
               url: request.url,
               statusCode: 403,
               statusMessage: 'Forbidden',
               headers: {},
-              body: [],
+              body: emptyBody(),
             }
       },
     }

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -10,6 +10,65 @@ const localhost =
   typeof window === 'undefined' ? '127.0.0.1' : window.location.hostname
 
 describe('fetch', () => {
+  it('passes credential config username to onAuth', async () => {
+    const { fs, gitdir } = await makeFixture('test-fetch-cors')
+    const url = 'https://example.com/repo.git'
+    await setConfig({
+      fs,
+      gitdir,
+      path: 'remote.origin.url',
+      value: url,
+    })
+    await setConfig({
+      fs,
+      gitdir,
+      path: `credential.${url}.username`,
+      value: 'alice',
+    })
+    const requests = []
+    const onAuthArgs = []
+    const mockHttp = {
+      request: async request => {
+        requests.push(request)
+        return requests.length === 1
+          ? {
+              statusCode: 401,
+              statusMessage: 'Unauthorized',
+              headers: {},
+              body: [],
+            }
+          : {
+              statusCode: 403,
+              statusMessage: 'Forbidden',
+              headers: {},
+              body: [],
+            }
+      },
+    }
+
+    let err
+    try {
+      await fetch({
+        fs,
+        http: mockHttp,
+        gitdir,
+        remote: 'origin',
+        ref: 'master',
+        singleBranch: true,
+        onAuth: (authUrl, auth) => {
+          onAuthArgs.push([authUrl, auth])
+          return { ...auth, password: 'secret' }
+        },
+      })
+    } catch (e) {
+      err = e
+    }
+
+    expect(err).toBeDefined()
+    expect(err.code).toEqual(Errors.HttpError.code)
+    expect(onAuthArgs).toEqual([[url, { username: 'alice', headers: {} }]])
+  })
+
   it('fetch (from Github)', async () => {
     const { fs, gitdir } = await makeFixture('test-fetch-cors')
     await setConfig({

--- a/__tests__/test-fetch.js
+++ b/__tests__/test-fetch.js
@@ -32,12 +32,14 @@ describe('fetch', () => {
         requests.push(request)
         return requests.length === 1
           ? {
+              url: request.url,
               statusCode: 401,
               statusMessage: 'Unauthorized',
               headers: {},
               body: [],
             }
           : {
+              url: request.url,
               statusCode: 403,
               statusMessage: 'Forbidden',
               headers: {},

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -13,6 +13,7 @@ import { GitPackIndex } from '../models/GitPackIndex.js'
 import { hasObject } from '../storage/hasObject.js'
 import { _readObject as readObject } from '../storage/readObject.js'
 import { abbreviateRef } from '../utils/abbreviateRef.js'
+import { addCredentialUsername } from '../utils/addCredentialUsername.js'
 import { collect } from '../utils/collect.js'
 import { emptyPackfile } from '../utils/emptyPackfile.js'
 import { filterCapabilities } from '../utils/filterCapabilities.js'
@@ -112,9 +113,9 @@ export async function _fetch({
   const GitRemoteHTTP = GitRemoteManager.getRemoteHelperFor({ url })
   const remoteHTTP = await GitRemoteHTTP.discover({
     http,
-    onAuth,
+    onAuth: addCredentialUsername({ config, onAuth }),
     onAuthSuccess,
-    onAuthFailure,
+    onAuthFailure: addCredentialUsername({ config, onAuth: onAuthFailure }),
     corsProxy,
     service: 'git-upload-pack',
     url,

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -16,6 +16,7 @@ import { GitConfigManager } from '../managers/GitConfigManager.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
 import { GitRemoteManager } from '../managers/GitRemoteManager.js'
 import { GitSideBand } from '../models/GitSideBand.js'
+import { addCredentialUsername } from '../utils/addCredentialUsername.js'
 import { filterCapabilities } from '../utils/filterCapabilities.js'
 import { forAwait } from '../utils/forAwait.js'
 import { pkg } from '../utils/pkg.js'
@@ -105,9 +106,9 @@ export async function _push({
   const GitRemoteHTTP = GitRemoteManager.getRemoteHelperFor({ url })
   const httpRemote = await GitRemoteHTTP.discover({
     http,
-    onAuth,
+    onAuth: addCredentialUsername({ config, onAuth }),
     onAuthSuccess,
-    onAuthFailure,
+    onAuthFailure: addCredentialUsername({ config, onAuth: onAuthFailure }),
     corsProxy,
     service: 'git-receive-pack',
     url,

--- a/src/utils/addCredentialUsername.js
+++ b/src/utils/addCredentialUsername.js
@@ -1,0 +1,9 @@
+export function addCredentialUsername({ config, onAuth }) {
+  if (!onAuth) return onAuth
+
+  return async (url, auth) => {
+    const username =
+      auth.username || (await config.get(`credential.${url}.username`))
+    return onAuth(url, username ? { ...auth, username } : auth)
+  }
+}


### PR DESCRIPTION
## Summary
- read credential.<url>.username from git config before invoking auth callbacks during fetch/push discovery
- preserve explicit usernames from the URL/auth object
- add a focused fetch test for credential config username propagation

Fixes #800

## Tests
- npx nps build.rollup
- npx eslint src/commands/fetch.js src/commands/push.js src/utils/addCredentialUsername.js __tests__/test-fetch.js
- npx prettier --check src/commands/fetch.js src/commands/push.js src/utils/addCredentialUsername.js __tests__/test-fetch.js
- NODE_OPTIONS=--experimental-vm-modules --max-old-space-size-percentage=80 npx jest __tests__/test-fetch.js -t passes credential config username to onAuth --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configured credential usernames for remote URLs are now automatically applied during fetch and push, reducing manual credential entry.

* **Tests**
  * Added a test that confirms configured usernames are supplied to authentication handlers during fetch, including handling of authentication failures and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->