### PR TITLE
fix: recursive mkdir

### DIFF
--- a/__tests__/test-utils-mkdirp.js
+++ b/__tests__/test-utils-mkdirp.js
@@ -1,0 +1,96 @@
+/* eslint-env node, browser, jasmine */
+import { mkdirp } from '../src/utils/mkdirp.js'
+
+// Minimal in-memory mock of the single-level `_mkdir` primitive that iso-git's
+// `fs` wrapper exposes. `_pre` is an optional hook that runs before each mkdir
+// and may throw to simulate backend-specific behavior (e.g. an eventually
+// consistent overlay reporting a transient ENOENT).
+function makeFs() {
+  const errno = code => Object.assign(new Error(code), { code })
+  return {
+    dirs: new Set(['']), // the root always exists
+    _pre: null,
+    async _mkdir(filepath) {
+      if (this._pre) this._pre(filepath)
+      const parent = filepath.slice(0, filepath.lastIndexOf('/'))
+      if (!this.dirs.has(parent)) throw errno('ENOENT')
+      if (this.dirs.has(filepath)) throw errno('EEXIST')
+      this.dirs.add(filepath)
+    },
+  }
+}
+
+const errno = code => Object.assign(new Error(code), { code })
+
+describe('utils/mkdirp', () => {
+  it('creates all missing parent directories', async () => {
+    const fs = makeFs()
+    await mkdirp(fs, '/a/b/c')
+    expect(fs.dirs.has('/a')).toBe(true)
+    expect(fs.dirs.has('/a/b')).toBe(true)
+    expect(fs.dirs.has('/a/b/c')).toBe(true)
+  })
+
+  it('is idempotent (EEXIST is treated as success)', async () => {
+    const fs = makeFs()
+    await mkdirp(fs, '/a/b')
+    // Running again must not throw even though everything already exists.
+    await mkdirp(fs, '/a/b')
+    expect(fs.dirs.has('/a/b')).toBe(true)
+  })
+
+  it('retries a transient ENOENT after the parent exists', async () => {
+    // Simulate an eventually-consistent backend: after '/a' is created, the
+    // first few attempts to create '/a/b' still report ENOENT before settling.
+    const fs = makeFs()
+    let flaky = 3
+    fs._pre = filepath => {
+      if (filepath === '/a/b' && fs.dirs.has('/a') && flaky > 0) {
+        flaky--
+        throw errno('ENOENT')
+      }
+    }
+    await mkdirp(fs, '/a/b')
+    expect(fs.dirs.has('/a/b')).toBe(true)
+    expect(flaky).toBe(0) // all transient failures were absorbed
+  })
+
+  it('gives up after exhausting retries on a persistent ENOENT', async () => {
+    const fs = makeFs()
+    fs._pre = filepath => {
+      if (filepath === '/a/b') throw errno('ENOENT')
+    }
+    let err
+    try {
+      await mkdirp(fs, '/a/b', 2)
+    } catch (e) {
+      err = e
+    }
+    expect(err && err.code).toBe('ENOENT')
+  })
+
+  it('propagates a non-ENOENT/EEXIST error immediately', async () => {
+    const fs = makeFs()
+    fs._pre = filepath => {
+      if (filepath === '/a') throw errno('EACCES')
+    }
+    let err
+    try {
+      await mkdirp(fs, '/a')
+    } catch (e) {
+      err = e
+    }
+    expect(err && err.code).toBe('EACCES')
+  })
+
+  it('treats a null error (some fs backends) as success', async () => {
+    const fs = {
+      async _mkdir() {
+        throw null // eslint-disable-line no-throw-literal
+      },
+    }
+    // Should resolve rather than reject.
+    await mkdirp(fs, '/a')
+    expect(true).toBe(true)
+  })
+})

--- a/__tests__/test-utils-mkdirp.js
+++ b/__tests__/test-utils-mkdirp.js
@@ -1,68 +1,106 @@
 /* eslint-env node, browser, jasmine */
 import { mkdirp } from '../src/utils/mkdirp.js'
 
-// Minimal in-memory mock of the single-level `_mkdir` primitive that iso-git's
-// `fs` wrapper exposes. `_pre` is an optional hook that runs before each mkdir
-// and may throw to simulate backend-specific behavior (e.g. an eventually
-// consistent overlay reporting a transient ENOENT).
-function makeFs() {
-  const errno = code => Object.assign(new Error(code), { code })
+const errno = code => Object.assign(new Error(code), { code })
+
+// Builds a single-level `mkdir(path)` primitive backed by an in-memory set of
+// directories — the shape `mkdirp` expects (like the raw `fs._mkdir`). `hook`,
+// if set, runs before each mkdir and may throw to simulate backend behavior
+// (e.g. a transient ENOENT from an eventually consistent overlay).
+function makeMkdir() {
+  const dirs = new Set(['']) // the root always exists
+  /** @type {((filepath: string) => void) | null} */
+  let hook = null
+  const mkdir = async filepath => {
+    if (hook) hook(filepath)
+    const parent = filepath.slice(0, filepath.lastIndexOf('/'))
+    if (!dirs.has(parent)) throw errno('ENOENT')
+    if (dirs.has(filepath)) throw errno('EEXIST')
+    dirs.add(filepath)
+  }
   return {
-    dirs: new Set(['']), // the root always exists
-    _pre: null,
-    async _mkdir(filepath) {
-      if (this._pre) this._pre(filepath)
-      const parent = filepath.slice(0, filepath.lastIndexOf('/'))
-      if (!this.dirs.has(parent)) throw errno('ENOENT')
-      if (this.dirs.has(filepath)) throw errno('EEXIST')
-      this.dirs.add(filepath)
+    mkdir,
+    dirs,
+    setHook(fn) {
+      hook = fn
     },
   }
 }
 
-const errno = code => Object.assign(new Error(code), { code })
-
 describe('utils/mkdirp', () => {
   it('creates all missing parent directories', async () => {
-    const fs = makeFs()
-    await mkdirp(fs, '/a/b/c')
+    const fs = makeMkdir()
+    await mkdirp(fs.mkdir, '/a/b/c')
     expect(fs.dirs.has('/a')).toBe(true)
     expect(fs.dirs.has('/a/b')).toBe(true)
     expect(fs.dirs.has('/a/b/c')).toBe(true)
   })
 
   it('is idempotent (EEXIST is treated as success)', async () => {
-    const fs = makeFs()
-    await mkdirp(fs, '/a/b')
+    const fs = makeMkdir()
+    await mkdirp(fs.mkdir, '/a/b')
     // Running again must not throw even though everything already exists.
-    await mkdirp(fs, '/a/b')
+    await mkdirp(fs.mkdir, '/a/b')
     expect(fs.dirs.has('/a/b')).toBe(true)
   })
 
   it('retries a transient ENOENT after the parent exists', async () => {
     // Simulate an eventually-consistent backend: after '/a' is created, the
     // first few attempts to create '/a/b' still report ENOENT before settling.
-    const fs = makeFs()
+    const fs = makeMkdir()
     let flaky = 3
-    fs._pre = filepath => {
+    fs.setHook(filepath => {
       if (filepath === '/a/b' && fs.dirs.has('/a') && flaky > 0) {
         flaky--
         throw errno('ENOENT')
       }
-    }
-    await mkdirp(fs, '/a/b')
+    })
+    await mkdirp(fs.mkdir, '/a/b')
     expect(fs.dirs.has('/a/b')).toBe(true)
     expect(flaky).toBe(0) // all transient failures were absorbed
   })
 
-  it('gives up after exhausting retries on a persistent ENOENT', async () => {
-    const fs = makeFs()
-    fs._pre = filepath => {
-      if (filepath === '/a/b') throw errno('ENOENT')
+  it('honors the caller-provided retry limit while creating a parent directory', async () => {
+    // '/a/b' (a parent of the requested '/a/b/c') reports a transient ENOENT a
+    // configurable number of times after its own parent '/a' exists — exercising
+    // the retry budget on parent creation, not just the leaf.
+    const makeFlakyParent = flakyCount => {
+      const fs = makeMkdir()
+      let remaining = flakyCount
+      fs.setHook(filepath => {
+        if (filepath === '/a/b' && fs.dirs.has('/a') && remaining > 0) {
+          remaining--
+          throw errno('ENOENT')
+        }
+      })
+      return fs
     }
+
+    // With enough retries the parent settles and the whole path is created.
+    const ok = makeFlakyParent(2)
+    await mkdirp(ok.mkdir, '/a/b/c', 2)
+    expect(ok.dirs.has('/a/b/c')).toBe(true)
+
+    // With too few retries the parent's transient ENOENT surfaces — proving the
+    // caller's limit propagates to parent creation (rather than the default).
+    const tooFew = makeFlakyParent(3)
     let err
     try {
-      await mkdirp(fs, '/a/b', 2)
+      await mkdirp(tooFew.mkdir, '/a/b/c', 1)
+    } catch (e) {
+      err = e
+    }
+    expect(err && err.code).toBe('ENOENT')
+  })
+
+  it('gives up after exhausting retries on a persistent ENOENT', async () => {
+    const fs = makeMkdir()
+    fs.setHook(filepath => {
+      if (filepath === '/a/b') throw errno('ENOENT')
+    })
+    let err
+    try {
+      await mkdirp(fs.mkdir, '/a/b', 2)
     } catch (e) {
       err = e
     }
@@ -70,13 +108,13 @@ describe('utils/mkdirp', () => {
   })
 
   it('propagates a non-ENOENT/EEXIST error immediately', async () => {
-    const fs = makeFs()
-    fs._pre = filepath => {
+    const fs = makeMkdir()
+    fs.setHook(filepath => {
       if (filepath === '/a') throw errno('EACCES')
-    }
+    })
     let err
     try {
-      await mkdirp(fs, '/a')
+      await mkdirp(fs.mkdir, '/a')
     } catch (e) {
       err = e
     }
@@ -84,13 +122,11 @@ describe('utils/mkdirp', () => {
   })
 
   it('treats a null error (some fs backends) as success', async () => {
-    const fs = {
-      async _mkdir() {
-        throw null // eslint-disable-line no-throw-literal
-      },
+    const mkdir = async () => {
+      throw null // eslint-disable-line no-throw-literal
     }
     // Should resolve rather than reject.
-    await mkdirp(fs, '/a')
+    await mkdirp(mkdir, '/a')
     expect(true).toBe(true)
   })
 })

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -159,7 +159,6 @@ export class FileSystem {
    * Make a directory (or series of nested directories) without throwing an error if it already exists.
    *
    * @param {string} filepath - The path to the directory.
-   * @param {boolean} [_selfCall=false] - Internal flag to prevent infinite recursion.
    * @returns {Promise<void>}
    */
   async mkdir(filepath) {
@@ -170,7 +169,7 @@ export class FileSystem {
     // that eventually-consistent backends throw when a freshly created parent
     // isn't visible yet, which is what made concurrent reflog writes into
     // `.git/logs/refs/*` fail intermittently.
-    await mkdirp(this, filepath)
+    await mkdirp(this._mkdir, filepath)
   }
 
   /**

--- a/src/models/FileSystem.js
+++ b/src/models/FileSystem.js
@@ -2,6 +2,7 @@ import pify from 'pify'
 
 import { compareStrings } from '../utils/compareStrings.js'
 import { dirname } from '../utils/dirname.js'
+import { mkdirp } from '../utils/mkdirp.js'
 import { rmRecursive } from '../utils/rmRecursive.js'
 import { isPromiseLike } from '../utils/types.js'
 
@@ -161,26 +162,15 @@ export class FileSystem {
    * @param {boolean} [_selfCall=false] - Internal flag to prevent infinite recursion.
    * @returns {Promise<void>}
    */
-  async mkdir(filepath, _selfCall = false) {
-    try {
-      await this._mkdir(filepath)
-    } catch (err) {
-      // If err is null then operation succeeded!
-      if (err === null) return
-      // If the directory already exists, that's OK!
-      if (err.code === 'EEXIST') return
-      // Avoid infinite loops of failure
-      if (_selfCall) throw err
-      // If we got a "no such file or directory error" backup and try again.
-      if (err.code === 'ENOENT') {
-        const parent = dirname(filepath)
-        // Check to see if we've gone too far
-        if (parent === '.' || parent === '/' || parent === filepath) throw err
-        // Infinite recursion, what could go wrong?
-        await this.mkdir(parent)
-        await this.mkdir(filepath, true)
-      }
-    }
+  async mkdir(filepath) {
+    // Recursively create the directory, using only single-level `_mkdir` so we
+    // don't depend on `{ recursive: true }` (which isn't part of the required
+    // `fs` contract — see docs/fs.md — and is unimplemented by some backends
+    // e.g. lightning-fs). The helper tolerates EEXIST and the transient ENOENT
+    // that eventually-consistent backends throw when a freshly created parent
+    // isn't visible yet, which is what made concurrent reflog writes into
+    // `.git/logs/refs/*` fail intermittently.
+    await mkdirp(this, filepath)
   }
 
   /**

--- a/src/utils/mkdirp.js
+++ b/src/utils/mkdirp.js
@@ -6,24 +6,28 @@ import { dirname } from './dirname.js'
  * `fs.mkdir(path, { recursive: true })`: recursive `mkdir` is NOT part of
  * isomorphic-git's required `fs` contract (see docs/fs.md — `mkdir` is only
  * `mkdir(path[, mode])`) and is unimplemented by some backends such as
- * lightning-fs, so we build it here on top of single-level `fs._mkdir(path)`
- * only — mirroring how `rmRecursive` provides `rm({ recursive: true })`.
+ * lightning-fs, so we build it here on top of a single-level `mkdir(path)`
+ * primitive only — mirroring how `rmRecursive` provides `rm({ recursive: true })`.
+ *
+ * It takes the raw single-level `mkdir` *function* (typically `fs._mkdir`)
+ * rather than the FileSystem wrapper, to stay decoupled from that type.
  *
  * `EEXIST` is treated as success, so two callers concurrently creating the same
  * directory (e.g. several reflog writes into `.git/logs/refs/*` during a stash)
  * don't fail each other. On backends whose layers are only eventually
  * consistent — e.g. an async copy-on-write overlay — a just-created parent may
- * not yet be visible when its child is created, so `_mkdir` can throw a
+ * not yet be visible when its child is created, so `mkdir` can throw a
  * transient `ENOENT`; those are retried a bounded number of times rather than
  * surfaced as a spurious failure.
  *
- * @param {import('../models/FileSystem.js').FileSystem} fs
+ * @param {(filepath: string) => Promise<unknown>} mkdir - Creates a single directory (non-recursive).
  * @param {string} filepath - The directory to create.
  * @param {number} [retries=10] - Max transient-ENOENT retries after the parent exists.
+ * @returns {Promise<void>}
  */
-export async function mkdirp(fs, filepath, retries = 10) {
+export async function mkdirp(mkdir, filepath, retries = 10) {
   try {
-    await fs._mkdir(filepath)
+    await mkdir(filepath)
   } catch (err) {
     // Some fs implementations signal success by yielding a null error.
     if (err === null) return
@@ -34,15 +38,15 @@ export async function mkdirp(fs, filepath, retries = 10) {
     const parent = dirname(filepath)
     // Stop if we've walked past the filesystem root.
     if (parent === '.' || parent === '/' || parent === filepath) throw err
-    // Create the missing parent(s) first.
-    await mkdirp(fs, parent)
+    // Create the missing parent(s) first, honoring the same retry budget.
+    await mkdirp(mkdir, parent, retries)
     // Then (re)create this directory. On an eventually-consistent backend the
     // parent may not be visible immediately after its mkdir resolves, so a
     // repeated ENOENT here is transient — retry a bounded number of times,
     // yielding between attempts so the pending write can settle.
     for (let attempt = 0; ; attempt++) {
       try {
-        await fs._mkdir(filepath)
+        await mkdir(filepath)
         return
       } catch (err2) {
         if (err2 === null || err2.code === 'EEXIST') return

--- a/src/utils/mkdirp.js
+++ b/src/utils/mkdirp.js
@@ -1,0 +1,58 @@
+import { dirname } from './dirname.js'
+
+/**
+ * Recursively creates the directory at `filepath`, creating any missing parent
+ * directories along the way. This is a portable replacement for
+ * `fs.mkdir(path, { recursive: true })`: recursive `mkdir` is NOT part of
+ * isomorphic-git's required `fs` contract (see docs/fs.md — `mkdir` is only
+ * `mkdir(path[, mode])`) and is unimplemented by some backends such as
+ * lightning-fs, so we build it here on top of single-level `fs._mkdir(path)`
+ * only — mirroring how `rmRecursive` provides `rm({ recursive: true })`.
+ *
+ * `EEXIST` is treated as success, so two callers concurrently creating the same
+ * directory (e.g. several reflog writes into `.git/logs/refs/*` during a stash)
+ * don't fail each other. On backends whose layers are only eventually
+ * consistent — e.g. an async copy-on-write overlay — a just-created parent may
+ * not yet be visible when its child is created, so `_mkdir` can throw a
+ * transient `ENOENT`; those are retried a bounded number of times rather than
+ * surfaced as a spurious failure.
+ *
+ * @param {import('../models/FileSystem.js').FileSystem} fs
+ * @param {string} filepath - The directory to create.
+ * @param {number} [retries=10] - Max transient-ENOENT retries after the parent exists.
+ */
+export async function mkdirp(fs, filepath, retries = 10) {
+  try {
+    await fs._mkdir(filepath)
+  } catch (err) {
+    // Some fs implementations signal success by yielding a null error.
+    if (err === null) return
+    // The directory already exists — that's fine.
+    if (err.code === 'EEXIST') return
+    // Anything other than a missing parent is a real error.
+    if (err.code !== 'ENOENT') throw err
+    const parent = dirname(filepath)
+    // Stop if we've walked past the filesystem root.
+    if (parent === '.' || parent === '/' || parent === filepath) throw err
+    // Create the missing parent(s) first.
+    await mkdirp(fs, parent)
+    // Then (re)create this directory. On an eventually-consistent backend the
+    // parent may not be visible immediately after its mkdir resolves, so a
+    // repeated ENOENT here is transient — retry a bounded number of times,
+    // yielding between attempts so the pending write can settle.
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await fs._mkdir(filepath)
+        return
+      } catch (err2) {
+        if (err2 === null || err2.code === 'EEXIST') return
+        if (err2.code === 'ENOENT' && attempt < retries) {
+          // Give the backend a turn of the event loop to become consistent.
+          await new Promise(resolve => setTimeout(resolve, 0))
+          continue
+        }
+        throw err2
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/test-exports.js`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
- [ ] read "Appendix A submodules" in the CONTRIBUTING.md document. Be sure to include submodule tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating nested directories.
  * Handles existing directories and temporary filesystem errors more gracefully.
  * Limits retries and surfaces unexpected filesystem errors promptly.

* **Tests**
  * Added coverage for recursive creation, retries, existing directories, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->