### PR TITLE
feat(log): include changed file object ids

### DIFF
--- a/__tests__/test-log.js
+++ b/__tests__/test-log.js
@@ -2,7 +2,15 @@
 import * as path from 'path'
 
 import { pgp } from '@isomorphic-git/pgp-plugin'
-import { add, commit, hashBlob, init, log, remove } from 'isomorphic-git'
+import {
+  add,
+  commit,
+  hashBlob,
+  init,
+  log,
+  remove,
+  resolveRef,
+} from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
 
@@ -45,6 +53,42 @@ describe('log', () => {
         [addedOid, null, 'b.txt'],
       ],
       [[oldOid, null, 'a.txt']],
+    ])
+  })
+
+  it('includes files within a directory that replaced a file', async () => {
+    const { fs, dir } = await makeFixture('test-init')
+    const author = {
+      name: 'Mr. Test',
+      email: 'mrtest@example.com',
+      timestamp: 1262356920,
+      timezoneOffset: 0,
+    }
+    const originalContent = 'original content'
+    const nestedContent = 'nested content'
+    const nestedOid = (await hashBlob({ object: nestedContent })).oid
+
+    await init({ fs, dir })
+    await fs.write(path.join(dir, 'entry'), originalContent)
+    await add({ fs, dir, filepath: 'entry' })
+    await commit({ fs, dir, author, message: 'Add file' })
+
+    await fs.rm(path.join(dir, 'entry'))
+    await remove({ fs, dir, filepath: 'entry' })
+    await fs.mkdir(path.join(dir, 'entry'))
+    await fs.write(path.join(dir, 'entry', 'nested.txt'), nestedContent)
+    await add({ fs, dir, filepath: 'entry/nested.txt' })
+    await commit({ fs, dir, author, message: 'Replace file with directory' })
+
+    const [latestCommit] = await log({
+      fs,
+      dir,
+      depth: 1,
+      includeChanges: true,
+    })
+
+    expect(latestCommit.commit.changes).toEqual([
+      [nestedOid, null, 'entry/nested.txt'],
     ])
   })
 
@@ -358,6 +402,36 @@ describe('log', () => {
         },
       ]
     `)
+  })
+
+  it('includes changes for a shallow boundary', async () => {
+    const { fs, dir } = await makeFixture('test-init')
+    const gitdir = path.join(dir, '.git')
+    const author = {
+      name: 'Mr. Test',
+      email: 'mrtest@example.com',
+      timestamp: 1262356920,
+      timezoneOffset: 0,
+    }
+    const originalContent = 'original content'
+    const updatedContent = 'updated content'
+    const updatedOid = (await hashBlob({ object: updatedContent })).oid
+
+    await init({ fs, dir })
+    await fs.write(path.join(dir, 'a.txt'), originalContent)
+    await add({ fs, dir, filepath: 'a.txt' })
+    await commit({ fs, dir, author, message: 'Initial commit' })
+    await fs.write(path.join(dir, 'a.txt'), updatedContent)
+    await add({ fs, dir, filepath: 'a.txt' })
+    await commit({ fs, dir, author, message: 'Update a.txt' })
+
+    const head = await resolveRef({ fs, dir, ref: 'HEAD' })
+    await fs.write(path.join(gitdir, 'shallow'), `${head}\n`)
+
+    const commits = await log({ fs, dir, includeChanges: true })
+
+    expect(commits).toHaveLength(1)
+    expect(commits[0].commit.changes).toEqual([[updatedOid, null, 'a.txt']])
   })
   it('has correct payloads and gpgsig', async () => {
     // Setup

--- a/__tests__/test-log.js
+++ b/__tests__/test-log.js
@@ -66,6 +66,7 @@ describe('log', () => {
     }
     const originalContent = 'original content'
     const nestedContent = 'nested content'
+    const originalOid = (await hashBlob({ object: originalContent })).oid
     const nestedOid = (await hashBlob({ object: nestedContent })).oid
 
     await init({ fs, dir })
@@ -88,6 +89,7 @@ describe('log', () => {
     })
 
     expect(latestCommit.commit.changes).toEqual([
+      [null, originalOid, 'entry'],
       [nestedOid, null, 'entry/nested.txt'],
     ])
   })

--- a/__tests__/test-log.js
+++ b/__tests__/test-log.js
@@ -1,10 +1,53 @@
 /* eslint-env node, browser, jasmine */
+import * as path from 'path'
+
 import { pgp } from '@isomorphic-git/pgp-plugin'
-import { log } from 'isomorphic-git'
+import { add, commit, hashBlob, init, log, remove } from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
 
 describe('log', () => {
+  it('includes changed file object ids when includeChanges is true', async () => {
+    const { fs, dir } = await makeFixture('test-init')
+    const author = {
+      name: 'Mr. Test',
+      email: 'mrtest@example.com',
+      timestamp: 1262356920,
+      timezoneOffset: 0,
+    }
+    const oldContent = 'old content'
+    const newContent = 'new content'
+    const addedContent = 'added content'
+    const oldOid = (await hashBlob({ object: oldContent })).oid
+    const newOid = (await hashBlob({ object: newContent })).oid
+    const addedOid = (await hashBlob({ object: addedContent })).oid
+
+    await init({ fs, dir })
+    await fs.write(path.join(dir, 'a.txt'), oldContent)
+    await add({ fs, dir, filepath: 'a.txt' })
+    await commit({ fs, dir, author, message: 'Add a.txt' })
+
+    await fs.write(path.join(dir, 'a.txt'), newContent)
+    await fs.write(path.join(dir, 'b.txt'), addedContent)
+    await add({ fs, dir, filepath: 'a.txt' })
+    await add({ fs, dir, filepath: 'b.txt' })
+    await commit({ fs, dir, author, message: 'Update a.txt and add b.txt' })
+
+    await remove({ fs, dir, filepath: 'a.txt' })
+    await commit({ fs, dir, author, message: 'Remove a.txt' })
+
+    const commits = await log({ fs, dir, includeChanges: true })
+
+    expect(commits.map(({ commit }) => commit.changes)).toEqual([
+      [[null, newOid, 'a.txt']],
+      [
+        [newOid, oldOid, 'a.txt'],
+        [addedOid, null, 'b.txt'],
+      ],
+      [[oldOid, null, 'a.txt']],
+    ])
+  })
+
   it('HEAD', async () => {
     const { fs, gitdir } = await makeFixture('test-log')
     const commits = await log({ fs, gitdir, ref: 'HEAD' })

--- a/src/api/log.js
+++ b/src/api/log.js
@@ -20,6 +20,7 @@ import { join } from '../utils/join.js'
  * @param {Date} [args.since] - Return history newer than the given date. Can be combined with `depth` to get whichever is shorter.
  * @param {boolean=} [args.force=false] do not throw error if filepath is not exist (works only for a single file). defaults to false
  * @param {boolean=} [args.follow=false] Continue listing the history of a file beyond renames (works only for a single file). defaults to false
+ * @param {boolean=} [args.includeChanges=false] Include changed file object ids for each commit. Each tuple is `[newOid, oldOid, filepath]`; an added or removed file has a null old or new oid, respectively.
  * @param {object} [args.cache] - a [cache](cache.md) object
  *
  * @returns {Promise<Array<ReadCommitResult>>} Resolves to an array of ReadCommitResult objects
@@ -46,6 +47,7 @@ export async function log({
   since, // Date
   force,
   follow,
+  includeChanges = false,
   cache = {},
 }) {
   try {
@@ -65,6 +67,7 @@ export async function log({
       since,
       force,
       follow,
+      includeChanges,
     })
   } catch (err) {
     err.caller = 'git.log'

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -1,7 +1,9 @@
 // @ts-check
 import '../typedefs.js'
 
+import { TREE } from '../commands/TREE.js'
 import { _readCommit } from '../commands/readCommit.js'
+import { _walk } from '../commands/walk.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
 import { GitShallowManager } from '../managers/GitShallowManager.js'
@@ -21,7 +23,7 @@ import { resolveFilepath } from '../utils/resolveFilepath.js'
  * @param {number|void} args.depth
  * @param {boolean=} [args.force=false] do not throw error if filepath is not exist (works only for a single file). defaults to false
  * @param {boolean=} [args.follow=false] Continue listing the history of a file beyond renames (works only for a single file). defaults to false
- * @param {boolean=} args.follow Continue listing the history of a file beyond renames (works only for a single file). defaults to false
+ * @param {boolean=} [args.includeChanges=false] Include changed file object ids for each commit.
  *
  * @returns {Promise<Array<ReadCommitResult>>} Resolves to an array of ReadCommitResult objects
  * @see ReadCommitResult
@@ -42,6 +44,7 @@ export async function _log({
   since,
   force,
   follow,
+  includeChanges,
 }) {
   const sinceTimestamp =
     typeof since === 'undefined'
@@ -169,5 +172,41 @@ export async function _log({
     // Process tips in order by age
     tips.sort((a, b) => compareAge(a.commit, b.commit))
   }
+  if (includeChanges) {
+    await Promise.all(
+      commits.map(async commit => {
+        commit.commit.changes = await getChanges({ fs, cache, gitdir, commit })
+      })
+    )
+  }
   return commits
+}
+
+async function getChanges({ fs, cache, gitdir, commit }) {
+  const parent =
+    commit.commit.parent[0] || '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+  return _walk({
+    fs,
+    cache,
+    gitdir,
+    trees: [TREE({ ref: commit.oid }), TREE({ ref: parent })],
+    map: async (filepath, [current, previous]) => {
+      const [currentType, previousType] = await Promise.all([
+        current && current.type(),
+        previous && previous.type(),
+      ])
+      if (
+        (currentType === 'tree' || !currentType) &&
+        (previousType === 'tree' || !previousType)
+      ) {
+        return
+      }
+      const [newOid, oldOid] = await Promise.all([
+        current ? current.oid() : null,
+        previous ? previous.oid() : null,
+      ])
+      if (newOid === oldOid) return
+      return [newOid, oldOid, filepath]
+    },
+  })
 }

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -173,18 +173,24 @@ export async function _log({
     tips.sort((a, b) => compareAge(a.commit, b.commit))
   }
   if (includeChanges) {
-    await Promise.all(
-      commits.map(async commit => {
-        commit.commit.changes = await getChanges({ fs, cache, gitdir, commit })
+    for (const commit of commits) {
+      commit.commit.changes = await getChanges({
+        fs,
+        cache,
+        gitdir,
+        commit,
+        shallow: shallowCommits.has(commit.oid),
       })
-    )
+    }
   }
   return commits
 }
 
-async function getChanges({ fs, cache, gitdir, commit }) {
+async function getChanges({ fs, cache, gitdir, commit, shallow }) {
   const parent =
-    commit.commit.parent[0] || '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+    shallow || !commit.commit.parent[0]
+      ? '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+      : commit.commit.parent[0]
   return _walk({
     fs,
     cache,
@@ -195,10 +201,7 @@ async function getChanges({ fs, cache, gitdir, commit }) {
         current && current.type(),
         previous && previous.type(),
       ])
-      if (
-        (currentType === 'tree' || !currentType) &&
-        (previousType === 'tree' || !previousType)
-      ) {
+      if (currentType === 'tree' || previousType === 'tree') {
         return
       }
       const [newOid, oldOid] = await Promise.all([

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -201,7 +201,16 @@ async function getChanges({ fs, cache, gitdir, commit, shallow }) {
         current && current.type(),
         previous && previous.type(),
       ])
-      if (currentType === 'tree' || previousType === 'tree') {
+      if (currentType === 'tree') {
+        if (previousType && previousType !== 'tree') {
+          return [null, await previous.oid(), filepath]
+        }
+        return
+      }
+      if (previousType === 'tree') {
+        if (currentType) {
+          return [await current.oid(), null, filepath]
+        }
         return
       }
       const [newOid, oldOid] = await Promise.all([

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -7,6 +7,7 @@ import './typedefs-http.js'
  * @property {string} message Commit message
  * @property {string} tree SHA-1 object id of corresponding file tree
  * @property {string[]} parent an array of zero or more SHA-1 object ids
+ * @property {[string | null, string | null, string][]} [changes] Changed files as `[newOid, oldOid, filepath]`; present when `log` is called with `includeChanges: true`.
  * @property {Object} author
  * @property {string} author.name The author's name
  * @property {string} author.email The author's email

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -7,7 +7,7 @@ import './typedefs-http.js'
  * @property {string} message Commit message
  * @property {string} tree SHA-1 object id of corresponding file tree
  * @property {string[]} parent an array of zero or more SHA-1 object ids
- * @property {[string | null, string | null, string][]} [changes] Changed files as `[newOid, oldOid, filepath]`; present when `log` is called with `includeChanges: true`.
+ * @property {Array.<Array.<string|null>>} [changes] Changed files as `[newOid, oldOid, filepath]`; present when `log` is called with `includeChanges: true`.
  * @property {Object} author
  * @property {string} author.name The author's name
  * @property {string} author.email The author's email


### PR DESCRIPTION
Fixes #1919.\n\nAdds the maintainer-proposed `includeChanges` option to `git.log()`. When enabled, each returned `commit` includes `changes` tuples in the form `[newOid, oldOid, filepath]`, comparing the commit against its first parent (or the empty tree for an initial commit). Added and removed files use `null` for the missing oid.\n\nThis intentionally exposes object ids only; callers can pass the corresponding blob contents to any diff library they choose.\n\nTests:\n- `npx nps lint`\n- `node --experimental-vm-modules node_modules/jest/bin/jest.js __tests__/test-log.js`\n- declaration build and TypeScript typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `includeChanges` option to commit history queries.
  * When enabled, each returned commit includes `commit.changes` as `[newOid, oldOid, filepath]` tuples for added, modified, and removed paths.
  * Supports edge cases like replacing a file with a directory and correctly reports changes at shallow-history boundaries.
* **Documentation**
  * Updated the commit object schema to describe the optional `changes` field and its tuple format.
* **Tests**
  * Expanded end-to-end, fixture-driven coverage for `includeChanges`, including shallow boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->