### PR TITLE
fix: NTFS Alternate Data Streams handling

### DIFF
--- a/__tests__/test-GitTree-entry-name-validation.js
+++ b/__tests__/test-GitTree-entry-name-validation.js
@@ -32,6 +32,36 @@ describe('GitTree entry-name validation', () => {
     rejects('git~1 ')
   })
 
+  // NTFS Alternate Data Streams are referenced as `<name>:<stream>:<type>`, and a
+  // directory's default stream `::$INDEX_ALLOCATION` lets `.git::$INDEX_ALLOCATION`
+  // resolve to the `.git` directory itself. git rejects *any* ADS of `.git`
+  // (CVE-2019-1352, git commit 7c3745fc), so only the portion before the first
+  // colon names the actual entry.
+  it('rejects NTFS Alternate Data Streams of .git', () => {
+    rejects('.git::$INDEX_ALLOCATION')
+    rejects('.git:$INDEX_ALLOCATION')
+    rejects('.git:foo')
+    rejects('.git...:alternate-stream') // git's own t1014 test case
+    rejects('.GIT:$DATA') // case-insensitive
+    rejects('.git.:stream') // trailing dot before the stream
+    rejects('.git :stream') // trailing space before the stream
+  })
+
+  it('rejects NTFS Alternate Data Streams of the git~1 short name', () => {
+    rejects('git~1::$INDEX_ALLOCATION')
+    rejects('git~1:foo')
+    rejects('GIT~1:$DATA')
+  })
+
+  it('accepts colon names whose leading component is not .git', () => {
+    expect(GitTree.from(entry('100644', 'foo:bar')).entries()[0].path).toBe(
+      'foo:bar'
+    )
+    expect(
+      GitTree.from(entry('100644', '.gitignore:bar')).entries()[0].path
+    ).toBe('.gitignore:bar')
+  })
+
   it('rejects HFS+ ignorable Unicode variants of .git', () => {
     rejects('.g‌it') // U+200C zero width non-joiner
     rejects('.‍git') // U+200D zero width joiner

--- a/src/models/GitTree.js
+++ b/src/models/GitTree.js
@@ -49,13 +49,19 @@ function parseBuffer(buffer) {
     // "." and ".." (which resolve outside the working directory), and ".git" (which git
     // disallows as a path component). Checks mirror git's is_ntfs_dotgit() and
     // is_hfs_dotgit(): case-insensitive, trailing dots/spaces stripped (NTFS),
-    // NTFS 8.3 short name aliases (git~1..git~9), and HFS+ ignorable Unicode
-    // characters stripped (zero-width joiners, directional marks, BOM, etc.).
+    // NTFS 8.3 short name aliases (git~1..git~9), NTFS Alternate Data Streams, and
+    // HFS+ ignorable Unicode characters stripped (zero-width joiners, directional
+    // marks, BOM, etc.).
     const hfsClean = path.replace(
       /[\u200C-\u200F\u202A-\u202E\u206A-\u206F\uFEFF]/g,
       ''
     )
-    const normalized = hfsClean.toLowerCase().replace(/[. ]+$/, '')
+    // NTFS Alternate Data Streams are referenced as `<name>:<stream>:<type>`, and a
+    // directory's default stream lets `.git::$INDEX_ALLOCATION` resolve to the `.git`
+    // directory itself. git forbids *any* ADS, so only the portion before the first
+    // colon names the actual entry we normalize and check.
+    const ntfsClean = hfsClean.split(':')[0]
+    const normalized = ntfsClean.toLowerCase().replace(/[. ]+$/, '')
     if (
       path.includes('\\') ||
       path.includes('/') ||


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Git tree entry names on NTFS filesystems.
  * Reserved `.git` paths are now consistently rejected across case, spacing, colon, and short-name variants.
  * Valid colon-containing names, such as `.gitignore:bar`, continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->