### PR TITLE
fix: honour core.autocrlf when status hashes the working copy

### DIFF
--- a/__tests__/test-status-in-submodule.js
+++ b/__tests__/test-status-in-submodule.js
@@ -139,8 +139,9 @@ describe('status', () => {
       message: 'initial',
       author: { name: 'Test', email: 'test@example.com' },
     })
-    // What a checkout under core.autocrlf=true leaves on a Windows disk: the
-    // blob is stored with LF and the working copy carries CRLF.
+    // The blob is stored with LF and the working copy carries CRLF. This
+    // library never writes CRLF, so on a real machine the working copy got
+    // that way from canonical git, an editor, or a syncing tool.
     await fs.write(path.join(dir, 'a.txt'), 'one\r\ntwo\r\n')
     // Test
     // status has to come first. statusMatrix refreshes the index stat cache,

--- a/__tests__/test-status-in-submodule.js
+++ b/__tests__/test-status-in-submodule.js
@@ -1,7 +1,15 @@
 /* eslint-env node, browser, jasmine */
 import * as path from 'path'
 
-import { status, add, init, remove } from 'isomorphic-git'
+import {
+  status,
+  add,
+  commit,
+  init,
+  remove,
+  setConfig,
+  statusMatrix,
+} from 'isomorphic-git'
 
 import { makeFixtureAsSubmodule } from './__helpers__/FixtureFSSubmodule.js'
 
@@ -115,5 +123,36 @@ describe('status', () => {
     expect(await status({ fs, dir, gitdir, filepath: 'i.txt' })).toEqual(
       '*added'
     )
+  })
+
+  it('honours core.autocrlf when hashing the working copy', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-empty')
+    await init({ fs, dir, gitdir })
+    await setConfig({ fs, dir, gitdir, path: 'core.autocrlf', value: true })
+    await fs.write(path.join(dir, 'a.txt'), 'one\ntwo\n')
+    await add({ fs, dir, gitdir, filepath: 'a.txt' })
+    await commit({
+      fs,
+      dir,
+      gitdir,
+      message: 'initial',
+      author: { name: 'Test', email: 'test@example.com' },
+    })
+    // What a checkout under core.autocrlf=true leaves on a Windows disk: the
+    // blob is stored with LF and the working copy carries CRLF.
+    await fs.write(path.join(dir, 'a.txt'), 'one\r\ntwo\r\n')
+    // Test
+    // status has to come first. statusMatrix refreshes the index stat cache,
+    // and once the cached stats match the CRLF file on disk, status returns the
+    // indexed oid without hashing anything, which hides the bug.
+    expect(await status({ fs, dir, gitdir, filepath: 'a.txt' })).toEqual(
+      'unmodified'
+    )
+    // GitWalkerFs already reads with the autocrlf option, so statusMatrix
+    // agrees the file is untouched either way.
+    expect(await statusMatrix({ fs, dir, gitdir })).toEqual([
+      ['a.txt', 1, 1, 1],
+    ])
   })
 })

--- a/__tests__/test-status.js
+++ b/__tests__/test-status.js
@@ -1,7 +1,15 @@
 /* eslint-env node, browser, jasmine */
 import * as path from 'path'
 
-import { status, add, init, remove } from 'isomorphic-git'
+import {
+  status,
+  add,
+  commit,
+  init,
+  remove,
+  setConfig,
+  statusMatrix,
+} from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
 
@@ -115,5 +123,36 @@ describe('status', () => {
     expect(await status({ fs, dir, gitdir, filepath: 'i.txt' })).toEqual(
       '*added'
     )
+  })
+
+  it('honours core.autocrlf when hashing the working copy', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-empty')
+    await init({ fs, dir, gitdir })
+    await setConfig({ fs, dir, gitdir, path: 'core.autocrlf', value: true })
+    await fs.write(path.join(dir, 'a.txt'), 'one\ntwo\n')
+    await add({ fs, dir, gitdir, filepath: 'a.txt' })
+    await commit({
+      fs,
+      dir,
+      gitdir,
+      message: 'initial',
+      author: { name: 'Test', email: 'test@example.com' },
+    })
+    // What a checkout under core.autocrlf=true leaves on a Windows disk: the
+    // blob is stored with LF and the working copy carries CRLF.
+    await fs.write(path.join(dir, 'a.txt'), 'one\r\ntwo\r\n')
+    // Test
+    // status has to come first. statusMatrix refreshes the index stat cache,
+    // and once the cached stats match the CRLF file on disk, status returns the
+    // indexed oid without hashing anything, which hides the bug.
+    expect(await status({ fs, dir, gitdir, filepath: 'a.txt' })).toEqual(
+      'unmodified'
+    )
+    // GitWalkerFs already reads with the autocrlf option, so statusMatrix
+    // agrees the file is untouched either way.
+    expect(await statusMatrix({ fs, dir, gitdir })).toEqual([
+      ['a.txt', 1, 1, 1],
+    ])
   })
 })

--- a/__tests__/test-status.js
+++ b/__tests__/test-status.js
@@ -139,8 +139,9 @@ describe('status', () => {
       message: 'initial',
       author: { name: 'Test', email: 'test@example.com' },
     })
-    // What a checkout under core.autocrlf=true leaves on a Windows disk: the
-    // blob is stored with LF and the working copy carries CRLF.
+    // The blob is stored with LF and the working copy carries CRLF. This
+    // library never writes CRLF, so on a real machine the working copy got
+    // that way from canonical git, an editor, or a syncing tool.
     await fs.write(path.join(dir, 'a.txt'), 'one\r\ntwo\r\n')
     // Test
     // status has to come first. statusMatrix refreshes the index stat cache,

--- a/src/api/status.js
+++ b/src/api/status.js
@@ -2,6 +2,7 @@
 import { _readTree } from '../commands/readTree.js'
 import { NotFoundError } from '../errors/NotFoundError.js'
 import { ObjectTypeError } from '../errors/ObjectTypeError.js'
+import { GitConfigManager } from '../managers/GitConfigManager.js'
 import { GitIgnoreManager } from '../managers/GitIgnoreManager.js'
 import { GitIndexManager } from '../managers/GitIndexManager.js'
 import { GitRefManager } from '../managers/GitRefManager.js'
@@ -110,7 +111,12 @@ export async function status({
       if (I && !compareStats(indexEntry, stats)) {
         return indexEntry.oid
       } else {
-        const object = await fs.read(join(dir, filepath))
+        // Read through the same core.autocrlf normalisation GitWalkerFs uses,
+        // so the working copy hashes to the blob that was stored. Without it a
+        // CRLF checkout of an LF blob reads as modified.
+        const config = await GitConfigManager.get({ fs, gitdir: updatedGitdir })
+        const autocrlf = await config.get('core.autocrlf')
+        const object = await fs.read(join(dir, filepath), { autocrlf })
         const workdirOid = await hashObject({
           gitdir: updatedGitdir,
           type: 'blob',


### PR DESCRIPTION
Fixes #1275.

## I'm fixing a bug

When the working tree holds CRLF and `core.autocrlf=true`, `status` reports `*modified` for a file nobody touched, disagreeing with both `statusMatrix()` and `git status`. The blob is stored with LF, `status` reads the file with no normalisation, hashes the CRLF bytes, and gets an oid that can never match the one in the index.

One correction to my first version of this description, which said a checkout leaves CRLF on disk. That is canonical git, not this library. `autocrlf` appears once in `FileSystem`, inside `read`, and `checkout` calls `fs.write(filepath, object)` with no options, so isomorphic-git never writes CRLF anywhere. A clone performed by this library cannot produce the reported state on its own; it comes from canonical git, an editor, or a syncing tool. The defect in `status` is the same either way.

`GitWalkerFs`, which backs `walk` and `statusMatrix`, already reads the right way:

```js
const config = await this._getGitConfig(fs, gitdir)
const autocrlf = await config.get('core.autocrlf')
content = await fs.read(`${dir}/${entry._fullpath}`, { autocrlf })
```

`api/status.js` did not:

```js
const object = await fs.read(join(dir, filepath))
```

So the two disagree about the same file. On Windows 11, same repository, same moment:

| | result |
|---|---|
| `statusMatrix()` | `[['a.txt', 1, 1, 1]]`, unmodified |
| `status({ filepath: 'a.txt' })` | `*modified` |

@acailly diagnosed this down to the bytes back in 2020, comparing the two hashes and finding `0a` on one side and `0d0a` on the other. The `autocrlf` support that landed since covers `add`, `walk` and `statusMatrix`, and `status` was left out.

## The fix

`status` reads through the same normalisation:

```diff
-        const object = await fs.read(join(dir, filepath))
+        const config = await GitConfigManager.get({ fs, gitdir: updatedGitdir })
+        const autocrlf = await config.get('core.autocrlf')
+        const object = await fs.read(join(dir, filepath), { autocrlf })
```

It sits inside the branch that already decided to hash the file, so the fast path where `compareStats` matches is untouched and nothing extra is read when the stats are clean.

## Tests

One test with the `-in-submodule` variant Appendix A of CONTRIBUTING asks for. Commit a file with LF under `core.autocrlf=true`, then write CRLF to the working copy explicitly, since nothing in this library would put it there.

**The assertion order is load-bearing, and my first version of this test was wrong.** It asserted `statusMatrix` first, and it passed without the fix. `statusMatrix` refreshes the index stat cache, and once the cached stats match the CRLF file on disk, `status` short-circuits on `compareStats` and returns the indexed oid without hashing anything. The bug was hidden by the line above it. `status` is checked first now, and there is a comment in the test saying why, so nobody reorders it later.

| | Result |
|---|---|
| First commit only | 2 failed |
| With the fix | 8 passed across both suites |

Control failure:

```
● status › honours core.autocrlf when hashing the working copy
  Expected: "unmodified"
  Received: "*modified"
```

Full suite on Node, Windows 11:

| | Failures |
|---|---|
| Before the fix | 16 |
| After the fix | 14 |

The 14 that remain fail identically on both sides. Thirteen of them are one thing: a fixture symlink comes back as `mode 33188` instead of `40960`, because creating symlinks on Windows needs elevation. The fourteenth is `clone > should set up the remote tracking branch by default`, which fails with a `MultipleGitError` against the local mock server.

One note on flakiness, since I saw it and would rather say so: in one of four full runs, `commit > create signed commit` failed on a signature check. It passed on the other three runs and passes on its own, and it has nothing to do with this change, but it is not deterministic on my machine.

## Overlap with #2394

That PR also touches `api/status.js` and `__tests__/test-status.js`. I test-merged the two branches: `src/api/status.js` merges cleanly, because the changes are in different parts of the function. `__tests__/test-status.js` conflicts, only because both branches append an `it()` at the end of the same `describe`. Whichever one you take first, I will rebase the other and repost the control numbers.

## What I did not verify

I ran the Node suite on Windows 11, which is the platform this bug is about, and not the Chrome or Firefox suites. `core.autocrlf=input` is still ignored after this change, deliberately. `FileSystem.js` gates on `options.autocrlf === 'true'`, so `input`, `yes`, `on` and `True` all fall through. For hashing purposes `input` should behave like `true`, but widening that gate changes `add` and the walker too, which is a behaviour change rather than a bug fix and deserves its own review. Naming it so this PR is not read as closing out autocrlf entirely.

Two sibling call sites read the working copy unnormalised the same way: `src/api/resetIndex.js` and `src/api/updateIndex.js`. The second is worse than the bug reported here, because the unnormalised bytes go on to `_writeObject`, so a CRLF blob enters the object database. I left both out to keep the diff reviewable and would rather raise `updateIndex` as its own issue.

I have not run `npm run add-contributor`. Happy to add the entry here if you would rather it landed in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status checks incorrectly reporting files as modified when CRLF line endings are used with `core.autocrlf=true`.
  * Updated status comparisons to normalize working-tree line endings consistently.
  * Ensured consistent behavior for both regular repositories and submodules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->