### PR TITLE
docs(readme): fix ES import example using unexported 'plugins'

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ import git from 'isomorphic-git'
 // or
 import * as git from 'isomorphic-git'
 // or
-import {plugins, clone, commit, push} from 'isomorphic-git'
+import {add, clone, commit, push} from 'isomorphic-git'
 ```
 
 View the full [Getting Started guide](https://isomorphic-git.github.io/docs/quickstart.html) on the docs website.


### PR DESCRIPTION
Closes #1526. The named-import example in the Getting Started section imported `plugins`, which isomorphic-git no longer exports, causing the example to fail with an import error. Replaced it with `add`, a function that is actually exported, so the example works as written.

## I'm fixing a bug or typo

- [x] this is not my first time contributing, so no README change needed
- [x] this is a docs-only change (README.md), squash merge is fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ES module usage example to demonstrate importing `add` from `isomorphic-git`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->