### PR TITLE
fix: detect reference cycles in GitRefManager.resolve

### DIFF
--- a/__tests__/test-GitRefManager-symref-cycle.js
+++ b/__tests__/test-GitRefManager-symref-cycle.js
@@ -1,0 +1,45 @@
+/* eslint-env node, browser, jasmine */
+import { GitRefManager } from 'isomorphic-git/internal-apis'
+
+import { makeFixture } from './__helpers__/FixtureFS.js'
+
+// Resolving a self-referential symref chain (a -> b -> a) must terminate rather than
+// recurse forever. git bounds this with SYMREF_MAXDEPTH; here we detect the cycle.
+describe('GitRefManager symref cycle handling', () => {
+  it('returns (throwing) instead of looping on a -> b -> a', async () => {
+    // Use real timers so the race below can time out if resolve never returns
+    // (FixtureFS installs fake timers by default).
+    if (globalThis.jest) jest.useRealTimers()
+
+    const { fs, gitdir } = await makeFixture('test-GitRefManager-symref-cycle')
+    await fs.write(
+      `${gitdir}/refs/remotes/origin/a`,
+      'ref: refs/remotes/origin/b\n'
+    )
+    await fs.write(
+      `${gitdir}/refs/remotes/origin/b`,
+      'ref: refs/remotes/origin/a\n'
+    )
+
+    const result = await Promise.race([
+      GitRefManager.resolve({ fs, gitdir, ref: 'refs/remotes/origin/a' }).then(
+        value => ({ value }),
+        error => ({ error })
+      ),
+      new Promise(resolve => setTimeout(() => resolve({ timedOut: true }), 5000)),
+    ])
+
+    // Without the fix resolve() never returns and we hit the 5s timeout.
+    expect(result.timedOut).toBeUndefined()
+    expect(result.error).toBeDefined()
+    expect(result.error.message).toMatch(/circular/i)
+  }, 15000)
+
+  it('still resolves a normal HEAD -> branch -> sha chain', async () => {
+    const { fs, gitdir } = await makeFixture('test-GitRefManager-symref-ok')
+    const sha = '0123456789abcdef0123456789abcdef01234567'
+    await fs.write(`${gitdir}/refs/heads/main`, `${sha}\n`)
+    await fs.write(`${gitdir}/HEAD`, 'ref: refs/heads/main\n')
+    expect(await GitRefManager.resolve({ fs, gitdir, ref: 'HEAD' })).toBe(sha)
+  })
+})

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -3,6 +3,7 @@ import '../typedefs.js'
 // This is a convenience wrapper for reading and writing files in the 'refs' directory.
 import AsyncLock from 'async-lock'
 
+import { InternalError } from '../errors/InternalError.js'
 import { InvalidOidError } from '../errors/InvalidOidError.js'
 import { NoRefspecError } from '../errors/NoRefspecError.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
@@ -255,7 +256,7 @@ export class GitRefManager {
    * @param {number} [args.depth = undefined] - The maximum depth to resolve symbolic refs.
    * @returns {Promise<string>} - The resolved object ID.
    */
-  static async resolve({ fs, gitdir, ref, depth = undefined }) {
+  static async resolve({ fs, gitdir, ref, depth = undefined, visited = new Set() }) {
     if (depth !== undefined) {
       depth--
       if (depth === -1) {
@@ -266,7 +267,7 @@ export class GitRefManager {
     // Is it a ref pointer?
     if (ref.startsWith('ref: ')) {
       ref = ref.slice('ref: '.length)
-      return GitRefManager.resolve({ fs, gitdir, ref, depth })
+      return GitRefManager.resolve({ fs, gitdir, ref, depth, visited })
     }
     // Is it a complete and valid SHA?
     if (ref.length === 40 && /[0-9a-f]{40}/.test(ref)) {
@@ -285,7 +286,21 @@ export class GitRefManager {
           packedMap.get(ref)
       )
       if (sha) {
-        return GitRefManager.resolve({ fs, gitdir, ref: sha.trim(), depth })
+        // Guard against circular symbolic references (e.g. a -> b -> a). Without
+        // tracking visited refs this recursion would not terminate.
+        if (visited.has(ref)) {
+          throw new InternalError(
+            `Circular reference detected while resolving ref "${ref}"`
+          )
+        }
+        visited.add(ref)
+        return GitRefManager.resolve({
+          fs,
+          gitdir,
+          ref: sha.trim(),
+          depth,
+          visited,
+        })
       }
     }
     // Do we give up?


### PR DESCRIPTION
Aligns with canonical git behavior. Two commits: a failing test first, then the fix, so the test can be seen going from failing to passing.