### PR TITLE
fix(ci): stop passing the string 'undefined' to bundlewatch

### DIFF
--- a/package-scripts.cjs
+++ b/package-scripts.cjs
@@ -25,37 +25,43 @@ const timeout15 = (command) =>
  * @returns {string}
  */
 const bundlewatchEnvironmentVariables = () => {
-  const options = [
-    `BUNDLEWATCH_GITHUB_TOKEN='${process.env.BUNDLEWATCH_GITHUB_TOKEN}'`,
-    `CI_REPO_OWNER='isomorphic-git'`,
-    `CI_REPO_NAME='isomorphic-git'`,
-  ]
+  // Interpolating an unset variable yields the literal string 'undefined',
+  // which bundlewatch then treats as a real value. Skip the option instead.
+  const options = []
+  const set = (name, value) => {
+    if (value !== undefined && value !== '') options.push(`${name}='${value}'`)
+  }
+
+  set('BUNDLEWATCH_GITHUB_TOKEN', process.env.BUNDLEWATCH_GITHUB_TOKEN)
+  set('CI_REPO_OWNER', 'isomorphic-git')
+  set('CI_REPO_NAME', 'isomorphic-git')
 
   // Azure DevOps Pipeline is not detected by bundlewatch (which uses ci-env).
   if (process.env.SYSTEM_COLLECTIONURI !== undefined) {
-    options.push(
-      `CI_COMMIT_SHA='${process.env.TRAVIS_PULL_REQUEST_SHA}'`,
-      `CI_BRANCH='${process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH}'`,
-      `CI_BRANCH_BASE='${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}'`
+    // On a pull request build Azure checks out a merge commit, so report the
+    // head of the source branch, which is the commit the status belongs to.
+    set(
+      'CI_COMMIT_SHA',
+      process.env.SYSTEM_PULLREQUEST_SOURCECOMMITID ??
+        process.env.BUILD_SOURCEVERSION
     )
+    set('CI_BRANCH', process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH)
+    set('CI_BRANCH_BASE', process.env.SYSTEM_PULLREQUEST_TARGETBRANCH)
   }
 
   // GitHub is not detected well using bundlewatch@0.2.5.
   else if (process.env.GITHUB_SHA) {
-    options.push(`CI_COMMIT_SHA='${process.env.GITHUB_SHA}'`)
+    set('CI_COMMIT_SHA', process.env.GITHUB_SHA)
 
     // Get the current and base branch for pull requests
     if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
-      options.push(
-        `CI_BRANCH='${process.env.GITHUB_HEAD_REF}'`,
-        `CI_BRANCH_BASE='${process.env.GITHUB_BASE_REF}'`
-      )
+      set('CI_BRANCH', process.env.GITHUB_HEAD_REF)
+      set('CI_BRANCH_BASE', process.env.GITHUB_BASE_REF)
     }
     // Otherwise, get the current branch. This handles push and workflow_dispatch events.
     // This does not handle tags (refs/tags/<tag_name>).
-    else if (process.env.GITHUB_REF.startsWith('refs/heads/')) {
-      const branch = process.env.GITHUB_REF.replace('refs/heads/')
-      options.push(`CI_BRANCH='${branch}'`)
+    else if (process.env.GITHUB_REF?.startsWith('refs/heads/')) {
+      set('CI_BRANCH', process.env.GITHUB_REF.replace('refs/heads/', ''))
     }
   }
 


### PR DESCRIPTION
Closes #2208.

The log in the issue shows every variable arriving as the literal string `'undefined'`. That happens because each option is built by interpolating `process.env.X` into a template literal, and `` `CI_BRANCH='${undefined}'` `` is `CI_BRANCH='undefined'`. bundlewatch then looks up a commit that does not exist, finds no baseline, and reports the entire bundle as added, which is the `(+11.87KB, -0B, +16.3%)` you saw.

Digging into it there were three causes, not one:

**The Azure branch read a Travis variable.** `TRAVIS_PULL_REQUEST_SHA` is never set on Azure DevOps, so `CI_COMMIT_SHA` was always `'undefined'` there. It now reads `SYSTEM_PULLREQUEST_SOURCECOMMITID`, which is the head of the source branch rather than the merge commit Azure checks out, falling back to `BUILD_SOURCEVERSION` on push builds.

**`GITHUB_REF.replace('refs/heads/')` was called with one argument.** The second parameter is the replacement, so the match was replaced with the string `undefined`:

```
> 'refs/heads/main'.replace('refs/heads/')
'undefinedmain'
```

That one is not in the report and would have kept the GitHub path broken even after fixing the Azure variable.

**Unset variables were emitted rather than skipped.** Options now go through a helper that drops `undefined` and empty values, so a missing token or a non-PR build simply produces fewer options.

## Verification

I drove `scripts.build.size` directly with the environment each CI provider sets, since that is where the string ends up. Before:

```
AZURE, pull request:  CI_COMMIT_SHA='undefined' CI_BRANCH='refs/heads/feature' CI_BRANCH_BASE='refs/heads/main'
AZURE, push:          CI_COMMIT_SHA='undefined' CI_BRANCH='undefined' CI_BRANCH_BASE='undefined'
GITHUB, push to main: CI_COMMIT_SHA='ghsha' CI_BRANCH='undefinedmain'
no CI, no token:      BUNDLEWATCH_GITHUB_TOKEN='undefined'
```

After:

```
AZURE, pull request:  CI_COMMIT_SHA='abc123' CI_BRANCH='refs/heads/feature' CI_BRANCH_BASE='refs/heads/main'
AZURE, push:          CI_COMMIT_SHA='def456'
GITHUB, push to main: CI_COMMIT_SHA='ghsha' CI_BRANCH='main'
no CI, no token:      (only CI_REPO_OWNER and CI_REPO_NAME)
```

What I could not test is the real Azure run, since I have no way to trigger one from a fork. The variable names are from the Azure DevOps predefined-variables documentation, and the branch is already gated on `SYSTEM_COLLECTIONURI`, so the rest of that path is unchanged.

`eslint package-scripts.cjs` reports the same 7 pre-existing errors before and after, at shifted line numbers; the new code adds none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI environment handling by excluding empty or undefined values.
  * Corrected pull request commit and build version detection for Azure DevOps.
  * Improved GitHub branch detection, including support for missing references and proper branch name formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->