### PR TITLE
fix: restore checkout filepaths from the index

### DIFF
--- a/__tests__/test-checkout-in-submodule.js
+++ b/__tests__/test-checkout-in-submodule.js
@@ -11,6 +11,7 @@ import {
   getConfig,
   fetch as gitFetch,
   setConfig,
+  statusMatrix,
 } from 'isomorphic-git'
 import http from 'isomorphic-git/http'
 
@@ -467,6 +468,27 @@ describe('checkout', () => {
     }
     expect(error).toBeNull()
     expect(await fs.read(`${dir}/README.md`, 'utf8')).not.toBe('Hello world')
+  })
+
+  it('restores filepaths from the index when no ref is provided', async () => {
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-checkout')
+    await checkout({ fs, dir, gitdir, ref: 'test-branch' })
+    await fs.write(`${dir}/README.md`, 'staged content', 'utf8')
+    await add({ fs, dir, gitdir, filepath: 'README.md' })
+    await fs.write(`${dir}/README.md`, 'workdir content', 'utf8')
+
+    await checkout({
+      fs,
+      dir,
+      gitdir,
+      force: true,
+      filepaths: ['README.md'],
+    })
+
+    expect(await fs.read(`${dir}/README.md`, 'utf8')).toBe('staged content')
+    expect(
+      await statusMatrix({ fs, dir, gitdir, filepaths: ['README.md'] })
+    ).toEqual([['README.md', 1, 2, 2]])
   })
 
   it('checkout files should not delete other files', async () => {

--- a/__tests__/test-checkout-in-submodule.js
+++ b/__tests__/test-checkout-in-submodule.js
@@ -10,6 +10,7 @@ import {
   branch,
   getConfig,
   fetch as gitFetch,
+  remove,
   setConfig,
   statusMatrix,
 } from 'isomorphic-git'
@@ -489,6 +490,19 @@ describe('checkout', () => {
     expect(
       await statusMatrix({ fs, dir, gitdir, filepaths: ['README.md'] })
     ).toEqual([['README.md', 1, 2, 2]])
+  })
+
+  it('does not delete a staged-deleted filepath when restoring from the index', async () => {
+    const { fs, dir, gitdir } = await makeFixtureAsSubmodule('test-checkout')
+    const filepath = 'src/utils/exists.js'
+    await checkout({ fs, dir, gitdir, ref: 'test-branch' })
+    const contents = await fs.read(`${dir}/${filepath}`)
+    await remove({ fs, dir, gitdir, filepath })
+
+    await checkout({ fs, dir, gitdir, force: true, filepaths: [filepath] })
+
+    expect(await fs.read(`${dir}/${filepath}`)).toEqual(contents)
+    expect(await listFiles({ fs, dir, gitdir })).not.toContain(filepath)
   })
 
   it('checkout files should not delete other files', async () => {

--- a/__tests__/test-checkout.js
+++ b/__tests__/test-checkout.js
@@ -10,6 +10,7 @@ import {
   branch,
   getConfig,
   fetch as gitFetch,
+  remove,
   setConfig,
   statusMatrix,
 } from 'isomorphic-git'
@@ -481,6 +482,19 @@ describe('checkout', () => {
     expect(
       await statusMatrix({ fs, dir, gitdir, filepaths: ['README.md'] })
     ).toEqual([['README.md', 1, 2, 2]])
+  })
+
+  it('does not delete a staged-deleted filepath when restoring from the index', async () => {
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    const filepath = 'src/utils/exists.js'
+    await checkout({ fs, dir, gitdir, ref: 'test-branch' })
+    const contents = await fs.read(`${dir}/${filepath}`)
+    await remove({ fs, dir, gitdir, filepath })
+
+    await checkout({ fs, dir, gitdir, force: true, filepaths: [filepath] })
+
+    expect(await fs.read(`${dir}/${filepath}`)).toEqual(contents)
+    expect(await listFiles({ fs, dir, gitdir })).not.toContain(filepath)
   })
 
   it('checkout files should not delete other files', async () => {

--- a/__tests__/test-checkout.js
+++ b/__tests__/test-checkout.js
@@ -11,6 +11,7 @@ import {
   getConfig,
   fetch as gitFetch,
   setConfig,
+  statusMatrix,
 } from 'isomorphic-git'
 import http from 'isomorphic-git/http'
 
@@ -459,6 +460,27 @@ describe('checkout', () => {
     }
     expect(error).toBeNull()
     expect(await fs.read(`${dir}/README.md`, 'utf8')).not.toBe('Hello world')
+  })
+
+  it('restores filepaths from the index when no ref is provided', async () => {
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    await checkout({ fs, dir, gitdir, ref: 'test-branch' })
+    await fs.write(`${dir}/README.md`, 'staged content', 'utf8')
+    await add({ fs, dir, gitdir, filepath: 'README.md' })
+    await fs.write(`${dir}/README.md`, 'workdir content', 'utf8')
+
+    await checkout({
+      fs,
+      dir,
+      gitdir,
+      force: true,
+      filepaths: ['README.md'],
+    })
+
+    expect(await fs.read(`${dir}/README.md`, 'utf8')).toBe('staged content')
+    expect(
+      await statusMatrix({ fs, dir, gitdir, filepaths: ['README.md'] })
+    ).toEqual([['README.md', 1, 2, 2]])
   })
 
   it('checkout files should not delete other files', async () => {

--- a/src/api/checkout.js
+++ b/src/api/checkout.js
@@ -19,7 +19,7 @@ import { join } from '../utils/join.js'
  * @param {string} args.dir - The [working tree](dir-vs-gitdir.md) directory path
  * @param {string} [args.gitdir=join(dir,'.git')] - [required] The [git directory](dir-vs-gitdir.md) path
  * @param {string} [args.ref = 'HEAD'] - Source to checkout files from
- * @param {string[]} [args.filepaths] - Limit the checkout to the given files and directories
+ * @param {string[]} [args.filepaths] - Limit the checkout to the given files and directories. If `ref` is not provided, restore them from the index.
  * @param {string} [args.remote = 'origin'] - Which remote repository to use
  * @param {boolean} [args.noCheckout = false] - If true, will update HEAD but won't update the working directory
  * @param {boolean} [args.noUpdateHead] - If true, will update the working directory but won't update HEAD. Defaults to `false` when `ref` is provided, and `true` if `ref` is not provided.
@@ -42,7 +42,7 @@ import { join } from '../utils/join.js'
  * console.log('done')
  *
  * @example
- * // restore the 'docs' and 'src/docs' folders to the way they were, overwriting any changes
+ * // restore the 'docs' and 'src/docs' folders from the index, overwriting any unstaged changes
  * await git.checkout({
  *   fs,
  *   dir: '/tutorial',
@@ -87,6 +87,8 @@ export async function checkout({
     assertParameter('gitdir', gitdir)
 
     const ref = _ref || 'HEAD'
+    const restoreFromIndex =
+      _ref === undefined && filepaths != null && filepaths.length > 0
     const fsp = new FileSystem(fs)
     const updatedGitdir = await discoverGitdir({ fsp, dotgit: gitdir })
     return await _checkout({
@@ -104,6 +106,7 @@ export async function checkout({
       dryRun,
       force,
       track,
+      restoreFromIndex,
       nonBlocking,
       batchSize,
     })

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -34,6 +34,7 @@ import { worthWalking } from '../utils/worthWalking.js'
  * @param {boolean} [args.dryRun]
  * @param {boolean} [args.force]
  * @param {boolean} [args.track]
+ * @param {boolean} [args.restoreFromIndex]
  * @param {boolean} [args.nonBlocking]
  * @param {number} [args.batchSize]
  *
@@ -55,6 +56,7 @@ export async function _checkout({
   dryRun,
   force,
   track = true,
+  restoreFromIndex = false,
   nonBlocking = false,
   batchSize = 100,
 }) {
@@ -114,6 +116,7 @@ export async function _checkout({
         ref,
         force,
         filepaths,
+        restoreFromIndex,
       })
     } catch (err) {
       // Throw a more helpful error message for this common mistake.
@@ -406,6 +409,7 @@ async function analyze({
   ref,
   force,
   filepaths,
+  restoreFromIndex,
 }) {
   let count = 0
   return _walk({
@@ -413,7 +417,7 @@ async function analyze({
     cache,
     dir,
     gitdir,
-    trees: [TREE({ ref }), WORKDIR(), STAGE()],
+    trees: [restoreFromIndex ? STAGE() : TREE({ ref }), WORKDIR(), STAGE()],
     map: async function (fullpath, [commit, workdir, stage]) {
       if (fullpath === '.') return
       // match against base paths

--- a/src/commands/checkout.js
+++ b/src/commands/checkout.js
@@ -442,7 +442,12 @@ async function analyze({
         // Ignore workdir files that are not tracked and not part of the new commit.
         case '001':
           // OK, make an exception for explicitly named files.
-          if (force && filepaths && filepaths.includes(fullpath)) {
+          if (
+            !restoreFromIndex &&
+            force &&
+            filepaths &&
+            filepaths.includes(fullpath)
+          ) {
             return ['delete', fullpath]
           }
           return


### PR DESCRIPTION
Closes #1741.

## I'm fixing a bug or typo

- [x] squash merge the PR with commit message "fix: restore checkout filepaths from the index"

## The problem

Calling `checkout` with `filepaths` and no `ref` currently restores the selected paths from `HEAD`. If a file has staged content plus a later worktree change, this discards the worktree change and overwrites the staged version with the copy from `HEAD`.

Canonical Git restores the worktree file from the index in this case, leaving the staged change intact.

## What changed

When `filepaths` is non-empty and `ref` is omitted, checkout now uses `STAGE()` as the source tree. Calls with an explicit `ref` still restore from that ref, and checkout without `filepaths` keeps its existing behavior.

The regression tests cover both regular repositories and submodules. Each test stages one version of a file, writes a second version to the worktree, runs checkout, and verifies that the staged content is restored without changing the index state.

## Tests

- `test-checkout.js` and `test-checkout-in-submodule.js`: 42 tests and 22 snapshots passed
- `build.test`: passed
- `test.typecheck`: passed
- ESLint: passed
- `git diff --check`: passed

The full Node suite reported 1,327 passing tests, 18 skipped tests, and four file-mode failures in the walk tests. A clean checkout of the same base commit produced the same four failures because the fixtures copied from NTFS did not preserve the expected modes and symlinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File-specific checkout without a reference now restores content from the staged index as expected.
  * Forced checkouts correctly preserve the file’s staged and working-tree status.

* **Documentation**
  * Updated checkout guidance and examples to clarify index-based restoration when no reference is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->