### PR TITLE
fix: validate readObject format consistently

### DIFF
--- a/__tests__/test-readObject-in-submodule.js
+++ b/__tests__/test-readObject-in-submodule.js
@@ -28,6 +28,7 @@ describe('readObject', () => {
     const { fs, gitdir } = await makeFixtureAsSubmodule('test-readObject')
     let error = null
     try {
+      // @ts-ignore
       await readObject({ fs, gitdir, oid, format: 'invalid' })
     } catch (err) {
       error = err

--- a/__tests__/test-readObject-in-submodule.js
+++ b/__tests__/test-readObject-in-submodule.js
@@ -21,6 +21,20 @@ describe('readObject', () => {
     expect(error).not.toBeNull()
     expect(error instanceof Errors.NotFoundError).toBe(true)
   })
+  it.each([
+    ['loose', 'e10ebb90d03eaacca84de1af0a59b444232da99e'],
+    ['packed', '0b8faa11b353db846b40eb064dfb299816542a46'],
+  ])('rejects an invalid format for a %s object', async (_, oid) => {
+    const { fs, gitdir } = await makeFixtureAsSubmodule('test-readObject')
+    let error = null
+    try {
+      await readObject({ fs, gitdir, oid, format: 'invalid' })
+    } catch (err) {
+      error = err
+    }
+    expect(error instanceof Errors.InternalError).toBe(true)
+    expect(error.data.message).toBe('invalid requested format "invalid"')
+  })
   it('parsed', async () => {
     // Setup
     const { fs, gitdir } = await makeFixtureAsSubmodule('test-readObject')

--- a/__tests__/test-readObject.js
+++ b/__tests__/test-readObject.js
@@ -21,6 +21,20 @@ describe('readObject', () => {
     expect(error).not.toBeNull()
     expect(error instanceof Errors.NotFoundError).toBe(true)
   })
+  it.each([
+    ['loose', 'e10ebb90d03eaacca84de1af0a59b444232da99e'],
+    ['packed', '0b8faa11b353db846b40eb064dfb299816542a46'],
+  ])('rejects an invalid format for a %s object', async (_, oid) => {
+    const { fs, gitdir } = await makeFixture('test-readObject')
+    let error = null
+    try {
+      await readObject({ fs, gitdir, oid, format: 'invalid' })
+    } catch (err) {
+      error = err
+    }
+    expect(error instanceof Errors.InternalError).toBe(true)
+    expect(error.data.message).toBe('invalid requested format "invalid"')
+  })
   it('parsed', async () => {
     // Setup
     const { fs, gitdir } = await makeFixture('test-readObject')

--- a/__tests__/test-readObject.js
+++ b/__tests__/test-readObject.js
@@ -28,6 +28,7 @@ describe('readObject', () => {
     const { fs, gitdir } = await makeFixture('test-readObject')
     let error = null
     try {
+      // @ts-ignore
       await readObject({ fs, gitdir, oid, format: 'invalid' })
     } catch (err) {
       error = err

--- a/src/storage/readObject.js
+++ b/src/storage/readObject.js
@@ -21,6 +21,10 @@ export async function _readObject({
   oid,
   format = 'content',
 }) {
+  if (!['deflated', 'wrapped', 'content'].includes(format)) {
+    throw new InternalError(`invalid requested format "${format}"`)
+  }
+
   // Curry the current read method so that the packfile un-deltification
   // process can acquire external ref-deltas.
   const getExternalRefDelta = oid => _readObject({ fs, cache, gitdir, oid })
@@ -80,9 +84,5 @@ export async function _readObject({
   result.object = object
   result.format = 'content'
 
-  if (format === 'content') {
-    return result
-  }
-
-  throw new InternalError(`invalid requested format "${format}"`)
+  return result
 }


### PR DESCRIPTION
## I'm fixing a bug or typo

- [x] squash merge the PR with commit message "fix: validate readObject format consistently"

## What changed

`_readObject` now validates the requested format before choosing the loose or packed object path. Previously, an invalid format raised `InternalError` for a loose object but returned `content` for a packed object because that path returned before reaching the validation.

Valid requests are unchanged. Packed objects still return `content` as documented.

Regression coverage checks invalid formats for both loose and packed objects in the regular and submodule test suites.

Closes #1240

## Tests

```bash
node --experimental-vm-modules node_modules/jest/bin/jest.js __tests__/test-readObject.js __tests__/test-readObject-in-submodule.js --runInBand --coverage=false
npx eslint src/storage/readObject.js __tests__/test-readObject.js __tests__/test-readObject-in-submodule.js
```

Both test suites passed: 38 tests and 24 snapshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when reading objects with an unsupported format.
  * Invalid format requests now return a clear internal error instead of proceeding with an invalid value.
* **Tests**
  * Added coverage for invalid formats across both loose and packed objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->