### PR TITLE
fix: avoid Windows path alias mismatch in symlink map

### DIFF
--- a/__tests__/__helpers__/make-symlinks-map.cjs
+++ b/__tests__/__helpers__/make-symlinks-map.cjs
@@ -49,22 +49,17 @@ function makeSymlinksMap(root) {
 
   // With core.symlinks=false, Git writes a symlink's target to a regular file.
   // Read the index to preserve those links in the browser fixture map.
-  const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-    cwd: root,
-    encoding: 'utf8',
-  }).trim()
-  const fixturePath = path.relative(repoRoot, root)
   const entries = execFileSync(
     'git',
-    ['ls-files', '--stage', '-z', '--', fixturePath],
-    { cwd: repoRoot, encoding: 'utf8' }
+    ['ls-files', '--stage', '-z', '--', '.'],
+    { cwd: root, encoding: 'utf8' }
   ).split('\0')
 
   for (const entry of entries) {
     const match = /^120000 [0-9a-f]+ \d+\t(.+)$/.exec(entry)
     if (!match) continue
 
-    const abs = path.join(repoRoot, match[1])
+    const abs = path.join(root, match[1])
     const rel = '/' + path.relative(root, abs).split(path.sep).join('/')
     if (!(rel in map)) {
       map[rel] = fs.readFileSync(abs, 'utf8').split(path.sep).join('/')


### PR DESCRIPTION
## Summary

Run `git ls-files` from the fixture root so Git returns paths relative to the same directory used by Node.

## Why

The regression test added in #2410 fails on the GitHub Windows runner. Git reports the temporary profile through its short `RUNNER~1` alias, while Node keeps the `runneradmin` path. Calling `path.relative()` across those two forms produces a pathspec outside the repository, which `git ls-files` rejects.

Running the command from the fixture root avoids that path conversion and keeps the map entries relative to `root` on every platform.

## Validation

- `server-only.test-make-symlinks-map.js`: 1 passed
- `nps build.indexjson`: preserved the symlink map and removed its fetch-index entry
- ESLint passed for the helper and regression test
- `git diff --check` passed
- The full Node suite passed 185 of 191 suites and 1,313 of 1,345 tests locally. The remaining 14 failures require Windows symlink privileges and reproduced unchanged on the clean `karma-matrix` head.

Follow-up to #2410. This fixes the Windows failure currently reported on #2383.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink discovery for fixture-based workflows.
  * Ensured symlink paths are resolved correctly relative to the fixture root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->