### PR TITLE
fix: fixing git internals

### DIFF
--- a/__tests__/server-only.test-checkout-symlink-leading-path.js
+++ b/__tests__/server-only.test-checkout-symlink-leading-path.js
@@ -1,0 +1,72 @@
+/* eslint-env node, jasmine */
+import { promises as fsp } from 'fs'
+import { join } from 'path'
+
+import * as git from 'isomorphic-git'
+
+import { makeFixture } from './__helpers__/FixtureFS.js'
+
+// checkout should not write a file whose parent path traverses a symlink. git does not
+// follow symlinks in the leading path when writing working-tree files; this checks the
+// same. (node-only: needs real symlinks.)
+describe('checkout symlinked leading path', () => {
+  it('does not write through a planted directory symlink', async () => {
+    const { fs, dir, gitdir } = await makeFixture(
+      'test-checkout-symlink-leading-path'
+    )
+    const author = { name: 't', email: 't@t', timestamp: 1000, timezoneOffset: 0 }
+
+    // A directory outside the working tree that the symlink will point at.
+    const sink = `${dir}-sink`
+    await fsp.mkdir(sink, { recursive: true })
+
+    // Build a commit whose tree contains config/inside.
+    await git.init({ fs, dir, gitdir })
+    const blob = await git.writeBlob({ fs, dir, gitdir, blob: Buffer.from('payload\n') })
+    const sub = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '100644', path: 'inside', oid: blob, type: 'blob' }],
+    })
+    const root = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'config', oid: sub, type: 'tree' }],
+    })
+    const commit = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: { message: 'c\n', tree: root, parent: [], author, committer: author },
+    })
+    await git.writeRef({ fs, dir, gitdir, ref: 'refs/heads/master', value: commit, force: true })
+    await git.writeRef({ fs, dir, gitdir, ref: 'HEAD', value: 'refs/heads/master', symbolic: true, force: true })
+
+    // Plant `config` as a directory symlink and track it, so checkout sees a
+    // symlink -> directory change and reaches the file-write step.
+    try {
+      await fsp.symlink(sink, join(dir, 'config'))
+    } catch (e) {
+      // Symlink creation not permitted here (e.g. Windows without privilege).
+      return
+    }
+    await git.add({ fs, dir, gitdir, filepath: 'config' })
+
+    let error
+    try {
+      await git.checkout({ fs, dir, gitdir, ref: 'master', force: true })
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeDefined()
+    const inner = error && error.errors && error.errors[0] ? error.errors[0] : error
+    expect(`${inner.code || inner.name}`).toMatch(/unsafe/i)
+
+    // The file must not have been written through the symlink into the sink.
+    await expect(
+      fsp.readFile(join(sink, 'inside'), 'utf8')
+    ).rejects.toBeDefined()
+  })
+})

--- a/__tests__/server-only.test-checkout-symlink-leading-path.js
+++ b/__tests__/server-only.test-checkout-symlink-leading-path.js
@@ -25,34 +25,68 @@ describe('checkout symlinked leading path', () => {
     const sink = `${dir}-sink`
     await fsp.mkdir(sink, { recursive: true })
 
-    // Build a commit whose tree contains config/inside.
+    // Build two commits whose trees contain config/inside (with different
+    // content so checkout emits an update op).  We checkout the first commit
+    // to populate the workdir and index, then plant the symlink and checkout
+    // the second commit.  This replaces the previous git.add() call which
+    // crashed on symlinks due to a GitIgnoreManager bug.
     await git.init({ fs, dir, gitdir })
-    const blob = await git.writeBlob({
+    const blobV1 = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('v1\n'),
+    })
+    const blobV2 = await git.writeBlob({
       fs,
       dir,
       gitdir,
       blob: Buffer.from('payload\n'),
     })
-    const sub = await git.writeTree({
+    const subV1 = await git.writeTree({
       fs,
       dir,
       gitdir,
-      tree: [{ mode: '100644', path: 'inside', oid: blob, type: 'blob' }],
+      tree: [{ mode: '100644', path: 'inside', oid: blobV1, type: 'blob' }],
     })
-    const root = await git.writeTree({
+    const subV2 = await git.writeTree({
       fs,
       dir,
       gitdir,
-      tree: [{ mode: '040000', path: 'config', oid: sub, type: 'tree' }],
+      tree: [{ mode: '100644', path: 'inside', oid: blobV2, type: 'blob' }],
     })
-    const commit = await git.writeCommit({
+    const rootV1 = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'config', oid: subV1, type: 'tree' }],
+    })
+    const rootV2 = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'config', oid: subV2, type: 'tree' }],
+    })
+    const commitV1 = await git.writeCommit({
       fs,
       dir,
       gitdir,
       commit: {
-        message: 'c\n',
-        tree: root,
+        message: 'v1\n',
+        tree: rootV1,
         parent: [],
+        author,
+        committer: author,
+      },
+    })
+    const commitV2 = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'v2\n',
+        tree: rootV2,
+        parent: [commitV1],
         author,
         committer: author,
       },
@@ -61,8 +95,16 @@ describe('checkout symlinked leading path', () => {
       fs,
       dir,
       gitdir,
+      ref: 'refs/heads/base',
+      value: commitV1,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
       ref: 'refs/heads/master',
-      value: commit,
+      value: commitV2,
       force: true,
     })
     await git.writeRef({
@@ -70,20 +112,23 @@ describe('checkout symlinked leading path', () => {
       dir,
       gitdir,
       ref: 'HEAD',
-      value: 'refs/heads/master',
+      value: 'refs/heads/base',
       symbolic: true,
       force: true,
     })
 
+    // Checkout the first commit to populate the workdir and index.
+    await git.checkout({ fs, dir, gitdir, ref: 'base', force: true })
+
     // Plant `config` as a directory symlink and track it, so checkout sees a
     // symlink -> directory change and reaches the file-write step.
+    await fsp.rm(join(dir, 'config'), { recursive: true })
     try {
       await fsp.symlink(sink, join(dir, 'config'))
     } catch (e) {
       // Symlink creation not permitted here (e.g. Windows without privilege).
       return
     }
-    await git.add({ fs, dir, gitdir, filepath: 'config' })
 
     let error
     try {
@@ -97,6 +142,279 @@ describe('checkout symlinked leading path', () => {
     expect(`${inner.code || inner.name}`).toMatch(/unsafe/i)
 
     // The file must not have been written through the symlink into the sink.
+    await expect(
+      fsp.readFile(join(sink, 'inside'), 'utf8')
+    ).rejects.toBeDefined()
+  })
+
+  it('does not mkdir through a symlinked leading path', async () => {
+    const { fs, dir, gitdir } = await makeFixture(
+      'test-checkout-symlink-leading-path'
+    )
+    const author = {
+      name: 't',
+      email: 't@t',
+      timestamp: 1000,
+      timezoneOffset: 0,
+    }
+
+    const sink = `${dir}-sink`
+    await fsp.mkdir(sink, { recursive: true })
+
+    await git.init({ fs, dir, gitdir })
+
+    // Commit A: evil/file (creates evil/ as a real directory)
+    // Commit B: evil/file + evil/sub/deep (adds a subdirectory)
+    // After checking out A, replace evil/ with a symlink to sink/.
+    // Checking out B should refuse to mkdir evil/sub through the symlink.
+    const blobV1 = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('v1\n'),
+    })
+    const blobPayload = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('payload\n'),
+    })
+    const evilTreeA = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '100644', path: 'file', oid: blobV1, type: 'blob' }],
+    })
+    const subTree = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '100644', path: 'deep', oid: blobPayload, type: 'blob' }],
+    })
+    const evilTreeB = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [
+        { mode: '100644', path: 'file', oid: blobV1, type: 'blob' },
+        { mode: '040000', path: 'sub', oid: subTree, type: 'tree' },
+      ],
+    })
+    const rootA = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'evil', oid: evilTreeA, type: 'tree' }],
+    })
+    const rootB = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'evil', oid: evilTreeB, type: 'tree' }],
+    })
+    const commitA = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'A\n',
+        tree: rootA,
+        parent: [],
+        author,
+        committer: author,
+      },
+    })
+    const commitB = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'B\n',
+        tree: rootB,
+        parent: [commitA],
+        author,
+        committer: author,
+      },
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'refs/heads/base',
+      value: commitA,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'refs/heads/target',
+      value: commitB,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'HEAD',
+      value: 'refs/heads/base',
+      symbolic: true,
+      force: true,
+    })
+
+    await git.checkout({ fs, dir, gitdir, ref: 'base', force: true })
+
+    await fsp.rm(join(dir, 'evil'), { recursive: true })
+    try {
+      await fsp.symlink(sink, join(dir, 'evil'))
+    } catch (e) {
+      return
+    }
+
+    let error
+    try {
+      await git.checkout({ fs, dir, gitdir, ref: 'target', force: true })
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeDefined()
+    const inner =
+      error && error.errors && error.errors[0] ? error.errors[0] : error
+    expect(`${inner.code || inner.name}`).toMatch(/unsafe/i)
+
+    // The directory must not have been created inside the sink.
+    await expect(fsp.stat(join(sink, 'sub'))).rejects.toBeDefined()
+  })
+
+  it('does not write through a planted directory symlink (nonBlocking)', async () => {
+    const { fs, dir, gitdir } = await makeFixture(
+      'test-checkout-symlink-leading-path'
+    )
+    const author = {
+      name: 't',
+      email: 't@t',
+      timestamp: 1000,
+      timezoneOffset: 0,
+    }
+
+    const sink = `${dir}-sink`
+    await fsp.mkdir(sink, { recursive: true })
+
+    // Same scenario as the first test, but using the nonBlocking code path.
+    await git.init({ fs, dir, gitdir })
+    const blobV1 = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('v1\n'),
+    })
+    const blobV2 = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('payload\n'),
+    })
+    const subV1 = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '100644', path: 'inside', oid: blobV1, type: 'blob' }],
+    })
+    const subV2 = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '100644', path: 'inside', oid: blobV2, type: 'blob' }],
+    })
+    const rootV1 = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'config', oid: subV1, type: 'tree' }],
+    })
+    const rootV2 = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'config', oid: subV2, type: 'tree' }],
+    })
+    const commitV1 = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'v1\n',
+        tree: rootV1,
+        parent: [],
+        author,
+        committer: author,
+      },
+    })
+    const commitV2 = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'v2\n',
+        tree: rootV2,
+        parent: [commitV1],
+        author,
+        committer: author,
+      },
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'refs/heads/base',
+      value: commitV1,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'refs/heads/master',
+      value: commitV2,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'HEAD',
+      value: 'refs/heads/base',
+      symbolic: true,
+      force: true,
+    })
+
+    await git.checkout({ fs, dir, gitdir, ref: 'base', force: true })
+
+    await fsp.rm(join(dir, 'config'), { recursive: true })
+    try {
+      await fsp.symlink(sink, join(dir, 'config'))
+    } catch (e) {
+      return
+    }
+
+    let error
+    try {
+      await git.checkout({
+        fs,
+        dir,
+        gitdir,
+        ref: 'master',
+        force: true,
+        nonBlocking: true,
+      })
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeDefined()
+    const inner =
+      error && error.errors && error.errors[0] ? error.errors[0] : error
+    expect(`${inner.code || inner.name}`).toMatch(/unsafe/i)
+
     await expect(
       fsp.readFile(join(sink, 'inside'), 'utf8')
     ).rejects.toBeDefined()

--- a/__tests__/server-only.test-checkout-symlink-leading-path.js
+++ b/__tests__/server-only.test-checkout-symlink-leading-path.js
@@ -14,7 +14,12 @@ describe('checkout symlinked leading path', () => {
     const { fs, dir, gitdir } = await makeFixture(
       'test-checkout-symlink-leading-path'
     )
-    const author = { name: 't', email: 't@t', timestamp: 1000, timezoneOffset: 0 }
+    const author = {
+      name: 't',
+      email: 't@t',
+      timestamp: 1000,
+      timezoneOffset: 0,
+    }
 
     // A directory outside the working tree that the symlink will point at.
     const sink = `${dir}-sink`
@@ -22,7 +27,12 @@ describe('checkout symlinked leading path', () => {
 
     // Build a commit whose tree contains config/inside.
     await git.init({ fs, dir, gitdir })
-    const blob = await git.writeBlob({ fs, dir, gitdir, blob: Buffer.from('payload\n') })
+    const blob = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('payload\n'),
+    })
     const sub = await git.writeTree({
       fs,
       dir,
@@ -39,10 +49,31 @@ describe('checkout symlinked leading path', () => {
       fs,
       dir,
       gitdir,
-      commit: { message: 'c\n', tree: root, parent: [], author, committer: author },
+      commit: {
+        message: 'c\n',
+        tree: root,
+        parent: [],
+        author,
+        committer: author,
+      },
     })
-    await git.writeRef({ fs, dir, gitdir, ref: 'refs/heads/master', value: commit, force: true })
-    await git.writeRef({ fs, dir, gitdir, ref: 'HEAD', value: 'refs/heads/master', symbolic: true, force: true })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'refs/heads/master',
+      value: commit,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'HEAD',
+      value: 'refs/heads/master',
+      symbolic: true,
+      force: true,
+    })
 
     // Plant `config` as a directory symlink and track it, so checkout sees a
     // symlink -> directory change and reaches the file-write step.
@@ -61,7 +92,8 @@ describe('checkout symlinked leading path', () => {
       error = e
     }
     expect(error).toBeDefined()
-    const inner = error && error.errors && error.errors[0] ? error.errors[0] : error
+    const inner =
+      error && error.errors && error.errors[0] ? error.errors[0] : error
     expect(`${inner.code || inner.name}`).toMatch(/unsafe/i)
 
     // The file must not have been written through the symlink into the sink.

--- a/__tests__/test-GitRefManager-symref-cycle.js
+++ b/__tests__/test-GitRefManager-symref-cycle.js
@@ -1,0 +1,45 @@
+/* eslint-env node, browser, jasmine */
+import { GitRefManager } from 'isomorphic-git/internal-apis'
+
+import { makeFixture } from './__helpers__/FixtureFS.js'
+
+// Resolving a self-referential symref chain (a -> b -> a) must terminate rather than
+// recurse forever. git bounds this with SYMREF_MAXDEPTH; here we detect the cycle.
+describe('GitRefManager symref cycle handling', () => {
+  it('returns (throwing) instead of looping on a -> b -> a', async () => {
+    // Use real timers so the race below can time out if resolve never returns
+    // (FixtureFS installs fake timers by default).
+    if (globalThis.jest) jest.useRealTimers()
+
+    const { fs, gitdir } = await makeFixture('test-GitRefManager-symref-cycle')
+    await fs.write(
+      `${gitdir}/refs/remotes/origin/a`,
+      'ref: refs/remotes/origin/b\n'
+    )
+    await fs.write(
+      `${gitdir}/refs/remotes/origin/b`,
+      'ref: refs/remotes/origin/a\n'
+    )
+
+    const result = await Promise.race([
+      GitRefManager.resolve({ fs, gitdir, ref: 'refs/remotes/origin/a' }).then(
+        value => ({ value }),
+        error => ({ error })
+      ),
+      new Promise(resolve => setTimeout(() => resolve({ timedOut: true }), 5000)),
+    ])
+
+    // Without the fix resolve() never returns and we hit the 5s timeout.
+    expect(result.timedOut).toBeUndefined()
+    expect(result.error).toBeDefined()
+    expect(result.error.message).toMatch(/circular/i)
+  }, 15000)
+
+  it('still resolves a normal HEAD -> branch -> sha chain', async () => {
+    const { fs, gitdir } = await makeFixture('test-GitRefManager-symref-ok')
+    const sha = '0123456789abcdef0123456789abcdef01234567'
+    await fs.write(`${gitdir}/refs/heads/main`, `${sha}\n`)
+    await fs.write(`${gitdir}/HEAD`, 'ref: refs/heads/main\n')
+    expect(await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })).toBe(sha)
+  })
+})

--- a/__tests__/test-GitRefManager-symref-cycle.js
+++ b/__tests__/test-GitRefManager-symref-cycle.js
@@ -1,4 +1,4 @@
-/* eslint-env node, browser, jasmine */
+/* eslint-env node, browser, jasmine, jest */
 import { GitRefManager } from 'isomorphic-git/internal-apis'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
@@ -26,7 +26,9 @@ describe('GitRefManager symref cycle handling', () => {
         value => ({ value }),
         error => ({ error })
       ),
-      new Promise(resolve => setTimeout(() => resolve({ timedOut: true }), 5000)),
+      new Promise(resolve =>
+        setTimeout(() => resolve({ timedOut: true }), 5000)
+      ),
     ])
 
     // Without the fix resolve() never returns and we hit the 5s timeout.

--- a/__tests__/test-GitTree-entry-name-validation.js
+++ b/__tests__/test-GitTree-entry-name-validation.js
@@ -23,6 +23,36 @@ describe('GitTree entry-name validation', () => {
     rejects('.git ')
   })
 
+  it('rejects NTFS 8.3 short name aliases for .git', () => {
+    rejects('git~1')
+    rejects('GIT~1')
+    rejects('git~2')
+    rejects('git~9')
+    rejects('git~1.')
+    rejects('git~1 ')
+  })
+
+  it('rejects HFS+ ignorable Unicode variants of .git', () => {
+    rejects('.g‌it') // U+200C zero width non-joiner
+    rejects('.‍git') // U+200D zero width joiner
+    rejects('.gi‎t') // U+200E left-to-right mark
+    rejects('.git﻿') // U+FEFF zero width no-break space (BOM)
+  })
+
+  it('rejects HFS+ ignorable Unicode variants of . and ..', () => {
+    rejects('.‌') // "." + zero width non-joiner
+    rejects('.‌.') // ".." with zero width non-joiner between dots
+  })
+
+  it('accepts git~10 and git~0 (not valid 8.3 aliases)', () => {
+    expect(GitTree.from(entry('100644', 'git~10')).entries()[0].path).toBe(
+      'git~10'
+    )
+    expect(GitTree.from(entry('100644', 'git~0')).entries()[0].path).toBe(
+      'git~0'
+    )
+  })
+
   it('accepts ordinary names, including .gitignore', () => {
     expect(GitTree.from(entry('100644', 'normal.txt')).entries()[0].path).toBe(
       'normal.txt'

--- a/__tests__/test-GitTree-entry-name-validation.js
+++ b/__tests__/test-GitTree-entry-name-validation.js
@@ -1,0 +1,34 @@
+/* eslint-env node, browser, jasmine */
+import { GitTree } from 'isomorphic-git/internal-apis'
+
+// GitTree should reject the reserved entry names git's verify_path() rejects:
+//   "." and ".."  — these resolve outside the working directory
+//   ".git"         — git disallows it as a path component
+// ".git" is matched case-insensitively and with trailing dots/spaces stripped, since
+// those are ignored on some filesystems (so ".git." and ".git " resolve to ".git").
+describe('GitTree entry-name validation', () => {
+  const oid = Buffer.alloc(20, 1)
+  // git tree entry on the wire: "<mode> <name>\0<20-byte oid>"
+  const entry = (mode, name) =>
+    Buffer.concat([Buffer.from(`${mode} ${name}`), Buffer.from([0]), oid])
+  const rejects = name =>
+    expect(() => GitTree.from(entry('40000', name))).toThrow(/unsafe/i)
+
+  it('rejects ".."', () => rejects('..'))
+  it('rejects "."', () => rejects('.'))
+  it('rejects ".git"', () => rejects('.git'))
+  it('rejects ".git" case-insensitively (".GIT")', () => rejects('.GIT'))
+  it('rejects ".git." and ".git " (trailing dot/space)', () => {
+    rejects('.git.')
+    rejects('.git ')
+  })
+
+  it('accepts ordinary names, including .gitignore', () => {
+    expect(GitTree.from(entry('100644', 'normal.txt')).entries()[0].path).toBe(
+      'normal.txt'
+    )
+    expect(GitTree.from(entry('100644', '.gitignore')).entries()[0].path).toBe(
+      '.gitignore'
+    )
+  })
+})

--- a/__tests__/test-applyDelta-bounded-allocation.js
+++ b/__tests__/test-applyDelta-bounded-allocation.js
@@ -1,0 +1,44 @@
+/* eslint-env node, browser, jasmine */
+import { applyDelta } from 'isomorphic-git/internal-apis'
+
+// applyDelta should build its result from the delta ops rather than pre-allocating the
+// size declared in the delta header. The declared target size may not match the actual
+// op output, so allocating it up front can reserve far more memory than the ops produce.
+function varIntLE(n) {
+  const bytes = []
+  do {
+    let byte = n & 0x7f
+    n = Math.floor(n / 128)
+    if (n) byte |= 0x80
+    bytes.push(byte)
+  } while (n)
+  return Buffer.from(bytes)
+}
+
+describe('applyDelta bounded allocation', () => {
+  it('applies a valid multi-op delta correctly', () => {
+    // sourceSize=0, targetSize=2, two 1-byte inserts ("a", "b")
+    const delta = Buffer.concat([
+      varIntLE(0),
+      varIntLE(2),
+      Buffer.from([0x01, 0x61, 0x01, 0x62]),
+    ])
+    expect(applyDelta(delta, Buffer.alloc(0)).toString()).toBe('ab')
+  })
+
+  it('throws when the declared target size exceeds the ops, without allocating it', () => {
+    const measure = typeof process !== 'undefined' && process.memoryUsage
+    const before = measure ? process.memoryUsage().external : 0
+    // declared targetSize = 0x7FFFFFFF but only a single 1-byte insert op
+    const delta = Buffer.concat([
+      varIntLE(0),
+      varIntLE(0x7fffffff),
+      Buffer.from([0x01, 0x00]),
+    ])
+    expect(() => applyDelta(delta, Buffer.alloc(0))).toThrow()
+    if (measure) {
+      const grewMB = (process.memoryUsage().external - before) / 1024 / 1024
+      expect(grewMB).toBeLessThan(100)
+    }
+  })
+})

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -248,6 +248,7 @@ export async function _checkout({
         .filter(([method]) => method === 'mkdir' || method === 'mkdir-index')
         .map(async function ([_, fullpath]) {
           const filepath = `${dir}/${fullpath}`
+          await assertNoSymlinkInLeadingPath(fs, dir, fullpath)
           await fs.mkdir(filepath)
           if (onProgress) {
             await onProgress({
@@ -727,6 +728,7 @@ async function updateWorkingDir(
 ) {
   const filepath = `${dir}/${fullpath}`
   if (method !== 'create-index' && method !== 'mkdir-index') {
+    await assertNoSymlinkInLeadingPath(fs, dir, fullpath)
     const { object } = await readObject({ fs, cache, gitdir, oid })
     if (chmod) {
       await fs.rm(filepath)

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -10,12 +10,37 @@ import { CommitNotFetchedError } from '../errors/CommitNotFetchedError.js'
 import { InternalError } from '../errors/InternalError.js'
 import { MultipleGitError } from '../errors/MultipleGitError.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
+import { UnsafeFilepathError } from '../errors/UnsafeFilepathError.js'
 import { GitConfigManager } from '../managers/GitConfigManager.js'
 import { GitIndexManager } from '../managers/GitIndexManager.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
 import { _readObject as readObject } from '../storage/readObject.js'
 import { flat } from '../utils/flat.js'
 import { worthWalking } from '../utils/worthWalking.js'
+
+/**
+ * Throw if any leading directory component of `fullpath` (relative to `dir`) is a symbolic
+ * link. git does not follow symlinks in the leading path when writing working-tree files;
+ * matching that avoids writing through a symlinked parent into a location outside `dir`.
+ *
+ * @param {import('../models/FileSystem.js').FileSystem} fs
+ * @param {string} dir
+ * @param {string} fullpath
+ */
+async function assertNoSymlinkInLeadingPath(fs, dir, fullpath) {
+  const parts = fullpath.split('/')
+  parts.pop() // the final segment is the entry being written, not a leading dir
+  let current = dir
+  for (const part of parts) {
+    if (part === '' || part === '.') continue
+    current = `${current}/${part}`
+    const stats = await fs.lstat(current)
+    // lstat returns null when the path doesn't exist yet (nothing to traverse).
+    if (stats && stats.isSymbolicLink()) {
+      throw new UnsafeFilepathError(fullpath)
+    }
+  }
+}
 
 /**
  * @param {object} args
@@ -292,6 +317,10 @@ export async function _checkout({
               .map(async function ([method, fullpath, oid, mode, chmod]) {
                 const filepath = `${dir}/${fullpath}`
                 if (method !== 'create-index' && method !== 'mkdir-index') {
+                  // Don't write through a symlinked leading path: a parent component that
+                  // is a symlink could otherwise redirect the write outside the working
+                  // tree. git applies the same check (it does not follow symlinks here).
+                  await assertNoSymlinkInLeadingPath(fs, dir, fullpath)
                   const { object } = await readObject({
                     fs,
                     cache,

--- a/src/internal-apis.js
+++ b/src/internal-apis.js
@@ -31,6 +31,7 @@ export * from './storage/readObject.js'
 export * from './storage/writeObject.js'
 export * from './storage/readObjectPacked.js'
 
+export * from './utils/applyDelta.js'
 export * from './utils/calculateBasicAuthHeader.js'
 export * from './utils/collect.js'
 export * from './utils/comparePath.js'

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -3,6 +3,7 @@ import '../typedefs.js'
 // This is a convenience wrapper for reading and writing files in the 'refs' directory.
 import AsyncLock from 'async-lock'
 
+import { InternalError } from '../errors/InternalError.js'
 import { InvalidOidError } from '../errors/InvalidOidError.js'
 import { NoRefspecError } from '../errors/NoRefspecError.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
@@ -255,7 +256,7 @@ export class GitRefManager {
    * @param {number} [args.depth = undefined] - The maximum depth to resolve symbolic refs.
    * @returns {Promise<string>} - The resolved object ID.
    */
-  static async resolve({ fs, gitdir, ref, depth = undefined }) {
+  static async resolve({ fs, gitdir, ref, depth = undefined, visited = new Set() }) {
     if (depth !== undefined) {
       depth--
       if (depth === -1) {
@@ -266,7 +267,7 @@ export class GitRefManager {
     // Is it a ref pointer?
     if (ref.startsWith('ref: ')) {
       ref = ref.slice('ref: '.length)
-      return GitRefManager.resolve({ fs, gitdir, ref, depth })
+      return GitRefManager.resolve({ fs, gitdir, ref, depth, visited })
     }
     // Is it a complete and valid SHA?
     if (ref.length === 40 && /[0-9a-f]{40}/.test(ref)) {
@@ -285,7 +286,21 @@ export class GitRefManager {
           packedMap.get(ref)
       )
       if (sha) {
-        return GitRefManager.resolve({ fs, gitdir, ref: sha.trim(), depth })
+        // Guard against circular symbolic references (e.g. a -> b -> a). Without
+        // tracking visited refs this recursion would not terminate.
+        if (visited.has(ref)) {
+          throw new InternalError(
+            `Circular reference detected while resolving ref "${ref}"`
+          )
+        }
+        visited.add(ref)
+        return GitRefManager.resolve({
+          fs,
+          gitdir,
+          ref: sha.trim(),
+          depth,
+          visited,
+        })
       }
     }
     // Do we give up?

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -256,7 +256,13 @@ export class GitRefManager {
    * @param {number} [args.depth = undefined] - The maximum depth to resolve symbolic refs.
    * @returns {Promise<string>} - The resolved object ID.
    */
-  static async resolve({ fs, gitdir, ref, depth = undefined, visited = new Set() }) {
+  static async resolve({
+    fs,
+    gitdir,
+    ref,
+    depth = undefined,
+    visited = new Set(),
+  }) {
     if (depth !== undefined) {
       depth--
       if (depth === -1) {

--- a/src/models/GitTree.js
+++ b/src/models/GitTree.js
@@ -47,15 +47,22 @@ function parseBuffer(buffer) {
 
     // Reject reserved entry names, matching git's verify_path(): path separators,
     // "." and ".." (which resolve outside the working directory), and ".git" (which git
-    // disallows as a path component). ".git" is matched case-insensitively and with
-    // trailing dots/spaces stripped, since those are ignored on some filesystems.
-    const normalized = path.toLowerCase().replace(/[. ]+$/, '')
+    // disallows as a path component). Checks mirror git's is_ntfs_dotgit() and
+    // is_hfs_dotgit(): case-insensitive, trailing dots/spaces stripped (NTFS),
+    // NTFS 8.3 short name aliases (git~1..git~9), and HFS+ ignorable Unicode
+    // characters stripped (zero-width joiners, directional marks, BOM, etc.).
+    const hfsClean = path.replace(
+      /[\u200C-\u200F\u202A-\u202E\u206A-\u206F\uFEFF]/g,
+      ''
+    )
+    const normalized = hfsClean.toLowerCase().replace(/[. ]+$/, '')
     if (
       path.includes('\\') ||
       path.includes('/') ||
-      path === '.' ||
-      path === '..' ||
-      normalized === '.git'
+      hfsClean === '.' ||
+      hfsClean === '..' ||
+      normalized === '.git' ||
+      /^\.?git~[1-9]$/.test(normalized)
     ) {
       throw new UnsafeFilepathError(path)
     }

--- a/src/models/GitTree.js
+++ b/src/models/GitTree.js
@@ -45,8 +45,18 @@ function parseBuffer(buffer) {
     const type = mode2type(mode)
     const path = buffer.slice(space + 1, nullchar).toString('utf8')
 
-    // Prevent malicious git repos from writing to "..\foo" on clone etc
-    if (path.includes('\\') || path.includes('/')) {
+    // Reject reserved entry names, matching git's verify_path(): path separators,
+    // "." and ".." (which resolve outside the working directory), and ".git" (which git
+    // disallows as a path component). ".git" is matched case-insensitively and with
+    // trailing dots/spaces stripped, since those are ignored on some filesystems.
+    const normalized = path.toLowerCase().replace(/[. ]+$/, '')
+    if (
+      path.includes('\\') ||
+      path.includes('/') ||
+      path === '.' ||
+      path === '..' ||
+      normalized === '.git'
+    ) {
       throw new UnsafeFilepathError(path)
     }
 

--- a/src/utils/applyDelta.js
+++ b/src/utils/applyDelta.js
@@ -23,21 +23,26 @@ export function applyDelta(delta, source) {
   if (firstOp.byteLength === targetSize) {
     target = firstOp
   } else {
-    // Otherwise, allocate a fresh buffer and slices
-    target = Buffer.alloc(targetSize)
-    const writer = new BufferCursor(target)
-    writer.copy(firstOp)
+    // Build the result from the delta ops instead of pre-allocating `targetSize`.
+    // `targetSize` comes from the delta header and may not match the actual op output,
+    // so allocating it up front can reserve far more memory than the ops produce.
+    // Building from the ops bounds memory to the real output size; the size check below
+    // still validates the total before concatenating.
+    const chunks = [firstOp]
+    let tell = firstOp.byteLength
 
     while (!reader.eof()) {
-      writer.copy(readOp(reader, source))
+      const op = readOp(reader, source)
+      chunks.push(op)
+      tell += op.byteLength
     }
 
-    const tell = writer.tell()
     if (targetSize !== tell) {
       throw new InternalError(
         `applyDelta expected target buffer to be ${targetSize} bytes but the resulting buffer was ${tell} bytes`
       )
     }
+    target = Buffer.concat(chunks, targetSize)
   }
   return target
 }


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened `checkout` against symbolic links in the leading components of destination paths, blocking any unsafe working-tree writes and returning an unsafe-path error.
  * Strengthened Git tree entry path validation by rejecting reserved/unsafe entry names such as `.`, `..`, and `.git` (case-insensitive), including variants with trailing dots/spaces.
* **Tests**
  * Added coverage for the leading-path symlink checkout scenario (including both blocking and non-blocking flows).
  * Added tests for `GitTree` reserved/unsafe entry-name rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->