### PR TITLE
fix: throw when TREE is given a ref that cannot be resolved

### DIFF
--- a/__tests__/test-walk.js
+++ b/__tests__/test-walk.js
@@ -11,6 +11,7 @@ import {
   commit,
   hashBlob,
   init,
+  writeRef,
 } from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
@@ -736,5 +737,35 @@ describe('walk', () => {
       map: async filepath => (filepath === '.' ? undefined : filepath),
     })
     expect(result).toEqual([])
+  })
+
+  it('throws when HEAD points to a missing non-branch ref', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-empty')
+    await init({ fs, dir, gitdir, defaultBranch: 'main' })
+    await writeRef({
+      fs,
+      dir,
+      gitdir,
+      ref: 'HEAD',
+      value: 'refs/tags/missing',
+      force: true,
+      symbolic: true,
+    })
+    // Test
+    let error = null
+    try {
+      await walk({
+        fs,
+        dir,
+        gitdir,
+        trees: [TREE({ ref: 'HEAD' })],
+        map: async filepath => filepath,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error instanceof Errors.NotFoundError).toBe(true)
   })
 })

--- a/__tests__/test-walk.js
+++ b/__tests__/test-walk.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 /* eslint-env node, browser, jasmine */
 import {
+  Errors,
   walk,
   WORKDIR,
   TREE,
@@ -9,6 +10,7 @@ import {
   add,
   commit,
   hashBlob,
+  init,
 } from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
@@ -679,5 +681,60 @@ describe('walk', () => {
       })
     ).oid
     expect(computedOid).toBe(entry.workdir.oid)
+  })
+
+  it('throws when TREE is given a ref that does not exist', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-walk')
+    // Test
+    let error = null
+    try {
+      await walk({
+        fs,
+        dir,
+        gitdir,
+        trees: [TREE({ ref: 'refs/heads/does-not-exist' })],
+        map: async filepath => filepath,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error instanceof Errors.NotFoundError).toBe(true)
+  })
+
+  it('throws when TREE is given a ref with a trailing newline', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-walk')
+    // Test
+    let error = null
+    try {
+      await walk({
+        fs,
+        dir,
+        gitdir,
+        trees: [TREE({ ref: 'master\n' })],
+        map: async filepath => filepath,
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error).not.toBeNull()
+    expect(error instanceof Errors.NotFoundError).toBe(true)
+  })
+
+  it('walks an empty tree on a branch that has no commits yet', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-empty')
+    await init({ fs, dir, gitdir, defaultBranch: 'main' })
+    // Test
+    const result = await walk({
+      fs,
+      dir,
+      gitdir,
+      trees: [TREE({ ref: 'HEAD' })],
+      map: async filepath => (filepath === '.' ? undefined : filepath),
+    })
+    expect(result).toEqual([])
   })
 })

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -367,7 +367,7 @@ export class GitRefManager {
     } catch (_) {
       return false
     }
-    if (!target.startsWith('refs/')) return false
+    if (!target.startsWith('refs/heads/')) return false
     return ref === 'HEAD' || refpaths(ref).includes(target)
   }
 

--- a/src/managers/GitRefManager.js
+++ b/src/managers/GitRefManager.js
@@ -340,6 +340,38 @@ export class GitRefManager {
   }
 
   /**
+   * Checks whether a ref names the branch HEAD points at in a repository where
+   * that branch has no commits yet.
+   *
+   * A repository created by `git init` has a HEAD pointing at a branch that
+   * does not exist on disk. Resolving that branch fails the same way resolving
+   * a misspelled ref does, so callers that want to treat the two differently
+   * need this to tell them apart.
+   *
+   * @param {Object} args
+   * @param {FSClient} args.fs - A file system implementation.
+   * @param {string} [args.gitdir=join(dir, '.git')] - [required] The [git directory](dir-vs-gitdir.md) path
+   * @param {string} args.ref - The ref to check.
+   * @returns {Promise<boolean>} - True if the ref names an unborn branch.
+   */
+  static async isUnbornBranch({ fs, gitdir, ref }) {
+    let target
+    try {
+      // depth 2 stops at the symbolic target instead of following it to an oid.
+      target = await GitRefManager.resolve({
+        fs,
+        gitdir,
+        ref: 'HEAD',
+        depth: 2,
+      })
+    } catch (_) {
+      return false
+    }
+    if (!target.startsWith('refs/')) return false
+    return ref === 'HEAD' || refpaths(ref).includes(target)
+  }
+
+  /**
    * Checks if a ref exists.
    *
    * @param {Object} args

--- a/src/models/GitWalkerRepo.js
+++ b/src/models/GitWalkerRepo.js
@@ -18,9 +18,16 @@ export class GitWalkerRepo {
       try {
         oid = await GitRefManager.resolve({ fs, gitdir, ref })
       } catch (e) {
-        if (e instanceof NotFoundError) {
-          // Handle fresh branches with no commits
+        // Only a branch that has no commits yet gets the empty tree. Anything
+        // else that fails to resolve is a ref the caller got wrong, and
+        // swallowing it here would walk an empty tree instead of saying so.
+        if (
+          e instanceof NotFoundError &&
+          (await GitRefManager.isUnbornBranch({ fs, gitdir, ref }))
+        ) {
           oid = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        } else {
+          throw e
         }
       }
       const tree = await resolveTree({ fs, cache: this.cache, gitdir, oid })


### PR DESCRIPTION
Closes #1885.

## I'm fixing a bug or typo

- [x] squash merge the PR with commit message "fix: throw when TREE is given a ref that cannot be resolved"

## The problem

`GitWalkerRepo` catches `NotFoundError` from `GitRefManager.resolve` and substitutes the empty tree oid. The comment says it is there for fresh branches with no commits, but the catch never checks for that, so any ref that fails to resolve walks an empty tree instead of reporting a problem.

On `main`, walking a repository that has `a.txt` and `b.txt` committed:

```js
await walk({ fs, dir, trees: [TREE({ ref: 'main' })], map })            // ['a.txt', 'b.txt']
await walk({ fs, dir, trees: [TREE({ ref: 'main\n' })], map })          // []
await walk({ fs, dir, trees: [TREE({ ref: 'does-not-exist' })], map })  // []
```

The trailing newline case is the one @inverted-capital reported here, and it is hard to debug because nothing goes wrong out loud.

The same catch also swallowed errors that were not `NotFoundError`, leaving `oid` undefined for `resolveTree` to trip over further down.

## What changed

`GitRefManager.isUnbornBranch` tells the two cases apart. It resolves `HEAD` with `depth: 2`, which stops at the symbolic target instead of following it to an oid, then checks whether the requested ref names that branch. A repository straight out of `git init` points HEAD at a branch that does not exist on disk yet, and that is the case the empty tree is for.

`GitWalkerRepo` now uses the empty tree only for that case and rethrows anything else.

## Behavior change

Callers that pass a ref which cannot be resolved used to get an empty walk and now get `NotFoundError`. Anything relying on the old silence will see an error where it saw an empty result. That is what this issue asks for, but it is visible from the outside, so it seemed worth stating rather than slipping in.

Walking a branch that has no commits is unchanged, and so is `statusMatrix` on a fresh repository.

## Tests

Three cases in `__tests__/test-walk.js`: a ref that does not exist, a ref with a trailing newline, and a branch with no commits that has to keep walking an empty tree. The first two fail on `main`. The third passes on `main` and is there to keep the fallback from being dropped by accident, and it does fail if `isUnbornBranch` is forced to return `false`.

Full suite on this branch: 747 passed, 7 failed. On `main`: 744 passed, 7 failed. The failing set is identical on both, and it is Windows-only symlink and file mode behavior that has nothing to do with this change. `eslint src __tests__` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository tree walking for branches with no commits.
  - Walking an unborn branch now returns an empty result.
  - Missing, invalid, or newline-terminated references now correctly report a not-found error instead of being treated as empty branches.
  - Added support for symbolic branch references when determining whether a branch is unborn.
  - Improved handling of repositories whose default branch has not received its first commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->