### PR TITLE
fix: don't split a CRLF that straddles two chunks in splitLines

### DIFF
--- a/__tests__/test-utils-splitLines.js
+++ b/__tests__/test-utils-splitLines.js
@@ -1,0 +1,39 @@
+/* eslint-env node, browser, jasmine */
+import { splitLines } from 'isomorphic-git/internal-apis'
+
+async function collect(chunks) {
+  const fifo = splitLines(
+    (async function* () {
+      for (const chunk of chunks) yield chunk
+    })()
+  )
+  const lines = []
+  while (true) {
+    const result = await fifo.next()
+    if (result.done) break
+    lines.push(result.value)
+  }
+  return lines
+}
+
+describe('utils/splitLines', () => {
+  it('splits on LF, CR and CRLF', async () => {
+    expect(await collect(['a\nb'])).toEqual(['a\n', 'b'])
+    expect(await collect(['a\rb'])).toEqual(['a\r', 'b'])
+    expect(await collect(['a\r\nb'])).toEqual(['a\r\n', 'b'])
+  })
+
+  it('does not split a CRLF that straddles two chunks', async () => {
+    // The same bytes, delivered in one chunk or two, must produce the same
+    // lines. Sockets decide where the boundary falls, the caller does not.
+    expect(await collect(['a\r', '\nb'])).toEqual(await collect(['a\r\nb']))
+  })
+
+  it('emits a trailing lone CR once the stream ends', async () => {
+    expect(await collect(['a\r'])).toEqual(['a\r'])
+  })
+
+  it('keeps a CR that is followed by something other than LF', async () => {
+    expect(await collect(['a\r', 'b'])).toEqual(['a\r', 'b'])
+  })
+})

--- a/src/internal-apis.js
+++ b/src/internal-apis.js
@@ -48,6 +48,7 @@ export * from './utils/padHex.js'
 export * from './utils/pkg.js'
 export * from './utils/resolveTree.js'
 export * from './utils/shasum.js'
+export * from './utils/splitLines.js'
 export * from './utils/sleep.js'
 export * from './utils/symbols.js'
 

--- a/src/utils/splitLines.js
+++ b/src/utils/splitLines.js
@@ -25,6 +25,11 @@ export function splitLines(input) {
       while (true) {
         const i = findSplit(tmp)
         if (i === -1) break
+        // A '\r' at the very end may be the first half of a '\r\n' whose '\n'
+        // arrives in the next chunk. Hold it back until there is a character
+        // after it to look at, otherwise the same bytes split into two lines
+        // or one depending only on where the socket boundary fell.
+        if (i === tmp.length && tmp[i - 1] === '\r') break
         output.write(tmp.slice(0, i))
         tmp = tmp.slice(i)
       }


### PR DESCRIPTION
`splitLines` treats a trailing `\r` as a finished line, so when a `\r\n` lands across two chunks the two halves become two lines. The same bytes then produce different output depending only on where the socket boundary fell, which is not something the caller controls.

```js
collect(['a\r\nb'])      // ['a\r\n', 'b']
collect(['a\r', '\nb'])  // ['a\r', '\n', 'b']   <- same bytes, extra line
```

The second form emits a line that is just `'\n'`. This feeds `onProgress` and `onMessage` through `fetch` and `push`, so a long progress stream can hand the consumer a stray empty message whenever a CRLF happens to straddle a read.

`findSplit` already handles CRLF correctly. It only ever sees one chunk's worth of text, so it cannot know whether a `\r` at the very end is a line on its own or the first half of a pair. The fix is to hold that `\r` back until there is a character after it, and to flush it at end of stream like any other remainder.

The comment at the top of the file says CRLF is included "just in case", so this keeps the intent it already states.

## Test plan

New `__tests__/test-utils-splitLines.js`, following `test-utils-join.js`. Four cases: the three delimiters in a single chunk, the straddled CRLF asserted against the single-chunk result, a trailing lone `\r` at end of stream, and a `\r` followed by an ordinary character.

I ran them against the code before the change: only the straddle case fails there, and the other three pass on both sides, so they are not asserting something that was already true.

`splitLines` is not reachable from `isomorphic-git/internal-apis`, which is how `test-utils-join.js` imports the util it covers, so this adds the one missing export line next to the others. Nothing else about the module's visibility changes.

`test-utils-splitLines` and `test-utils-join` pass, 42 assertions. `test-fetch` and `test-push`, which are the two consumers, pass with 30 tests and the snapshot unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line processing when line-ending characters are split across incoming data chunks.
  * Ensured consistent handling of trailing carriage returns and mixed line-ending formats.
  * Improved build reporting by omitting incomplete values and using more reliable commit information.

* **Tests**
  * Added coverage for LF, CR, CRLF, chunk boundaries, trailing carriage returns, and mixed line-ending scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->