### PR TITLE
fix: global acquire lock

### DIFF
--- a/src/commands/stash.js
+++ b/src/commands/stash.js
@@ -199,7 +199,7 @@ export async function _stashDrop({ fs, dir, gitdir, refIdx = 0 }) {
   reflogEntries.splice(refIdx, 1)
 
   const stashReflogPath = stashMgr.refLogsStashPath
-  await acquireLock({ reflogEntries, stashReflogPath, stashMgr }, async () => {
+  await acquireLock(stashReflogPath, async () => {
     if (reflogEntries.length) {
       await fs.write(
         stashReflogPath,

--- a/src/managers/GitStashManager.js
+++ b/src/managers/GitStashManager.js
@@ -188,7 +188,7 @@ export class GitStashManager {
     )
     const filepath = this.refLogsStashPath
 
-    await acquireLock({ filepath, entry }, async () => {
+    await acquireLock(filepath, async () => {
       const appendTo = (await this.fs.exists(filepath))
         ? await this.fs.read(filepath, 'utf8')
         : ''

--- a/src/utils/walkerToTreeEntryMap.js
+++ b/src/utils/walkerToTreeEntryMap.js
@@ -44,7 +44,7 @@ async function checkAndWriteBlob(fs, gitdir, dir, filepath, oid = null) {
     : undefined
   let retOid = objContent ? oid : undefined
   if (!objContent) {
-    await acquireLock({ fs, gitdir, currentFilepath }, async () => {
+    await acquireLock(currentFilepath, async () => {
       const object = stats.isSymbolicLink()
         ? await fs.readlink(currentFilepath).then(posixifyPathBuffer)
         : await fs.read(currentFilepath)
@@ -259,7 +259,7 @@ export async function applyTreeChanges({
   })
 
   // apply the changes to work dir
-  await acquireLock({ fs, gitdir, dirRemoved, ops }, async () => {
+  await acquireLock(gitdir, async () => {
     for (const op of ops) {
       const currentFilepath = join(dir, op.filepath)
       switch (op.method) {


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling during stash operations and repository updates.
  * Reduced the risk of conflicts when writing stash records, blobs, and tree data.
  * Existing stash and file-update behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->