### PR TITLE
fix: preserve fixture symlinks when core.symlinks is false

### DIFF
--- a/__tests__/__helpers__/make-symlinks-map.cjs
+++ b/__tests__/__helpers__/make-symlinks-map.cjs
@@ -19,46 +19,86 @@
 //   - make-index recorded symlinks as regular files (fixed there with lstat), and
 //   - the Fetch backend has no way to carry a symlink's target inline.
 
+const { execFileSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
 
-const root = path.join(__dirname, '..', '__fixtures__')
+/**
+ * @param {string} root
+ * @returns {Record<string, string>}
+ */
+function makeSymlinksMap(root) {
+  /** @type {Record<string, string>} posix path (rooted at '/') -> link target */
+  const map = {}
 
-/** @type {Record<string, string>} posix path (rooted at '/') -> link target */
-const map = {}
-
-/** @param {string} dir */
-function walk(dir) {
-  for (const name of fs.readdirSync(dir)) {
-    const abs = path.join(dir, name)
-    const stat = fs.lstatSync(abs)
-    if (stat.isSymbolicLink()) {
-      const rel = '/' + path.relative(root, abs).split(path.sep).join('/')
-      map[rel] = fs.readlinkSync(abs).split(path.sep).join('/')
-    } else if (stat.isDirectory()) {
-      walk(abs)
+  /** @param {string} dir */
+  function walk(dir) {
+    for (const name of fs.readdirSync(dir)) {
+      const abs = path.join(dir, name)
+      const stat = fs.lstatSync(abs)
+      if (stat.isSymbolicLink()) {
+        const rel = '/' + path.relative(root, abs).split(path.sep).join('/')
+        map[rel] = fs.readlinkSync(abs).split(path.sep).join('/')
+      } else if (stat.isDirectory()) {
+        walk(abs)
+      }
     }
   }
-}
 
-walk(root)
+  walk(root)
 
-fs.writeFileSync(path.join(root, 'symlinks.json'), JSON.stringify(map))
+  // With core.symlinks=false, Git writes a symlink's target to a regular file.
+  // Read the index to preserve those links in the browser fixture map.
+  const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: root,
+    encoding: 'utf8',
+  }).trim()
+  const fixturePath = path.relative(repoRoot, root)
+  const entries = execFileSync(
+    'git',
+    ['ls-files', '--stage', '-z', '--', fixturePath],
+    { cwd: repoRoot, encoding: 'utf8' }
+  ).split('\0')
 
-// Strip the symlink entries from index.json so the Fetch backend never tries to
-// serve (and readlink) them — they are materialized in the overlay instead.
-const indexPath = path.join(root, 'index.json')
-const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'))
-let removed = 0
-for (const linkPath of Object.keys(map)) {
-  if (linkPath in index.entries) {
-    delete index.entries[linkPath]
-    removed++
+  for (const entry of entries) {
+    const match = /^120000 [0-9a-f]+ \d+\t(.+)$/.exec(entry)
+    if (!match) continue
+
+    const abs = path.join(repoRoot, match[1])
+    const rel = '/' + path.relative(root, abs).split(path.sep).join('/')
+    if (!(rel in map)) {
+      map[rel] = fs.readFileSync(abs, 'utf8').split(path.sep).join('/')
+    }
   }
-}
-fs.writeFileSync(indexPath, JSON.stringify(index))
 
-console.log(
-  `Wrote ${Object.keys(map).length} symlink(s) to symlinks.json; ` +
-    `removed ${removed} from index.json`
-)
+  return map
+}
+
+function main() {
+  const root = path.join(__dirname, '..', '__fixtures__')
+  const map = makeSymlinksMap(root)
+
+  fs.writeFileSync(path.join(root, 'symlinks.json'), JSON.stringify(map))
+
+  // Strip the symlink entries from index.json so the Fetch backend never tries to
+  // serve (and readlink) them — they are materialized in the overlay instead.
+  const indexPath = path.join(root, 'index.json')
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'))
+  let removed = 0
+  for (const linkPath of Object.keys(map)) {
+    if (linkPath in index.entries) {
+      delete index.entries[linkPath]
+      removed++
+    }
+  }
+  fs.writeFileSync(indexPath, JSON.stringify(index))
+
+  console.log(
+    `Wrote ${Object.keys(map).length} symlink(s) to symlinks.json; ` +
+      `removed ${removed} from index.json`
+  )
+}
+
+if (require.main === module) main()
+
+module.exports = { makeSymlinksMap }

--- a/__tests__/server-only.test-make-symlinks-map.js
+++ b/__tests__/server-only.test-make-symlinks-map.js
@@ -1,0 +1,45 @@
+/* eslint-env node, browser, jasmine */
+
+import { execFileSync } from 'child_process'
+import * as fs from 'fs'
+import { createRequire } from 'module'
+import * as os from 'os'
+import * as path from 'path'
+
+const require = createRequire(import.meta.url)
+const { makeSymlinksMap } = require('./__helpers__/make-symlinks-map.cjs')
+
+describe('makeSymlinksMap', () => {
+  let dir
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reads symlinks from the index when the worktree contains a regular file', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'symlinks-map-'))
+    const fixtures = path.join(dir, 'fixtures')
+    fs.mkdirSync(fixtures)
+    fs.writeFileSync(path.join(fixtures, 'target.txt'), 'target')
+    fs.writeFileSync(path.join(fixtures, 'link.txt'), 'target.txt')
+
+    execFileSync('git', ['init', '--quiet'], { cwd: dir })
+    const oid = execFileSync('git', ['hash-object', '-w', '--stdin'], {
+      cwd: dir,
+      encoding: 'utf8',
+      input: 'target.txt',
+    }).trim()
+    execFileSync(
+      'git',
+      [
+        'update-index',
+        '--add',
+        '--cacheinfo',
+        `120000,${oid},fixtures/link.txt`,
+      ],
+      { cwd: dir }
+    )
+
+    expect(makeSymlinksMap(fixtures)).toEqual({ '/link.txt': 'target.txt' })
+  })
+})


### PR DESCRIPTION
## What changed

Git can check out tracked symlinks as regular files when `core.symlinks=false`. In that case, `make-symlinks-map.cjs` only sees a regular file and leaves the browser fixture symlink map empty. The browser then exposes mode `33188` instead of `40960` for `test-walk/folder/3.txt`.

The helper now supplements its filesystem scan with `120000` entries from the Git index. Existing filesystem symlinks remain authoritative, while regular-file checkouts use the blob contents as the link target.

The regression test creates a temporary repository with a `120000` index entry and a regular worktree file. It failed with an empty map before the fix and passes after it.

Follow-up to #2383 and [this maintainer comment](https://github.com/isomorphic-git/isomorphic-git/pull/2383#issuecomment-5270855695).

## Validation

- Targeted regression: 1 passed
- `npx nps build.indexjson`
- `npx nps lint`
- Chrome Headless on Windows: 1,297 passed, 9 skipped, 0 failed
- `git diff --check`
