### PR TITLE
fix(statusMatrix): do not traverse symlinks in GitWalkerFs (#1215)

### DIFF
--- a/__tests__/server-only.test-statusMatrix-symlink.js
+++ b/__tests__/server-only.test-statusMatrix-symlink.js
@@ -1,0 +1,22 @@
+/* eslint-env node, jasmine */
+import * as path from 'path'
+
+import { statusMatrix } from 'isomorphic-git'
+
+import { makeFixture } from './__helpers__/FixtureFS.js'
+
+describe('statusMatrix with symlink', () => {
+  it('statusMatrix with symlink targeting ignored directory', async () => {
+    const { fs, dir, gitdir, _fs } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, '.gitignore'), 'ignored-dir\n')
+    await fs.mkdir(path.join(dir, 'ignored-dir'))
+    await fs.write(path.join(dir, 'ignored-dir', 'file.txt'), 'secret')
+    await _fs.promises.symlink('ignored-dir', path.join(dir, 'symlink-to-ignored'))
+
+    const matrix = await statusMatrix({ fs, dir, gitdir })
+    expect(matrix).toEqual([
+      ['.gitignore', 0, 2, 0],
+      ['symlink-to-ignored', 0, 2, 0],
+    ])
+  })
+})

--- a/__tests__/server-only.test-statusMatrix-symlink.js
+++ b/__tests__/server-only.test-statusMatrix-symlink.js
@@ -11,7 +11,10 @@ describe('statusMatrix with symlink', () => {
     await fs.write(path.join(dir, '.gitignore'), 'ignored-dir\n')
     await fs.mkdir(path.join(dir, 'ignored-dir'))
     await fs.write(path.join(dir, 'ignored-dir', 'file.txt'), 'secret')
-    await _fs.promises.symlink('ignored-dir', path.join(dir, 'symlink-to-ignored'))
+    await _fs.promises.symlink(
+      'ignored-dir',
+      path.join(dir, 'symlink-to-ignored')
+    )
 
     const matrix = await statusMatrix({ fs, dir, gitdir })
     expect(matrix).toEqual([

--- a/__tests__/test-statusMatrix.js
+++ b/__tests__/test-statusMatrix.js
@@ -1,4 +1,5 @@
 /* eslint-env node, browser, jasmine */
+import { promises as fsp } from 'fs'
 import * as path from 'path'
 
 import { statusMatrix, add, remove } from 'isomorphic-git'
@@ -415,5 +416,19 @@ describe('statusMatrix', () => {
     expect(matrix).toEqual([['a.txt', 1, 1, 1]])
     const indexAfter = await fs.read(path.join(gitdir, 'index'))
     expect(indexAfter).toEqual(indexBefore)
+  })
+
+  it('statusMatrix with symlink targeting ignored directory', async () => {
+    const { fs, dir, gitdir } = await makeFixture('test-empty')
+    await fs.write(path.join(dir, '.gitignore'), 'ignored-dir\n')
+    await fs.mkdir(path.join(dir, 'ignored-dir'))
+    await fs.write(path.join(dir, 'ignored-dir', 'file.txt'), 'secret')
+    await fsp.symlink('ignored-dir', path.join(dir, 'symlink-to-ignored'))
+
+    const matrix = await statusMatrix({ fs, dir, gitdir })
+    expect(matrix).toEqual([
+      ['.gitignore', 0, 2, 0],
+      ['symlink-to-ignored', 0, 2, 0],
+    ])
   })
 })

--- a/__tests__/test-statusMatrix.js
+++ b/__tests__/test-statusMatrix.js
@@ -1,5 +1,4 @@
 /* eslint-env node, browser, jasmine */
-import { promises as fsp } from 'fs'
 import * as path from 'path'
 
 import { statusMatrix, add, remove } from 'isomorphic-git'
@@ -416,19 +415,5 @@ describe('statusMatrix', () => {
     expect(matrix).toEqual([['a.txt', 1, 1, 1]])
     const indexAfter = await fs.read(path.join(gitdir, 'index'))
     expect(indexAfter).toEqual(indexBefore)
-  })
-
-  it('statusMatrix with symlink targeting ignored directory', async () => {
-    const { fs, dir, gitdir } = await makeFixture('test-empty')
-    await fs.write(path.join(dir, '.gitignore'), 'ignored-dir\n')
-    await fs.mkdir(path.join(dir, 'ignored-dir'))
-    await fs.write(path.join(dir, 'ignored-dir', 'file.txt'), 'secret')
-    await fsp.symlink('ignored-dir', path.join(dir, 'symlink-to-ignored'))
-
-    const matrix = await statusMatrix({ fs, dir, gitdir })
-    expect(matrix).toEqual([
-      ['.gitignore', 0, 2, 0],
-      ['symlink-to-ignored', 0, 2, 0],
-    ])
   })
 })

--- a/src/models/GitWalkerFs.js
+++ b/src/models/GitWalkerFs.js
@@ -50,6 +50,7 @@ export class GitWalkerFs {
   }
 
   async readdir(entry) {
+    if ((await entry.type()) !== 'tree') return null
     const filepath = entry._fullpath
     const { fs, dir } = this
     const names = await fs.readdir(join(dir, filepath))


### PR DESCRIPTION
## Description
Fixes #1215.

When a repository contains a symlink targeting an ignored directory (such as `node_modules`), `statusMatrix()` was previously traversing the symlink target because `GitWalkerFs.readdir()` called `fs.readdir()`, which follows directory symlinks. As a result, files within the ignored directory were incorrectly reported as untracked/new files.

This change adds a check in `GitWalkerFs.readdir()` to ensure `readdir` is only performed on `tree` entries (actual directories), matching the behavior of `GitWalkerRepo` and `GitWalkerIndex`.

## Changes Made
1. **`src/models/GitWalkerFs.js`**: Added `if ((await entry.type()) !== 'tree') return null` inside `GitWalkerFs.readdir(entry)`.
2. **`__tests__/test-statusMatrix.js`**: Added unit test `statusMatrix with symlink targeting ignored directory` to prevent regression.

## Verification
- Added unit test passes cleanly in Jest.
- Tested against reproduction case, confirming `statusMatrix()` output matches native `git status --porcelain=v1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory reading behavior by safely short-circuiting when encountering non-directory entries.

* **Tests**
  * Added coverage for status matrix behavior when a symlink points to an ignored directory, ensuring expected paths and status/stage counts are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->