### PR TITLE
disable bitbucket tests

### DIFF
--- a/__tests__/test-hosting-providers-in-submodule.js
+++ b/__tests__/test-hosting-providers-in-submodule.js
@@ -108,7 +108,8 @@ describe('Hosting Providers', () => {
     })
   })
 
-  describe('Bitbucket', () => {
+  // TODO: Re-enable once Bitbucket token/access changes are resolved.
+  describe.skip('Bitbucket', () => {
     // This App Password is for the test account 'isomorphic-git' user on Bitbucket,
     // with "repositories.read" and "repositories.write" access. However the only repo the account has access to is
     // https://bitbucket.org/isomorphic-git/test.empty

--- a/__tests__/test-hosting-providers.js
+++ b/__tests__/test-hosting-providers.js
@@ -100,7 +100,8 @@ describe('Hosting Providers', () => {
     })
   })
 
-  describe('Bitbucket', () => {
+  // TODO: Re-enable once Bitbucket token/access changes are resolved.
+  describe.skip('Bitbucket', () => {
     // This App Password is for the test account 'isomorphic-git' user on Bitbucket,
     // with "repositories.read" and "repositories.write" access. However the only repo the account has access to is
     // https://bitbucket.org/isomorphic-git/test.empty


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled the Bitbucket hosting-provider test suite while access/token issues are resolved.
  * Added a note to re-enable the tests once the underlying access problem is fixed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->