### PR TITLE
fix: include file mode changes in filepath log

### DIFF
--- a/__tests__/test-log-in-submodule.js
+++ b/__tests__/test-log-in-submodule.js
@@ -1,10 +1,77 @@
 /* eslint-env node, browser, jasmine */
 import { pgp } from '@isomorphic-git/pgp-plugin'
-import { log } from 'isomorphic-git'
+import {
+  log,
+  writeBlob,
+  writeCommit,
+  writeRef,
+  writeTree,
+} from 'isomorphic-git'
 
 import { makeFixtureAsSubmodule } from './__helpers__/FixtureFSSubmodule.js'
 
 describe('log', () => {
+  it('includes commits that only change a file mode', async () => {
+    const { fs, dir } = await makeFixtureAsSubmodule('test-init')
+    const author = {
+      name: 'Mr. Test',
+      email: 'mrtest@example.com',
+      timestamp: 1262356920,
+      timezoneOffset: 0,
+    }
+    const oid = await writeBlob({
+      fs,
+      dir,
+      blob: Buffer.from('#!/bin/sh\n'),
+    })
+    const regularTree = await writeTree({
+      fs,
+      dir,
+      tree: [{ mode: '100644', path: 'script.sh', oid, type: 'blob' }],
+    })
+    const regularCommit = await writeCommit({
+      fs,
+      dir,
+      commit: {
+        message: 'Add script\n',
+        tree: regularTree,
+        parent: [],
+        author,
+        committer: author,
+      },
+    })
+    const executableTree = await writeTree({
+      fs,
+      dir,
+      tree: [{ mode: '100755', path: 'script.sh', oid, type: 'blob' }],
+    })
+    const executableCommit = await writeCommit({
+      fs,
+      dir,
+      commit: {
+        message: 'Make script executable\n',
+        tree: executableTree,
+        parent: [regularCommit],
+        author,
+        committer: author,
+      },
+    })
+    await writeRef({
+      fs,
+      dir,
+      ref: 'refs/heads/main',
+      value: executableCommit,
+      force: true,
+    })
+
+    const commits = await log({ fs, dir, ref: 'main', filepath: 'script.sh' })
+
+    expect(commits.map(({ commit }) => commit.message.trim())).toEqual([
+      'Make script executable',
+      'Add script',
+    ])
+  })
+
   it('HEAD', async () => {
     const { fs, gitdir } = await makeFixtureAsSubmodule('test-log')
     const commits = await log({ fs, gitdir, ref: 'HEAD' })

--- a/__tests__/test-log.js
+++ b/__tests__/test-log.js
@@ -10,11 +10,76 @@ import {
   log,
   remove,
   resolveRef,
+  writeBlob,
+  writeCommit,
+  writeRef,
+  writeTree,
 } from 'isomorphic-git'
 
 import { makeFixture } from './__helpers__/FixtureFS.js'
 
 describe('log', () => {
+  it('includes commits that only change a file mode', async () => {
+    const { fs, dir } = await makeFixture('test-init')
+    const author = {
+      name: 'Mr. Test',
+      email: 'mrtest@example.com',
+      timestamp: 1262356920,
+      timezoneOffset: 0,
+    }
+    const oid = await writeBlob({
+      fs,
+      dir,
+      blob: Buffer.from('#!/bin/sh\n'),
+    })
+    const regularTree = await writeTree({
+      fs,
+      dir,
+      tree: [{ mode: '100644', path: 'script.sh', oid, type: 'blob' }],
+    })
+    const regularCommit = await writeCommit({
+      fs,
+      dir,
+      commit: {
+        message: 'Add script\n',
+        tree: regularTree,
+        parent: [],
+        author,
+        committer: author,
+      },
+    })
+    const executableTree = await writeTree({
+      fs,
+      dir,
+      tree: [{ mode: '100755', path: 'script.sh', oid, type: 'blob' }],
+    })
+    const executableCommit = await writeCommit({
+      fs,
+      dir,
+      commit: {
+        message: 'Make script executable\n',
+        tree: executableTree,
+        parent: [regularCommit],
+        author,
+        committer: author,
+      },
+    })
+    await writeRef({
+      fs,
+      dir,
+      ref: 'refs/heads/main',
+      value: executableCommit,
+      force: true,
+    })
+
+    const commits = await log({ fs, dir, ref: 'main', filepath: 'script.sh' })
+
+    expect(commits.map(({ commit }) => commit.message.trim())).toEqual([
+      'Make script executable',
+      'Add script',
+    ])
+  })
+
   it('includes changed file object ids when includeChanges is true', async () => {
     const { fs, dir } = await makeFixture('test-init')
     const author = {

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -9,7 +9,7 @@ import { GitRefManager } from '../managers/GitRefManager.js'
 import { GitShallowManager } from '../managers/GitShallowManager.js'
 import { compareAge } from '../utils/compareAge.js'
 import { resolveFileIdInTree } from '../utils/resolveFileIdInTree.js'
-import { resolveFilepath } from '../utils/resolveFilepath.js'
+import { resolveFilepathEntry } from '../utils/resolveFilepath.js'
 
 /**
  * Get commit descriptions from the git history
@@ -57,6 +57,7 @@ export async function _log({
   const oid = await GitRefManager.resolve({ fs, gitdir, ref })
   const tips = [await _readCommit({ fs, cache, gitdir, oid })]
   let lastFileOid
+  let lastFileMode
   let lastCommit
   let isOk
 
@@ -76,19 +77,23 @@ export async function _log({
     }
 
     if (filepath) {
-      let vFileOid
+      let vFileEntry
       try {
-        vFileOid = await resolveFilepath({
+        vFileEntry = await resolveFilepathEntry({
           fs,
           cache,
           gitdir,
           oid: commit.commit.tree,
           filepath,
         })
-        if (lastCommit && lastFileOid !== vFileOid) {
+        if (
+          lastCommit &&
+          (lastFileOid !== vFileEntry.oid || lastFileMode !== vFileEntry.mode)
+        ) {
           commits.push(lastCommit)
         }
-        lastFileOid = vFileOid
+        lastFileOid = vFileEntry.oid
+        lastFileMode = vFileEntry.mode
         lastCommit = commit
         isOk = true
       } catch (e) {

--- a/src/utils/resolveFilepath.js
+++ b/src/utils/resolveFilepath.js
@@ -7,6 +7,23 @@ import { _readObject as readObject } from '../storage/readObject.js'
 import { resolveTree } from '../utils/resolveTree.js'
 
 export async function resolveFilepath({ fs, cache, gitdir, oid, filepath }) {
+  const entry = await resolveFilepathEntry({
+    fs,
+    cache,
+    gitdir,
+    oid,
+    filepath,
+  })
+  return entry.oid
+}
+
+export async function resolveFilepathEntry({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  filepath,
+}) {
   // Ensure there are no leading or trailing directory separators.
   // I was going to do this automatically, but then found that the Git Terminal for Windows
   // auto-expands --filepath=/src/utils to --filepath=C:/Users/Will/AppData/Local/Programs/Git/src/utils
@@ -20,10 +37,10 @@ export async function resolveFilepath({ fs, cache, gitdir, oid, filepath }) {
   const result = await resolveTree({ fs, cache, gitdir, oid })
   const tree = result.tree
   if (filepath === '') {
-    oid = result.oid
+    return { mode: '040000', oid: result.oid, path: '', type: 'tree' }
   } else {
     const pathArray = filepath.split('/')
-    oid = await _resolveFilepath({
+    return _resolveFilepath({
       fs,
       cache,
       gitdir,
@@ -33,7 +50,6 @@ export async function resolveFilepath({ fs, cache, gitdir, oid, filepath }) {
       filepath,
     })
   }
-  return oid
 }
 
 async function _resolveFilepath({
@@ -49,7 +65,7 @@ async function _resolveFilepath({
   for (const entry of tree) {
     if (entry.path === name) {
       if (pathArray.length === 0) {
-        return entry.oid
+        return entry
       } else {
         const { type, object } = await readObject({
           fs,


### PR DESCRIPTION
## I'm fixing a bug or typo

When `log` filters by `filepath`, it currently compares only the blob OID between adjacent commits. A commit that changes the file mode without changing its contents therefore gets filtered out.

This change keeps the blob OID available for rename tracking and compares the tree entry mode separately. It also adds the same regression coverage for regular repositories and submodules.

Closes #1957

## Testing

- `test-log.js` and `test-log-in-submodule.js`: 17 tests passed
- ESLint passed for the four changed files
- `git diff --check` passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed file-specific logs so they include commits where a file’s executable status or other file mode changes, even when its contents remain unchanged.
  - Preserved correct reverse chronological ordering for these commits.
  - Improved handling of root paths and file entries during log filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->