### PR TITLE
fix: recognize the scp-like syntax with a user other than git

### DIFF
--- a/__tests__/test-GitRemoteManager.js
+++ b/__tests__/test-GitRemoteManager.js
@@ -92,4 +92,45 @@ describe('GitRemoteManager', () => {
     expect(helper).toBeNull()
     expect(error.code).toBe(Errors.UrlParseError.code)
   })
+  it('getRemoteHelperFor (scp-like syntax, user other than git)', async () => {
+    // git-clone(1): "[user@]host.xz:path/to/repo.git/". The user is part of the
+    // syntax, so a self-hosted forge handing out gitolite@ or ubuntu@ is the
+    // same shape as github handing out git@.
+    for (const url of [
+      'git@github.com:owner/repo.git',
+      'gitolite@git.example.com:team/repo.git',
+      'ubuntu@10.0.0.5:repo.git',
+    ]) {
+      let helper = null
+      let error = null
+      try {
+        helper = await GitRemoteManager.getRemoteHelperFor({ url })
+      } catch (err) {
+        error = err
+      }
+      expect(helper).toBeNull()
+      // ssh is not a transport isomorphic-git speaks, so the useful answer is
+      // the one that names the https url to use instead.
+      expect(error.code).toBe(Errors.UnknownTransportError.code)
+      expect(error.data.suggestion).toBe(
+        url.replace(/^[^/@:]+@([^/@:]+):/, 'https://$1/')
+      )
+    }
+  })
+
+  it('getRemoteHelperFor (a colon that is not scp-like)', async () => {
+    // No user, so this stays with the scheme parser and keeps failing the way
+    // it always has.
+    let helper = null
+    let error = null
+    try {
+      helper = await GitRemoteManager.getRemoteHelperFor({
+        url: 'oid:c3c2a92aa2bda58d667cb57493270b83bd14d1ed',
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(helper).toBeNull()
+    expect(error.code).toBe(Errors.UrlParseError.code)
+  })
 })

--- a/src/managers/GitRemoteManager.js
+++ b/src/managers/GitRemoteManager.js
@@ -45,9 +45,15 @@ export class GitRemoteManager {
  * @param {string} args.url - The URL of the remote repository.
  * @returns {Object|undefined} - An object containing the transport and address, or undefined if parsing fails.
  */
+// git-clone(1) calls this the "shorter scp-like syntax": [user@]host:path. The
+// user is part of the syntax, not part of the word `git`, and a self-hosted
+// forge is as likely to hand out `gitolite@`, `forgejo@` or `ubuntu@`. The host
+// and the user cannot hold a slash, an at sign or a colon, so `https://x` and a
+// `scheme:address` override are left to the expression below.
+const scpLike = /^[^/@:]+@[^/@:]+:/
+
 function parseRemoteUrl({ url }) {
-  // the stupid "shorter scp-like syntax"
-  if (url.startsWith('git@')) {
+  if (scpLike.test(url)) {
     return {
       transport: 'ssh',
       address: url,

--- a/src/utils/translateSSHtoHTTP.js
+++ b/src/utils/translateSSHtoHTTP.js
@@ -1,6 +1,8 @@
 export function translateSSHtoHTTP(url) {
-  // handle "shorter scp-like syntax"
-  url = url.replace(/^git@([^:]+):/, 'https://$1/')
+  // handle "shorter scp-like syntax". The user is dropped: it names an ssh
+  // account and means nothing over https, which is what the old expression did
+  // for `git@` too.
+  url = url.replace(/^[^/@:]+@([^/@:]+):/, 'https://$1/')
   // handle proper SSH URLs
   url = url.replace(/^ssh:\/\//, 'https://')
   return url


### PR DESCRIPTION
`parseRemoteUrl` recognizes the shorter scp-like syntax with `url.startsWith('git@')`. git-clone(1) writes that syntax as

```
[user@]host.xz:path/to/repo.git/
```

so the user is part of the grammar rather than part of the word `git`. A self-hosted forge is as likely to hand out `gitolite@`, `forgejo@` or a plain `ubuntu@` on a box, and those fall through to the scheme expression, which needs a `://` or `::` and finds neither:

```js
await git.clone({ url: 'gitolite@git.example.com:team/repo.git', ... })
// before  UrlParseError: Cannot parse remote URL: "gitolite@git.example.com:team/repo.git"
// after   UnknownTransportError: Git remote "..." uses an unrecognized transport protocol: "ssh"
//         with data.suggestion = "https://git.example.com/team/repo.git"
```

Both are errors, since isomorphic-git does not speak ssh either way, but they are not equally useful. The second is the one that tells the reader which url to use instead, and it is what `git@` has always given them.

### The change

The `startsWith` becomes an expression that accepts any user. It is deliberately narrow: the user and the host may not hold a slash, an at sign or a colon, so `https://host/x` and the `scheme::address` override still belong to the parser below, and `oid:c3c2a92...` still comes back as `UrlParseError`. There is a test pinning that last one, since it is the existing behaviour and easy to break here.

I left the userless form alone. git accepts `host.xz:path` with no user at all, but telling that apart from a local path with a colon in it needs more care than this change deserves, and it is the rarer shape. Happy to look at it separately if you would like it covered.

`translateSSHtoHTTP` widens to match. It keeps dropping the user, which is what it already did for `git@`: the user names an ssh account and carries no meaning over https.

### Tests

Two added to `__tests__/test-GitRemoteManager.js`. The first walks `git@`, `gitolite@` and `ubuntu@` through `getRemoteHelperFor` and checks both the error code and the suggested url. It fails on `main`:

```
× getRemoteHelperFor (scp-like syntax, user other than git)
  Expected: "UnknownTransportError"
  Received: "UrlParseError"
```

The second is the control for `oid:...`, which passes on both sides on purpose.

`npx eslint src __tests__` is clean.

One note on sequencing: #2191 is open against the line just below this one, anchoring the scheme expression with `^`. The two changes are independent but adjacent, so whichever lands second may want a rebase. Happy to do that on this one either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of Git SSH-style remote URLs for arbitrary user accounts.
  - Added clearer handling and HTTPS suggestions for unsupported SCP-like remote formats.
  - Preserved appropriate errors for invalid colon-separated URLs without a user account.
  - Updated SSH-to-HTTPS conversion to support any valid account and host combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->