### PR TITLE
fix: unsafe symlink from cherry pick

### DIFF
--- a/__tests__/server-only.test-cherryPick-symlink-leading-path.js
+++ b/__tests__/server-only.test-cherryPick-symlink-leading-path.js
@@ -1,0 +1,139 @@
+/* eslint-env node, jasmine */
+import { promises as fsp } from 'fs'
+import { join } from 'path'
+
+import * as git from 'isomorphic-git'
+
+import { makeFixture } from './__helpers__/FixtureFS.js'
+
+// cherryPick applies the resulting tree to the working directory via
+// applyTreeChanges. It must not write a file (or mkdir) whose parent path
+// traverses a symlink, exactly like checkout. Canonical git replaces the
+// symlink with a real directory instead of following it; isomorphic-git
+// refuses the unsafe write. (node-only: needs real symlinks.)
+describe('cherryPick symlinked leading path', () => {
+  it('does not write through a tracked directory symlink', async () => {
+    const { fs, dir, gitdir } = await makeFixture(
+      'test-cherryPick-symlink-leading-path'
+    )
+    const author = {
+      name: 't',
+      email: 't@t',
+      timestamp: 1000,
+      timezoneOffset: 0,
+    }
+
+    // A directory outside the working tree that the symlink points at.
+    const sink = `${dir}-sink`
+    await fsp.mkdir(sink, { recursive: true })
+
+    await git.init({ fs, dir, gitdir })
+
+    // Base commit: `link` is a symlink pointing outside the worktree.
+    const linkBlob = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from(sink),
+    })
+    const baseTree = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '120000', path: 'link', oid: linkBlob, type: 'blob' }],
+    })
+    const baseCommit = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'base\n',
+        tree: baseTree,
+        parent: [],
+        author,
+        committer: author,
+      },
+    })
+
+    // Malicious commit (child of base): `link` becomes a directory containing
+    // `link/marker`. Cherry-picking this onto base merges to `link/marker`,
+    // whose leading component `link` is a symlink on disk.
+    const markerBlob = await git.writeBlob({
+      fs,
+      dir,
+      gitdir,
+      blob: Buffer.from('pwned\n'),
+    })
+    const linkDirTree = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '100644', path: 'marker', oid: markerBlob, type: 'blob' }],
+    })
+    const evilTree = await git.writeTree({
+      fs,
+      dir,
+      gitdir,
+      tree: [{ mode: '040000', path: 'link', oid: linkDirTree, type: 'tree' }],
+    })
+    const evilCommit = await git.writeCommit({
+      fs,
+      dir,
+      gitdir,
+      commit: {
+        message: 'evil\n',
+        tree: evilTree,
+        parent: [baseCommit],
+        author,
+        committer: author,
+      },
+    })
+
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'refs/heads/master',
+      value: baseCommit,
+      force: true,
+    })
+    await git.writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'HEAD',
+      value: 'refs/heads/master',
+      symbolic: true,
+      force: true,
+    })
+
+    // Checkout base so the `link` symlink exists on disk.
+    await git.checkout({ fs, dir, gitdir, ref: 'master', force: true })
+
+    // Sanity: the symlink is really on disk.
+    const lst = await fsp.lstat(join(dir, 'link'))
+    expect(lst.isSymbolicLink()).toBe(true)
+
+    let error
+    try {
+      await git.cherryPick({
+        fs,
+        dir,
+        gitdir,
+        oid: evilCommit,
+        committer: author,
+      })
+    } catch (e) {
+      error = e
+    }
+    expect(error).toBeDefined()
+    const inner =
+      error && error.errors && error.errors[0] ? error.errors[0] : error
+    expect(`${inner.code || inner.name}`).toMatch(/unsafe/i)
+
+    // The marker must not have been written through the symlink into the sink.
+    await expect(
+      fsp.readFile(join(sink, 'marker'), 'utf8')
+    ).rejects.toBeDefined()
+  })
+})

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -10,37 +10,13 @@ import { CommitNotFetchedError } from '../errors/CommitNotFetchedError.js'
 import { InternalError } from '../errors/InternalError.js'
 import { MultipleGitError } from '../errors/MultipleGitError.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
-import { UnsafeFilepathError } from '../errors/UnsafeFilepathError.js'
 import { GitConfigManager } from '../managers/GitConfigManager.js'
 import { GitIndexManager } from '../managers/GitIndexManager.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
 import { _readObject as readObject } from '../storage/readObject.js'
+import { assertNoSymlinkInLeadingPath } from '../utils/assertNoSymlinkInLeadingPath.js'
 import { flat } from '../utils/flat.js'
 import { worthWalking } from '../utils/worthWalking.js'
-
-/**
- * Throw if any leading directory component of `fullpath` (relative to `dir`) is a symbolic
- * link. git does not follow symlinks in the leading path when writing working-tree files;
- * matching that avoids writing through a symlinked parent into a location outside `dir`.
- *
- * @param {import('../models/FileSystem.js').FileSystem} fs
- * @param {string} dir
- * @param {string} fullpath
- */
-async function assertNoSymlinkInLeadingPath(fs, dir, fullpath) {
-  const parts = fullpath.split('/')
-  parts.pop() // the final segment is the entry being written, not a leading dir
-  let current = dir
-  for (const part of parts) {
-    if (part === '' || part === '.') continue
-    current = `${current}/${part}`
-    const stats = await fs.lstat(current)
-    // lstat returns null when the path doesn't exist yet (nothing to traverse).
-    if (stats && stats.isSymbolicLink()) {
-      throw new UnsafeFilepathError(fullpath)
-    }
-  }
-}
 
 /**
  * @param {object} args

--- a/src/utils/assertNoSymlinkInLeadingPath.js
+++ b/src/utils/assertNoSymlinkInLeadingPath.js
@@ -1,0 +1,26 @@
+import { UnsafeFilepathError } from '../errors/UnsafeFilepathError.js'
+
+/**
+ * Refuse to materialize a working-tree entry whose parent path traverses a
+ * symbolic link. A leading component that is a symlink could otherwise redirect
+ * a write or mkdir outside the working tree. git applies the same check: it does
+ * not follow symlinks in the leading path when writing working-tree files.
+ *
+ * @param {import('../models/FileSystem.js').FileSystem} fs
+ * @param {string} dir
+ * @param {string} fullpath
+ */
+export async function assertNoSymlinkInLeadingPath(fs, dir, fullpath) {
+  const parts = fullpath.split('/')
+  parts.pop() // the final segment is the entry being written, not a leading dir
+  let current = dir
+  for (const part of parts) {
+    if (part === '' || part === '.') continue
+    current = `${current}/${part}`
+    const stats = await fs.lstat(current)
+    // lstat returns null when the path doesn't exist yet (nothing to traverse).
+    if (stats && stats.isSymbolicLink()) {
+      throw new UnsafeFilepathError(fullpath)
+    }
+  }
+}

--- a/src/utils/walkerToTreeEntryMap.js
+++ b/src/utils/walkerToTreeEntryMap.js
@@ -13,6 +13,7 @@ import { _readObject } from '../storage/readObject.js'
 import { readObjectLoose } from '../storage/readObjectLoose.js'
 import { _writeObject } from '../storage/writeObject.js'
 
+import { assertNoSymlinkInLeadingPath } from './assertNoSymlinkInLeadingPath.js'
 import { join } from './join.js'
 import { posixifyPathBuffer } from './posixifyPathBuffer.js'
 
@@ -266,6 +267,11 @@ export async function applyTreeChanges({
           await fs.rmdir(currentFilepath)
           break
         case 'mkdir':
+          // Don't mkdir through a symlinked leading path: a parent component that
+          // is a symlink could otherwise redirect the directory creation outside
+          // the working tree. git applies the same check (it does not follow
+          // symlinks here) — see checkout.
+          await assertNoSymlinkInLeadingPath(fs, dir, op.filepath)
           await fs.mkdir(currentFilepath)
           break
         case 'rm':
@@ -278,6 +284,10 @@ export async function applyTreeChanges({
               currentFilepath.startsWith(removedDir)
             )
           ) {
+            // Don't write through a symlinked leading path (see checkout): a
+            // parent component that is a symlink could redirect the write to a
+            // location outside the working tree.
+            await assertNoSymlinkInLeadingPath(fs, dir, op.filepath)
             const { object } = await _readObject({
               fs,
               cache: {},


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented checkout and cherry-pick operations from writing files through symlinked paths outside the working directory.
  * Added safeguards when creating directories or writing files during tree updates.
  * Unsafe path operations now fail safely without modifying external locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->