### PR TITLE
fix: exclude git system files when expanding a ref

### DIFF
--- a/__tests__/test-GitRefManager-in-submodule.js
+++ b/__tests__/test-GitRefManager-in-submodule.js
@@ -355,6 +355,110 @@ describe('GitRefManager', () => {
     expect(await fs.read(`${gitdirsmfullpath}/index`)).toEqual(before)
   })
 
+  it('updateRemoteRefs refuses a refspec that targets a git system file', async () => {
+    const { fs, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    const before = await fs.read(`${gitdirsmfullpath}/index`)
+    // The local side of a refspec is whatever the config says, so a remote
+    // cannot be trusted to translate only into refs/.
+    let error = null
+    try {
+      await GitRefManager.updateRemoteRefs({
+        fs,
+        gitdir: gitdirsmfullpath,
+        remote: 'origin',
+        refs: new Map([
+          ['refs/heads/main', 'e10ebb90d03eaacca84de1af0a59b444232da99e'],
+        ]),
+        symrefs: new Map(),
+        tags: false,
+        refspecs: ['+refs/heads/main:index'],
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(await fs.read(`${gitdirsmfullpath}/index`)).toEqual(before)
+  })
+
+  it('updateRemoteRefs rejects a bad refspec before pruneTags deletes anything', async () => {
+    const { fs, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    const oid = 'e10ebb90d03eaacca84de1af0a59b444232da99e'
+    // pruneTags clears refs/tags before the write loop runs, so a refspec that
+    // is refused later takes the tags down with it. The fetch cannot put them
+    // back: it throws before writing anything.
+    let error = null
+    try {
+      await GitRefManager.updateRemoteRefs({
+        fs,
+        gitdir: gitdirsmfullpath,
+        remote: 'origin',
+        refs: new Map([
+          ['refs/heads/main', oid],
+          ['refs/tags/v1.0.0', oid],
+        ]),
+        symrefs: new Map(),
+        tags: true,
+        refspecs: ['+refs/heads/main:index'],
+        pruneTags: true,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(
+      await GitRefManager.resolve({
+        fs,
+        gitdir: gitdirsmfullpath,
+        ref: 'refs/tags/v1.0.0',
+      })
+    ).toEqual(oid)
+  })
+
+  it('updateRemoteRefs rejects a bad refspec before prune deletes anything', async () => {
+    const { fs, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    const oid = 'e10ebb90d03eaacca84de1af0a59b444232da99e'
+    await GitRefManager.writeRef({
+      fs,
+      gitdir: gitdirsmfullpath,
+      ref: 'refs/remotes/origin/stale',
+      value: oid,
+    })
+    // Same hazard on the prune path: a ref the remote no longer advertises is
+    // deleted before the refspec that targets `.git/index` is refused.
+    let error = null
+    try {
+      await GitRefManager.updateRemoteRefs({
+        fs,
+        gitdir: gitdirsmfullpath,
+        remote: 'origin',
+        refs: new Map([['refs/heads/main', oid]]),
+        symrefs: new Map(),
+        tags: false,
+        refspecs: [
+          '+refs/heads/*:refs/remotes/origin/*',
+          '+refs/heads/main:index',
+        ],
+        prune: true,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(
+      await GitRefManager.resolve({
+        fs,
+        gitdir: gitdirsmfullpath,
+        ref: 'refs/remotes/origin/stale',
+      })
+    ).toEqual(oid)
+  })
+
   it('expand does not return a git system file', async () => {
     const { fs, gitdirsmfullpath } =
       await makeFixtureAsSubmodule('test-checkout')

--- a/__tests__/test-GitRefManager-in-submodule.js
+++ b/__tests__/test-GitRefManager-in-submodule.js
@@ -308,6 +308,32 @@ describe('GitRefManager', () => {
     await Promise.all(writePromises)
   })
 
+  it('writeRef refuses to write over a git system file', async () => {
+    const { fs, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    const oid = 'e10ebb90d03eaacca84de1af0a59b444232da99e'
+    const before = await fs.read(`${gitdirsmfullpath}/index`)
+    // `.git/index` is not a ref, and its bare name is a legal one-level ref
+    // name, so an unguarded write lands on the staging area and destroys it.
+    // Canonical git refuses: "cannot lock ref 'index': reference broken".
+    for (const ref of ['config', 'index', 'shallow']) {
+      let error = null
+      try {
+        await GitRefManager.writeRef({
+          fs,
+          gitdir: gitdirsmfullpath,
+          ref,
+          value: oid,
+        })
+      } catch (err) {
+        error = err
+      }
+      expect(error).not.toBeNull()
+      expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    }
+    expect(await fs.read(`${gitdirsmfullpath}/index`)).toEqual(before)
+  })
+
   it('expand does not return a git system file', async () => {
     const { fs, gitdirsmfullpath } =
       await makeFixtureAsSubmodule('test-checkout')

--- a/__tests__/test-GitRefManager-in-submodule.js
+++ b/__tests__/test-GitRefManager-in-submodule.js
@@ -334,6 +334,27 @@ describe('GitRefManager', () => {
     expect(await fs.read(`${gitdirsmfullpath}/index`)).toEqual(before)
   })
 
+  it('deleteRefs refuses to delete a git system file', async () => {
+    const { fs, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    const before = await fs.read(`${gitdirsmfullpath}/index`)
+    // deleteRefs goes straight to fs.rm, so an unguarded call removes the
+    // staging area outright rather than merely overwriting it.
+    let error = null
+    try {
+      await GitRefManager.deleteRefs({
+        fs,
+        gitdir: gitdirsmfullpath,
+        refs: ['index'],
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(await fs.read(`${gitdirsmfullpath}/index`)).toEqual(before)
+  })
+
   it('expand does not return a git system file', async () => {
     const { fs, gitdirsmfullpath } =
       await makeFixtureAsSubmodule('test-checkout')

--- a/__tests__/test-GitRefManager-in-submodule.js
+++ b/__tests__/test-GitRefManager-in-submodule.js
@@ -1,5 +1,5 @@
 /* eslint-env node, browser, jasmine */
-import { Errors } from 'isomorphic-git'
+import { Errors, branch } from 'isomorphic-git'
 import { GitRefManager } from 'isomorphic-git/internal-apis'
 
 import { makeFixtureAsSubmodule } from './__helpers__/FixtureFSSubmodule.js'
@@ -475,5 +475,45 @@ describe('GitRefManager', () => {
       expect(error).not.toBeNull()
       expect(error.code).toBe(Errors.NotFoundError.code)
     }
+  })
+
+  it('expand still resolves a branch named after a git system file', async () => {
+    const { fs, dir, gitdir, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    await branch({ fs, dir, gitdir, ref: 'config', checkout: false })
+    const oid = await GitRefManager.resolve({
+      fs,
+      gitdir: gitdirsmfullpath,
+      ref: 'refs/heads/config',
+    })
+    // The filter must drop only the *bare* `config` candidate (which would land
+    // on `.git/config`), never the `refs/heads/config` one. A branch legally
+    // named after a git system file therefore stays fully resolvable.
+    expect(
+      await GitRefManager.expand({
+        fs,
+        gitdir: gitdirsmfullpath,
+        ref: 'config',
+      })
+    ).toEqual('refs/heads/config')
+    // A fully-qualified nested ref whose leaf matches a system-file name is
+    // never a candidate for filtering.
+    expect(
+      await GitRefManager.expand({
+        fs,
+        gitdir: gitdirsmfullpath,
+        ref: 'refs/heads/config',
+      })
+    ).toEqual('refs/heads/config')
+    // resolve() carries the same filter line, so verify its positive path too:
+    // the short name must resolve to the branch oid, not try to parse
+    // `.git/config` as a ref.
+    expect(
+      await GitRefManager.resolve({
+        fs,
+        gitdir: gitdirsmfullpath,
+        ref: 'config',
+      })
+    ).toEqual(oid)
   })
 })

--- a/__tests__/test-GitRefManager-in-submodule.js
+++ b/__tests__/test-GitRefManager-in-submodule.js
@@ -1,4 +1,5 @@
 /* eslint-env node, browser, jasmine */
+import { Errors } from 'isomorphic-git'
 import { GitRefManager } from 'isomorphic-git/internal-apis'
 
 import { makeFixtureAsSubmodule } from './__helpers__/FixtureFSSubmodule.js'
@@ -305,5 +306,23 @@ describe('GitRefManager', () => {
       expect(resolvedRef).toMatch(value)
     }
     await Promise.all(writePromises)
+  })
+
+  it('expand does not return a git system file', async () => {
+    const { fs, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    // The first refpath candidate is the bare name, so a lookup that does not
+    // filter finds `.git/config`, `.git/index` and `.git/shallow` on disk. Those
+    // are repository files, not refs. `resolve` already excludes them (#709).
+    for (const ref of ['config', 'index', 'shallow']) {
+      let error = null
+      try {
+        await GitRefManager.expand({ fs, gitdir: gitdirsmfullpath, ref })
+      } catch (err) {
+        error = err
+      }
+      expect(error).not.toBeNull()
+      expect(error.code).toBe(Errors.NotFoundError.code)
+    }
   })
 })

--- a/__tests__/test-GitRefManager.js
+++ b/__tests__/test-GitRefManager.js
@@ -346,6 +346,77 @@ describe('GitRefManager', () => {
     expect(await fs.read(`${gitdir}/index`)).toEqual(before)
   })
 
+  it('updateRemoteRefs rejects a bad refspec before pruneTags deletes anything', async () => {
+    const { fs, gitdir } = await makeFixture('test-checkout')
+    const oid = 'e10ebb90d03eaacca84de1af0a59b444232da99e'
+    // pruneTags clears refs/tags before the write loop runs, so a refspec that
+    // is refused later takes the tags down with it. The fetch cannot put them
+    // back: it throws before writing anything.
+    let error = null
+    try {
+      await GitRefManager.updateRemoteRefs({
+        fs,
+        gitdir,
+        remote: 'origin',
+        refs: new Map([
+          ['refs/heads/main', oid],
+          ['refs/tags/v1.0.0', oid],
+        ]),
+        symrefs: new Map(),
+        tags: true,
+        refspecs: ['+refs/heads/main:index'],
+        pruneTags: true,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(
+      await GitRefManager.resolve({ fs, gitdir, ref: 'refs/tags/v1.0.0' })
+    ).toEqual(oid)
+  })
+
+  it('updateRemoteRefs rejects a bad refspec before prune deletes anything', async () => {
+    const { fs, gitdir } = await makeFixture('test-checkout')
+    const oid = 'e10ebb90d03eaacca84de1af0a59b444232da99e'
+    await GitRefManager.writeRef({
+      fs,
+      gitdir,
+      ref: 'refs/remotes/origin/stale',
+      value: oid,
+    })
+    // Same hazard on the prune path: a ref the remote no longer advertises is
+    // deleted before the refspec that targets `.git/index` is refused.
+    let error = null
+    try {
+      await GitRefManager.updateRemoteRefs({
+        fs,
+        gitdir,
+        remote: 'origin',
+        refs: new Map([['refs/heads/main', oid]]),
+        symrefs: new Map(),
+        tags: false,
+        refspecs: [
+          '+refs/heads/*:refs/remotes/origin/*',
+          '+refs/heads/main:index',
+        ],
+        prune: true,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(
+      await GitRefManager.resolve({
+        fs,
+        gitdir,
+        ref: 'refs/remotes/origin/stale',
+      })
+    ).toEqual(oid)
+  })
+
   it('expand does not return a git system file', async () => {
     const { fs, gitdir } = await makeFixture('test-checkout')
     // The first refpath candidate is the bare name, so a lookup that does not

--- a/__tests__/test-GitRefManager.js
+++ b/__tests__/test-GitRefManager.js
@@ -1,5 +1,5 @@
 /* eslint-env node, browser, jasmine */
-import { Errors } from 'isomorphic-git'
+import { Errors, branch } from 'isomorphic-git'
 import { GitRefManager } from 'isomorphic-git/internal-apis'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
@@ -361,5 +361,32 @@ describe('GitRefManager', () => {
       expect(error).not.toBeNull()
       expect(error.code).toBe(Errors.NotFoundError.code)
     }
+  })
+
+  it('expand still resolves a branch named after a git system file', async () => {
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    await branch({ fs, dir, gitdir, ref: 'config', checkout: false })
+    const oid = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: 'refs/heads/config',
+    })
+    // The filter must drop only the *bare* `config` candidate (which would land
+    // on `.git/config`), never the `refs/heads/config` one. A branch legally
+    // named after a git system file therefore stays fully resolvable.
+    expect(await GitRefManager.expand({ fs, gitdir, ref: 'config' })).toEqual(
+      'refs/heads/config'
+    )
+    // A fully-qualified nested ref whose leaf matches a system-file name is
+    // never a candidate for filtering.
+    expect(
+      await GitRefManager.expand({ fs, gitdir, ref: 'refs/heads/config' })
+    ).toEqual('refs/heads/config')
+    // resolve() carries the same filter line, so verify its positive path too:
+    // the short name must resolve to the branch oid, not try to parse
+    // `.git/config` as a ref.
+    expect(await GitRefManager.resolve({ fs, gitdir, ref: 'config' })).toEqual(
+      oid
+    )
   })
 })

--- a/__tests__/test-GitRefManager.js
+++ b/__tests__/test-GitRefManager.js
@@ -284,6 +284,26 @@ describe('GitRefManager', () => {
     await Promise.all(writePromises)
   })
 
+  it('writeRef refuses to write over a git system file', async () => {
+    const { fs, gitdir } = await makeFixture('test-checkout')
+    const oid = 'e10ebb90d03eaacca84de1af0a59b444232da99e'
+    const before = await fs.read(`${gitdir}/index`)
+    // `.git/index` is not a ref, and its bare name is a legal one-level ref
+    // name, so an unguarded write lands on the staging area and destroys it.
+    // Canonical git refuses: "cannot lock ref 'index': reference broken".
+    for (const ref of ['config', 'index', 'shallow']) {
+      let error = null
+      try {
+        await GitRefManager.writeRef({ fs, gitdir, ref, value: oid })
+      } catch (err) {
+        error = err
+      }
+      expect(error).not.toBeNull()
+      expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    }
+    expect(await fs.read(`${gitdir}/index`)).toEqual(before)
+  })
+
   it('expand does not return a git system file', async () => {
     const { fs, gitdir } = await makeFixture('test-checkout')
     // The first refpath candidate is the bare name, so a lookup that does not

--- a/__tests__/test-GitRefManager.js
+++ b/__tests__/test-GitRefManager.js
@@ -1,4 +1,5 @@
 /* eslint-env node, browser, jasmine */
+import { Errors } from 'isomorphic-git'
 import { GitRefManager } from 'isomorphic-git/internal-apis'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
@@ -281,5 +282,22 @@ describe('GitRefManager', () => {
       expect(resolvedRef).toMatch(value)
     }
     await Promise.all(writePromises)
+  })
+
+  it('expand does not return a git system file', async () => {
+    const { fs, gitdir } = await makeFixture('test-checkout')
+    // The first refpath candidate is the bare name, so a lookup that does not
+    // filter finds `.git/config`, `.git/index` and `.git/shallow` on disk. Those are
+    // repository files, not refs. `resolve` already excludes them (#709).
+    for (const ref of ['config', 'index', 'shallow']) {
+      let error = null
+      try {
+        await GitRefManager.expand({ fs, gitdir, ref })
+      } catch (err) {
+        error = err
+      }
+      expect(error).not.toBeNull()
+      expect(error.code).toBe(Errors.NotFoundError.code)
+    }
   })
 })

--- a/__tests__/test-GitRefManager.js
+++ b/__tests__/test-GitRefManager.js
@@ -304,6 +304,48 @@ describe('GitRefManager', () => {
     expect(await fs.read(`${gitdir}/index`)).toEqual(before)
   })
 
+  it('deleteRefs refuses to delete a git system file', async () => {
+    const { fs, gitdir } = await makeFixture('test-checkout')
+    const before = await fs.read(`${gitdir}/index`)
+    // deleteRefs goes straight to fs.rm, so an unguarded call removes the
+    // staging area outright rather than merely overwriting it.
+    let error = null
+    try {
+      await GitRefManager.deleteRefs({ fs, gitdir, refs: ['index'] })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(await fs.read(`${gitdir}/index`)).toEqual(before)
+  })
+
+  it('updateRemoteRefs refuses a refspec that targets a git system file', async () => {
+    const { fs, gitdir } = await makeFixture('test-checkout')
+    const before = await fs.read(`${gitdir}/index`)
+    // The local side of a refspec is whatever the config says, so a remote
+    // cannot be trusted to translate only into refs/.
+    let error = null
+    try {
+      await GitRefManager.updateRemoteRefs({
+        fs,
+        gitdir,
+        remote: 'origin',
+        refs: new Map([
+          ['refs/heads/main', 'e10ebb90d03eaacca84de1af0a59b444232da99e'],
+        ]),
+        symrefs: new Map(),
+        tags: false,
+        refspecs: ['+refs/heads/main:index'],
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error.code).toBe(Errors.InvalidRefNameError.code)
+    expect(await fs.read(`${gitdir}/index`)).toEqual(before)
+  })
+
   it('expand does not return a git system file', async () => {
     const { fs, gitdir } = await makeFixture('test-checkout')
     // The first refpath candidate is the bare name, so a lookup that does not

--- a/__tests__/test-checkout-in-submodule.js
+++ b/__tests__/test-checkout-in-submodule.js
@@ -1,6 +1,9 @@
+import * as path from 'path'
+
 import {
   Errors,
   checkout,
+  currentBranch,
   listFiles,
   add,
   commit,
@@ -738,5 +741,22 @@ describe('checkout', () => {
     const files = await fs.readdir(`${dir}/ignored`)
     expect(files).toContain('regular-file.txt')
     expect(files).not.toContain('.gitignore')
+  })
+
+  it('checkout a branch named after a git system file keeps HEAD attached', async () => {
+    // Setup
+    const { fs, dir, gitdir, gitdirsmfullpath } =
+      await makeFixtureAsSubmodule('test-checkout')
+    await branch({ fs, dir, gitdir, ref: 'index', checkout: false })
+    // Test
+    await checkout({ fs, dir, gitdir, ref: 'index' })
+    // Every repository has a `.git/index`, and checkout asks GitRefManager to
+    // expand the ref before deciding whether it is a branch. When the expansion
+    // returns the index file instead of refs/heads/index, checkout concludes it
+    // is not a branch and detaches HEAD, so later commits belong to no branch.
+    expect(await currentBranch({ fs, dir, gitdir })).toEqual('index')
+    expect(await fs.read(path.join(gitdirsmfullpath, 'HEAD'), 'utf8')).toEqual(
+      'ref: refs/heads/index\n'
+    )
   })
 })

--- a/__tests__/test-checkout.js
+++ b/__tests__/test-checkout.js
@@ -1,6 +1,9 @@
+import * as path from 'path'
+
 import {
   Errors,
   checkout,
+  currentBranch,
   listFiles,
   add,
   commit,
@@ -729,5 +732,21 @@ describe('checkout', () => {
     const files = await fs.readdir(`${dir}/ignored`)
     expect(files).toContain('regular-file.txt')
     expect(files).not.toContain('.gitignore')
+  })
+
+  it('checkout a branch named after a git system file keeps HEAD attached', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    await branch({ fs, dir, gitdir, ref: 'index', checkout: false })
+    // Test
+    await checkout({ fs, dir, gitdir, ref: 'index' })
+    // Every repository has a `.git/index`, and checkout asks GitRefManager to
+    // expand the ref before deciding whether it is a branch. When the expansion
+    // returns the index file instead of refs/heads/index, checkout concludes it
+    // is not a branch and detaches HEAD, so later commits belong to no branch.
+    expect(await currentBranch({ fs, dir, gitdir })).toEqual('index')
+    expect(await fs.read(path.join(gitdir, 'HEAD'), 'utf8')).toEqual(
+      'ref: refs/heads/index\n'
+    )
   })
 })

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -5,6 +5,7 @@ import AsyncLock from 'async-lock'
 
 import { InternalError } from '../errors/InternalError.js'
 import { InvalidOidError } from '../errors/InvalidOidError.js'
+import { InvalidRefNameError } from '../errors/InvalidRefNameError.js'
 import { NoRefspecError } from '../errors/NoRefspecError.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
 import { GitPackedRefs } from '../models/GitPackedRefs.js'
@@ -26,6 +27,16 @@ const refpaths = ref => [
 
 // @see https://git-scm.com/docs/gitrepository-layout
 const GIT_FILES = ['config', 'description', 'index', 'shallow', 'commondir']
+
+// These names are legal one-level ref names, so nothing upstream of here
+// rejects them, and writing to one lands on the repository file itself.
+// Canonical git refuses too: `git update-ref index <oid>` fails with
+// "cannot lock ref 'index': reference broken" and leaves the file alone.
+function assertWritableRef(ref) {
+  if (GIT_FILES.includes(ref)) {
+    throw new InvalidRefNameError(ref, `refs/heads/${ref}`)
+  }
+}
 
 let lock
 
@@ -178,6 +189,7 @@ export class GitRefManager {
   // TODO: make this less crude?
   static async writeRef({ fs, gitdir, ref, value }) {
     // Validate input
+    assertWritableRef(ref)
     if (!value.match(/[0-9a-f]{40}/)) {
       throw new InvalidOidError(value)
     }
@@ -197,6 +209,7 @@ export class GitRefManager {
    * @returns {Promise<void>}
    */
   static async writeSymbolicRef({ fs, gitdir, ref, value }) {
+    assertWritableRef(ref)
     await acquireLock(ref, async () =>
       fs.write(join(gitdir, ref), 'ref: ' + `${value.trim()}\n`, 'utf8')
     )

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -348,7 +348,7 @@ export class GitRefManager {
     // We need to alternate between the file system and the packed-refs
     const packedMap = await GitRefManager.packedRefs({ fs, gitdir })
     // Look in all the proper paths, in this order
-    const allpaths = refpaths(ref)
+    const allpaths = refpaths(ref).filter(p => !GIT_FILES.includes(p)) // exclude git system files (#709)
     for (const ref of allpaths) {
       const refExists = await acquireLock(ref, async () =>
         fs.exists(`${gitdir}/${ref}`)

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -92,6 +92,31 @@ export class GitRefManager {
     }
     const refspec = GitRefSpecSet.from(refspecs)
     const actualRefsToWrite = new Map()
+    // Work out every destination this call will write, before touching the
+    // repository. Translating is pure, so it can happen up here; the writes
+    // themselves stay at the end of the function.
+    const refTranslations = refspec.translate([...refs.keys()])
+    const symrefTranslations = []
+    for (const [serverRef, translatedRef] of refspec.translate([
+      ...symrefs.keys(),
+    ])) {
+      const symtarget = refspec.translateOne(symrefs.get(serverRef))
+      if (symtarget) {
+        symrefTranslations.push([translatedRef, `ref: ${symtarget}`])
+      }
+    }
+    // The local side of a refspec is whatever `remote.<name>.fetch` says, so a
+    // config like `+refs/heads/main:index` lands a write on `.git/index`.
+    // Refuse it here rather than at the write loop: `pruneTags` and `prune`
+    // delete refs in between, so a later throw leaves the repository pruned
+    // and not updated. The tags added below are always `refs/tags/...`, which
+    // is never a system file, so nothing is missed by checking this early.
+    for (const [, translatedRef] of refTranslations) {
+      assertWritableRef(translatedRef)
+    }
+    for (const [translatedRef] of symrefTranslations) {
+      assertWritableRef(translatedRef)
+    }
     // Delete all current tags if the pruneTags argument is true.
     if (pruneTags) {
       const tags = await GitRefManager.listRefs({
@@ -119,18 +144,12 @@ export class GitRefManager {
       }
     }
     // Combine refs and symrefs giving symrefs priority
-    const refTranslations = refspec.translate([...refs.keys()])
     for (const [serverRef, translatedRef] of refTranslations) {
       const value = refs.get(serverRef)
       actualRefsToWrite.set(translatedRef, value)
     }
-    const symrefTranslations = refspec.translate([...symrefs.keys()])
-    for (const [serverRef, translatedRef] of symrefTranslations) {
-      const value = symrefs.get(serverRef)
-      const symtarget = refspec.translateOne(value)
-      if (symtarget) {
-        actualRefsToWrite.set(translatedRef, `ref: ${symtarget}`)
-      }
+    for (const [translatedRef, value] of symrefTranslations) {
+      actualRefsToWrite.set(translatedRef, value)
     }
     // If `prune` argument is true, clear out the existing local refspec roots
     const pruned = []
@@ -168,11 +187,6 @@ export class GitRefManager {
     // Examples of refs we need to avoid writing in loose format for efficieny's sake
     // are .git/refs/remotes/origin/refs/remotes/remote_mirror_3059
     // and .git/refs/remotes/origin/refs/merge-requests
-    // The local side of a refspec is whatever `remote.<name>.fetch` says, so a
-    // config like `+refs/heads/main:index` lands a write on `.git/index`.
-    for (const key of actualRefsToWrite.keys()) {
-      assertWritableRef(key)
-    }
     for (const [key, value] of actualRefsToWrite) {
       await acquireLock(key, async () =>
         fs.write(join(gitdir, key), `${value.trim()}\n`, 'utf8')

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -168,6 +168,11 @@ export class GitRefManager {
     // Examples of refs we need to avoid writing in loose format for efficieny's sake
     // are .git/refs/remotes/origin/refs/remotes/remote_mirror_3059
     // and .git/refs/remotes/origin/refs/merge-requests
+    // The local side of a refspec is whatever `remote.<name>.fetch` says, so a
+    // config like `+refs/heads/main:index` lands a write on `.git/index`.
+    for (const key of actualRefsToWrite.keys()) {
+      assertWritableRef(key)
+    }
     for (const [key, value] of actualRefsToWrite) {
       await acquireLock(key, async () =>
         fs.write(join(gitdir, key), `${value.trim()}\n`, 'utf8')
@@ -238,6 +243,8 @@ export class GitRefManager {
    * @returns {Promise<void>}
    */
   static async deleteRefs({ fs, gitdir, refs }) {
+    // Validate input
+    refs.forEach(assertWritableRef)
     // Delete regular ref
     await Promise.all(refs.map(ref => fs.rm(join(gitdir, ref))))
     // Delete any packed ref


### PR DESCRIPTION
Fixes #767.

## I'm fixing a bug

`GitRefManager.resolve` filters the git system files out of its refpath candidates. `expand` does not:

```js
// resolve
const allpaths = refpaths(ref).filter(p => !GIT_FILES.includes(p)) // exclude git system files (#709)

// expand
const allpaths = refpaths(ref)
```

The first candidate `refpaths` produces is the bare name, so `expand({ ref: 'index' })` calls `fs.exists('.git/index')`, finds the index file, and returns `'index'`. Same for `config`, `shallow`, `description` and `commondir`. None of them are refs.

## Why it matters beyond a wrong return value

`checkout` uses `expand` to decide whether the ref names a branch:

```js
const fullRef = await GitRefManager.expand({ fs, gitdir, ref })
if (fullRef.startsWith('refs/heads')) {
  await GitRefManager.writeSymbolicRef({ fs, gitdir, ref: 'HEAD', value: fullRef })
} else {
  // detached head
  await GitRefManager.writeRef({ fs, gitdir, ref: 'HEAD', value: oid })
}
```

`'index'` does not start with `refs/heads`, so checking out a branch called `index` writes a detached HEAD. No error is raised. Commits made afterwards belong to no branch, which is what the reporter saw as `currentBranch()` returning `undefined`.

Reproduced on a fresh repository:

```
HEAD                : 13f4eb0828efbe457d544ee30dfda75eb27e0d75   <- detached
refs/heads/index    : exists
currentBranch       : undefined
expandRef("index")  : index
expandRef("config") : config
```

After the fix:

```
HEAD                : ref: refs/heads/index
currentBranch       : index
expandRef("index")  : refs/heads/index
expandRef("config") : throws NotFoundError
```

## The fix

One line, applying to `expand` the filter `resolve` already has. I left `expandAgainstMap` and `resolveAgainstMap` alone: they look names up in a map of refs, where a repository file can never be a key.

`deleteBranch` is unaffected too, since it normalises to `refs/heads/` before expanding.

## Tests

Two tests, following the checklist in Appendix A of CONTRIBUTING, so each one has a plain and an `-in-submodule` variant:

- `test-GitRefManager.js`: `expand` throws `NotFoundError` for `config`, `index` and `shallow`.
- `test-checkout.js`: checking out a branch named `index` leaves HEAD pointing at `refs/heads/index`.

They are in the first commit and the fix is in the second, so the tests can be watched going from failing to passing.

| | Result |
|---|---|
| First commit only | 4 failed |
| With the fix | 4 passed |

Full suite on Node, before and after:

| | Failures |
|---|---|
| Before the fix | 16 |
| After the fix | 14 |

The difference is exactly these four tests. The 14 that remain fail identically on both sides and are unrelated to refs: five symlink tests, one `autocrlf` test, `clone > should set up the remote tracking branch by default`, and a few others. They are environmental on my machine.

## What I did not verify

I ran the Node suite on Windows 11, not the Chrome or Firefox browser suites. The 14 pre-existing failures listed above are almost certainly the Windows symlink restriction rather than anything about this repository, but I have not confirmed that on Linux, so I am reporting the counts as measured rather than calling the suite green.

I have not run `npm run add-contributor`. Happy to add the entry in this PR if you would rather it landed together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Git system files such as `config`, `index`, and `shallow` from being overwritten, deleted, or treated as bare references.
  * Preserved support for valid branches named after system files, including correct checkout and attached `HEAD` behavior.
  * Ensured invalid reference updates are rejected before repository changes or pruning occur.
  * Added regression coverage for standard repositories and submodules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->