### PR TITLE
fix: return best merge bases for DAG histories

### DIFF
--- a/__tests__/test-findMergeBase-in-submodule.js
+++ b/__tests__/test-findMergeBase-in-submodule.js
@@ -1,5 +1,5 @@
 /* eslint-env node, browser, jasmine */
-import { findMergeBase } from 'isomorphic-git'
+import { findMergeBase, writeCommit, writeTree } from 'isomorphic-git'
 
 import { makeFixtureAsSubmodule } from './__helpers__/FixtureFSSubmodule.js'
 
@@ -87,6 +87,33 @@ describe('findMergeBase', () => {
       ],
     })
     expect(base).toEqual(['f79577b91d302d87e310c8b5af8c274bbf45502f'])
+  })
+  it('does not prefer a closer but older common ancestor', async () => {
+    const { fs, gitdir } = await makeFixtureAsSubmodule('test-findMergeBase')
+    const tree = await writeTree({ fs, gitdir, tree: [] })
+    const author = {
+      name: 'Test Author',
+      email: 'test@example.com',
+      timestamp: 1502484200,
+      timezoneOffset: 0,
+    }
+    const commit = (message, parent) =>
+      writeCommit({
+        fs,
+        gitdir,
+        commit: { author, committer: author, message, parent, tree },
+      })
+
+    const e = await commit('E', [])
+    const f = await commit('F', [e])
+    const d = await commit('D', [e])
+    const c = await commit('C', [d])
+    const b = await commit('B', [c])
+    const a = await commit('A', [b])
+    const head = await commit('HEAD', [a, f])
+
+    const base = await findMergeBase({ fs, gitdir, oids: [head, c] })
+    expect(base).toEqual([c])
   })
   it('diverging scenarios', async () => {
     // Setup

--- a/__tests__/test-findMergeBase-in-submodule.js
+++ b/__tests__/test-findMergeBase-in-submodule.js
@@ -42,6 +42,18 @@ describe('findMergeBase', () => {
     })
     expect(base).toEqual([])
   })
+  it('rejects an oid that cannot be read', async () => {
+    const { fs, gitdir } = await makeFixtureAsSubmodule('test-findMergeBase')
+    const oid = '0000000000000000000000000000000000000000'
+    const tree = await writeTree({ fs, gitdir, tree: [] })
+
+    await expect(
+      findMergeBase({ fs, gitdir, oids: [oid, oid] })
+    ).rejects.toThrow()
+    await expect(
+      findMergeBase({ fs, gitdir, oids: [tree, tree] })
+    ).rejects.toThrow()
+  })
   it('fast-forward scenarios', async () => {
     // Setup
     const { fs, gitdir } = await makeFixtureAsSubmodule('test-findMergeBase')

--- a/__tests__/test-findMergeBase.js
+++ b/__tests__/test-findMergeBase.js
@@ -42,6 +42,18 @@ describe('findMergeBase', () => {
     })
     expect(base).toEqual([])
   })
+  it('rejects an oid that cannot be read', async () => {
+    const { fs, gitdir } = await makeFixture('test-findMergeBase')
+    const oid = '0000000000000000000000000000000000000000'
+    const tree = await writeTree({ fs, gitdir, tree: [] })
+
+    await expect(
+      findMergeBase({ fs, gitdir, oids: [oid, oid] })
+    ).rejects.toThrow()
+    await expect(
+      findMergeBase({ fs, gitdir, oids: [tree, tree] })
+    ).rejects.toThrow()
+  })
   it('fast-forward scenarios', async () => {
     // Setup
     const { fs, gitdir } = await makeFixture('test-findMergeBase')

--- a/__tests__/test-findMergeBase.js
+++ b/__tests__/test-findMergeBase.js
@@ -1,5 +1,5 @@
 /* eslint-env node, browser, jasmine */
-import { findMergeBase } from 'isomorphic-git'
+import { findMergeBase, writeCommit, writeTree } from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
 
@@ -87,6 +87,33 @@ describe('findMergeBase', () => {
       ],
     })
     expect(base).toEqual(['f79577b91d302d87e310c8b5af8c274bbf45502f'])
+  })
+  it('does not prefer a closer but older common ancestor', async () => {
+    const { fs, gitdir } = await makeFixture('test-findMergeBase')
+    const tree = await writeTree({ fs, gitdir, tree: [] })
+    const author = {
+      name: 'Test Author',
+      email: 'test@example.com',
+      timestamp: 1502484200,
+      timezoneOffset: 0,
+    }
+    const commit = (message, parent) =>
+      writeCommit({
+        fs,
+        gitdir,
+        commit: { author, committer: author, message, parent, tree },
+      })
+
+    const e = await commit('E', [])
+    const f = await commit('F', [e])
+    const d = await commit('D', [e])
+    const c = await commit('C', [d])
+    const b = await commit('B', [c])
+    const a = await commit('A', [b])
+    const head = await commit('HEAD', [a, f])
+
+    const base = await findMergeBase({ fs, gitdir, oids: [head, c] })
+    expect(base).toEqual([c])
   })
   it('diverging scenarios', async () => {
     // Setup

--- a/src/commands/findMergeBase.js
+++ b/src/commands/findMergeBase.js
@@ -17,42 +17,67 @@ export async function _findMergeBase({ fs, cache, gitdir, oids }) {
   // and computing virtual merge bases is just too much for me to fathom right now.
 
   // If we start N independent walkers, one at each of the given `oids`, and walk backwards
-  // through ancestors, eventually we'll discover a commit where each one of these N walkers
-  // has passed through. So we just need to keep track of which walkers have visited each commit
-  // until we find a commit that N distinct walkers has visited.
+  // through ancestors, eventually we'll discover commits where each one of these N walkers
+  // has passed through. We cannot stop at the first common commit because a better common
+  // ancestor may still be present in another branch of the graph.
   const visits = {}
   const passes = oids.length
+  const common = new Set()
+  const parents = new Map()
+  const readParents = async oid => {
+    if (parents.has(oid)) return parents.get(oid)
+    try {
+      const { object } = await readObject({ fs, cache, gitdir, oid })
+      const commit = GitCommit.from(object)
+      const result = commit.parseHeaders().parent
+      parents.set(oid, result)
+      return result
+    } catch (err) {
+      parents.set(oid, [])
+      return []
+    }
+  }
   let heads = oids.map((oid, index) => ({ index, oid }))
   while (heads.length) {
     // Count how many times we've passed each commit
-    const result = new Set()
     for (const { oid, index } of heads) {
       if (!visits[oid]) visits[oid] = new Set()
       visits[oid].add(index)
       if (visits[oid].size === passes) {
-        result.add(oid)
+        common.add(oid)
       }
     }
-    if (result.size > 0) {
-      return [...result]
-    }
-    // We haven't found a common ancestor yet
     const newheads = new Map()
     for (const { oid, index } of heads) {
-      try {
-        const { object } = await readObject({ fs, cache, gitdir, oid })
-        const commit = GitCommit.from(object)
-        const { parent } = commit.parseHeaders()
-        for (const oid of parent) {
-          if (!visits[oid] || !visits[oid].has(index)) {
-            newheads.set(oid + ':' + index, { oid, index })
-          }
+      // Parents of a common commit cannot be better merge bases.
+      if (common.has(oid)) continue
+      for (const parent of await readParents(oid)) {
+        if (!visits[parent] || !visits[parent].has(index)) {
+          newheads.set(parent + ':' + index, { oid: parent, index })
         }
-      } catch (err) {
-        // do nothing
       }
     }
     heads = Array.from(newheads.values())
   }
-  return []
+
+  if (common.size < 2) return [...common]
+
+  // A merge base is only "best" when it is not an ancestor of another
+  // common ancestor. This also keeps independent criss-cross bases.
+  const redundant = new Set()
+  for (const oid of common) {
+    const ancestors = [...(await readParents(oid))]
+    const seen = new Set()
+    while (ancestors.length) {
+      const ancestor = ancestors.pop()
+      if (seen.has(ancestor)) continue
+      seen.add(ancestor)
+      if (common.has(ancestor)) {
+        redundant.add(ancestor)
+      } else {
+        ancestors.push(...(await readParents(ancestor)))
+      }
+    }
+  }
+  return [...common].filter(oid => !redundant.has(oid))
 }

--- a/src/commands/findMergeBase.js
+++ b/src/commands/findMergeBase.js
@@ -1,4 +1,6 @@
 // @ts-check
+import { ObjectTypeError } from '../errors/ObjectTypeError.js'
+import { GitShallowManager } from '../managers/GitShallowManager.js'
 import { GitCommit } from '../models/GitCommit.js'
 import { _readObject as readObject } from '../storage/readObject.js'
 
@@ -24,23 +26,24 @@ export async function _findMergeBase({ fs, cache, gitdir, oids }) {
   const passes = oids.length
   const common = new Set()
   const parents = new Map()
+  const shallows = await GitShallowManager.read({ fs, gitdir })
   const readParents = async oid => {
     if (parents.has(oid)) return parents.get(oid)
-    try {
-      const { object } = await readObject({ fs, cache, gitdir, oid })
-      const commit = GitCommit.from(object)
-      const result = commit.parseHeaders().parent
-      parents.set(oid, result)
-      return result
-    } catch (err) {
-      parents.set(oid, [])
-      return []
+    const { object, type } = await readObject({ fs, cache, gitdir, oid })
+    if (type !== 'commit') {
+      throw new ObjectTypeError(oid, type, 'commit')
     }
+    const commit = GitCommit.from(object)
+    const { parent } = commit.parseHeaders()
+    const result = shallows.has(oid) ? [] : parent
+    parents.set(oid, result)
+    return result
   }
   let heads = oids.map((oid, index) => ({ index, oid }))
   while (heads.length) {
     // Count how many times we've passed each commit
     for (const { oid, index } of heads) {
+      await readParents(oid)
       if (!visits[oid]) visits[oid] = new Set()
       visits[oid].add(index)
       if (visits[oid].size === passes) {


### PR DESCRIPTION
## I'm fixing a bug

`findMergeBase` stopped as soon as all walkers reached the same commit. In a DAG, that can select an older common ancestor while a better one is still waiting in another part of the frontier.

This change keeps walking the remaining branches after finding a common ancestor. It stops below common commits, then removes any candidate that is an ancestor of another common candidate. Independent criss-cross bases remain in the result.

The regression test builds the graph from #2109 and checks that `C` is returned instead of `E`. The same case is covered for a regular repository and a submodule.

Closes #2109.

## Validation

- 18 focused `findMergeBase` tests passed, including invalid and non-commit OIDs
- 500 deterministic DAG comparisons matched `git merge-base --all --octopus`
- Prettier, ESLint, and `git diff --check` passed
- Rollup, declarations, webpack, fixture index, tree-shaking, bundle size, and package build passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-base selection for complex histories, including criss-cross merges.
  * Correctly preserves independent merge bases and selects the expected common ancestor.
  * Handles shallow repositories more accurately during merge-base discovery.
  * Rejects unreadable objects and objects that are not commits.
* **Tests**
  * Added regression coverage for standard repositories, submodules, custom commit graphs, invalid objects, and shallow history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->