### PR TITLE
fix: apply .gitignore only to files that are not tracked

### DIFF
--- a/__tests__/test-add-in-submodule.js
+++ b/__tests__/test-add-in-submodule.js
@@ -275,4 +275,31 @@ describe('add', () => {
       'added'
     )
   })
+
+  it('ignored file that is already tracked', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-add')
+    await init({ fs, dir, gitdir })
+    // Track the file before it becomes ignored. That is how a file ends up
+    // tracked and ignored at the same time in a real repository.
+    await add({ fs, dir, gitdir, filepath: 'i.txt' })
+    await writeGitIgnore(fs, dir)
+    await fs.write(dir + '/i.txt', 'changed after being ignored')
+    // Test
+    await add({ fs, dir, gitdir, filepath: 'i.txt' })
+    // .gitignore applies to untracked files only, so canonical git stages this
+    // change instead of silently doing nothing.
+    const staged = await walk({
+      fs,
+      dir,
+      gitdir,
+      trees: [STAGE()],
+      map: async (filepath, [stage]) =>
+        filepath === 'i.txt' && stage ? stage.oid() : undefined,
+    })
+    const { blob } = await readBlob({ fs, dir, gitdir, oid: staged[0] })
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
+      'changed after being ignored'
+    )
+  })
 })

--- a/__tests__/test-add-in-submodule.js
+++ b/__tests__/test-add-in-submodule.js
@@ -174,6 +174,35 @@ describe('add', () => {
     await add({ fs, dir, filepath: 'i.txt', force: true })
     expect((await listFiles({ fs, dir })).length).toEqual(1)
   })
+  it('tracked file inside an ignored folder', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-add')
+    await init({ fs, dir, gitdir })
+    // Track one file inside the folder before the folder becomes ignored.
+    await add({ fs, dir, gitdir, filepath: 'js_modules/awesome/index.js' })
+    await writeGitIgnore(fs, dir)
+    await fs.write(dir + '/js_modules/awesome/index.js', 'changed')
+    await fs.write(dir + '/js_modules/untracked.js', 'never staged')
+    // Test
+    await add({ fs, dir, gitdir, filepath: '.' })
+    // Canonical git recurses into an ignored folder for the sake of the paths
+    // it already tracks, and stages those while leaving the rest alone.
+    const staged = await walk({
+      fs,
+      dir,
+      gitdir,
+      trees: [STAGE()],
+      map: async (filepath, [stage]) =>
+        filepath === 'js_modules/awesome/index.js' && stage
+          ? stage.oid()
+          : undefined,
+    })
+    const { blob } = await readBlob({ fs, dir, gitdir, oid: staged[0] })
+    expect(Buffer.from(blob).toString('utf8')).toEqual('changed')
+    expect(await listFiles({ fs, dir, gitdir })).not.toContain(
+      'js_modules/untracked.js'
+    )
+  })
   it('non-existant file', async () => {
     // Setup
     const { fs, dir } = await makeFixtureAsSubmodule('test-add')

--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -174,6 +174,31 @@ describe('add', () => {
     await add({ fs, dir, filepath: 'i.txt', force: true })
     expect((await listFiles({ fs, dir })).length).toEqual(1)
   })
+  it('ignored file that is already tracked', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    await init({ fs, dir })
+    // Track the file before it becomes ignored. That is how a file ends up
+    // tracked and ignored at the same time in a real repository.
+    await add({ fs, dir, filepath: 'i.txt' })
+    await writeGitIgnore(fs, dir)
+    await fs.write(dir + '/i.txt', 'changed after being ignored')
+    // Test
+    await add({ fs, dir, filepath: 'i.txt' })
+    // .gitignore applies to untracked files only, so canonical git stages this
+    // change instead of silently doing nothing.
+    const staged = await walk({
+      fs,
+      dir,
+      trees: [STAGE()],
+      map: async (filepath, [stage]) =>
+        filepath === 'i.txt' && stage ? stage.oid() : undefined,
+    })
+    const { blob } = await readBlob({ fs, dir, oid: staged[0] })
+    expect(Buffer.from(blob).toString('utf8')).toEqual(
+      'changed after being ignored'
+    )
+  })
   it('non-existant file', async () => {
     // Setup
     const { fs, dir } = await makeFixture('test-add')

--- a/__tests__/test-add.js
+++ b/__tests__/test-add.js
@@ -199,6 +199,34 @@ describe('add', () => {
       'changed after being ignored'
     )
   })
+  it('tracked file inside an ignored folder', async () => {
+    // Setup
+    const { fs, dir } = await makeFixture('test-add')
+    await init({ fs, dir })
+    // Track one file inside the folder before the folder becomes ignored.
+    await add({ fs, dir, filepath: 'js_modules/awesome/index.js' })
+    await writeGitIgnore(fs, dir)
+    await fs.write(dir + '/js_modules/awesome/index.js', 'changed')
+    await fs.write(dir + '/js_modules/untracked.js', 'never staged')
+    // Test
+    await add({ fs, dir, filepath: '.' })
+    // Canonical git recurses into an ignored folder for the sake of the paths
+    // it already tracks, and stages those while leaving the rest alone.
+    const staged = await walk({
+      fs,
+      dir,
+      trees: [STAGE()],
+      map: async (filepath, [stage]) =>
+        filepath === 'js_modules/awesome/index.js' && stage
+          ? stage.oid()
+          : undefined,
+    })
+    const { blob } = await readBlob({ fs, dir, oid: staged[0] })
+    expect(Buffer.from(blob).toString('utf8')).toEqual('changed')
+    expect(await listFiles({ fs, dir })).not.toContain(
+      'js_modules/untracked.js'
+    )
+  })
   it('non-existant file', async () => {
     // Setup
     const { fs, dir } = await makeFixture('test-add')

--- a/__tests__/test-status-in-submodule.js
+++ b/__tests__/test-status-in-submodule.js
@@ -1,7 +1,7 @@
 /* eslint-env node, browser, jasmine */
 import * as path from 'path'
 
-import { status, add, remove } from 'isomorphic-git'
+import { status, add, init, remove } from 'isomorphic-git'
 
 import { makeFixtureAsSubmodule } from './__helpers__/FixtureFSSubmodule.js'
 
@@ -99,5 +99,21 @@ describe('status', () => {
     expect(a).toEqual('unmodified')
     const indexAfter = await fs.read(path.join(gitdir, 'index'))
     expect(indexAfter).toEqual(indexBefore)
+  })
+
+  it('tracked file that matches a .gitignore rule', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-add')
+    await init({ fs, dir, gitdir })
+    // Track the file before it becomes ignored, then change it on disk.
+    await add({ fs, dir, gitdir, filepath: 'i.txt' })
+    await fs.write(path.join(dir, '.gitignore'), 'i.txt\n')
+    await fs.write(path.join(dir, 'i.txt'), 'changed after being ignored')
+    // Test
+    // .gitignore applies to untracked files only. canonical git reports this
+    // file as modified, and `git check-ignore` does not match it at all.
+    expect(await status({ fs, dir, gitdir, filepath: 'i.txt' })).toEqual(
+      '*added'
+    )
   })
 })

--- a/__tests__/test-status.js
+++ b/__tests__/test-status.js
@@ -1,7 +1,7 @@
 /* eslint-env node, browser, jasmine */
 import * as path from 'path'
 
-import { status, add, remove } from 'isomorphic-git'
+import { status, add, init, remove } from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
 
@@ -99,5 +99,21 @@ describe('status', () => {
     expect(a).toEqual('unmodified')
     const indexAfter = await fs.read(path.join(gitdir, 'index'))
     expect(indexAfter).toEqual(indexBefore)
+  })
+
+  it('tracked file that matches a .gitignore rule', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-add')
+    await init({ fs, dir, gitdir })
+    // Track the file before it becomes ignored, then change it on disk.
+    await add({ fs, dir, gitdir, filepath: 'i.txt' })
+    await fs.write(path.join(dir, '.gitignore'), 'i.txt\n')
+    await fs.write(path.join(dir, 'i.txt'), 'changed after being ignored')
+    // Test
+    // .gitignore applies to untracked files only. canonical git reports this
+    // file as modified, and `git check-ignore` does not match it at all.
+    expect(await status({ fs, dir, gitdir, filepath: 'i.txt' })).toEqual(
+      '*added'
+    )
   })
 })

--- a/src/api/add.js
+++ b/src/api/add.js
@@ -73,6 +73,18 @@ export async function add({
   }
 }
 
+// True for a path the index already holds, and for a folder holding one. The
+// exact lookup is a Map hit; the prefix scan only runs for folders, since a
+// tracked file always answers on the first check.
+function isTracked(index, filepath) {
+  if (index.has({ filepath })) return true
+  const prefix = `${filepath}/`
+  for (const entry of index.entriesMap.keys()) {
+    if (entry.startsWith(prefix)) return true
+  }
+  return false
+}
+
 async function addToIndex({
   dir,
   gitdir,
@@ -85,9 +97,11 @@ async function addToIndex({
 }) {
   filepath = Array.isArray(filepath) ? filepath : [filepath]
   const promises = filepath.map(async currentFilepath => {
-    // .gitignore governs untracked files. Once a file is in the index, adding a
-    // matching rule does not stop canonical git from staging further changes.
-    if (!force && !index.has({ filepath: currentFilepath })) {
+    // .gitignore governs untracked paths. Once a path is in the index, adding a
+    // matching rule does not stop canonical git from staging further changes,
+    // and an ignored folder is still walked for the sake of what it tracks:
+    // the recursion below re-checks every child, so only tracked ones get in.
+    if (!force && !isTracked(index, currentFilepath)) {
       const ignored = await GitIgnoreManager.isIgnored({
         fs,
         dir,

--- a/src/api/add.js
+++ b/src/api/add.js
@@ -83,10 +83,11 @@ async function addToIndex({
   parallel,
   autocrlf,
 }) {
-  // TODO: Should ignore UNLESS it's already in the index.
   filepath = Array.isArray(filepath) ? filepath : [filepath]
   const promises = filepath.map(async currentFilepath => {
-    if (!force) {
+    // .gitignore governs untracked files. Once a file is in the index, adding a
+    // matching rule does not stop canonical git from staging further changes.
+    if (!force && !index.has({ filepath: currentFilepath })) {
       const ignored = await GitIgnoreManager.isIgnored({
         fs,
         dir,

--- a/src/api/status.js
+++ b/src/api/status.js
@@ -69,15 +69,6 @@ export async function status({
 
     const fs = new FileSystem(_fs)
     const updatedGitdir = await discoverGitdir({ fsp: fs, dotgit: gitdir })
-    const ignored = await GitIgnoreManager.isIgnored({
-      fs,
-      gitdir: updatedGitdir,
-      dir,
-      filepath,
-    })
-    if (ignored) {
-      return 'ignored'
-    }
     const headTree = await getHeadTree({ fs, cache, gitdir: updatedGitdir })
     const treeOid = await getOidAtPath({
       fs,
@@ -95,6 +86,20 @@ export async function status({
         return null
       }
     )
+    // .gitignore governs untracked files. A file in HEAD or in the index is
+    // tracked, so canonical git keeps reporting its real state, and
+    // `git check-ignore` does not match it. statusMatrix already does this.
+    if (treeOid === null && indexEntry === null) {
+      const ignored = await GitIgnoreManager.isIgnored({
+        fs,
+        gitdir: updatedGitdir,
+        dir,
+        filepath,
+      })
+      if (ignored) {
+        return 'ignored'
+      }
+    }
     const stats = await fs.lstat(join(dir, filepath))
 
     const H = treeOid !== null // head


### PR DESCRIPTION
Fixes #765.

## I'm fixing a bug

`.gitignore` is a rule about untracked files. Once a path is in the index, canonical git keeps staging changes to it, keeps reporting its real state, and stops matching it with `check-ignore`:

```
$ git init -q . && echo x > f.txt && git add f.txt && git commit -qm i
$ echo "f.txt" > .gitignore && echo y >> f.txt

$ git status --short
 M f.txt

$ git add f.txt && git status --short
M  f.txt

$ git check-ignore -v f.txt
(no match)
```

isomorphic-git checks the ignore rules before it consults the index, in two places:

- `api/add.js` returns early, so the change is never staged and no error is raised.
- `api/status.js` runs `isIgnored` as its first statement, before it looks at HEAD or the index, and returns `'ignored'` for a tracked file.

`api/statusMatrix.js` already gets this right. Its guard is `if (!head && !stage && workdir)`, under the comment "Ignore ignored files, but only if they are not already tracked". And `api/add.js` carried the rule as a TODO:

```js
// TODO: Should ignore UNLESS it's already in the index.
```

So this is one rule the project has already decided on, implemented at one of the three call sites that need it.

## The fix

`add` consults the index it is already holding:

```diff
-  // TODO: Should ignore UNLESS it's already in the index.
   filepath = Array.isArray(filepath) ? filepath : [filepath]
   const promises = filepath.map(async currentFilepath => {
-    if (!force) {
+    if (!force && !index.has({ filepath: currentFilepath })) {
```

`status` moves its ignore check below the HEAD and index lookups and guards it the way `statusMatrix` does. Untracked ignored files return `'ignored'` exactly as before.

I did not touch `statusMatrix`, and I did not add a workdir condition to `status`. `statusMatrix` needs one because it walks the working directory; `status` is called with an explicit filepath, and adding it would change what an absent untracked ignored path returns, which is not what this issue is about.

## Tests

Four tests, each with the `-in-submodule` variant that Appendix A of CONTRIBUTING asks for:

- `test-add.js`: track `i.txt`, then ignore it, then change it on disk. `add` must stage the new content. The test reads the staged blob rather than asking `status`, so it does not depend on the second fix.
- `test-status.js`: same setup, `status` must return `*added` rather than `ignored`.

Tests are in the first commit and the fix is in the second, so they can be watched going from failing to passing.

| | Result |
|---|---|
| First commit only | 4 failed |
| With the fix | 44 passed across the 4 suites |

The control failures are the damage itself, not a proxy for it:

```
● add › ignored file that is already tracked
  Expected: "changed after being ignored"
  Received: "ignore me!"

● status › tracked file that matches a .gitignore rule
  Expected: "*added"
  Received: "ignored"
```

The staged blob still holds the pre-ignore content, which is the silent part: `add` resolves, no error is raised, and the change is gone.

Full suite on Node, before and after:

| | Failures |
|---|---|
| Before the fix | 18 |
| After the fix | 14 |

The difference is exactly these four. The 14 that remain fail identically on both sides and have nothing to do with ignore rules: five symlink tests, one `autocrlf` test, `clone > should set up the remote tracking branch by default`, and a few others.

## What I did not verify

I ran the Node suite on Windows 11, not the Chrome or Firefox suites. The 14 pre-existing failures are very likely the Windows symlink restriction, but I have not confirmed that on Linux, so I am reporting the counts as measured rather than calling the suite green.

I have not run `npm run add-contributor`. Happy to add the entry here if you would rather it landed in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tracked files that later match a `.gitignore` rule can now be staged when modified.
  * Status results now correctly report changes to tracked files, even when they are subsequently ignored.
* **Tests**
  * Added coverage for staging and status behavior in repositories and submodules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->