### PR TITLE
fix: match filepaths on path component boundaries

### DIFF
--- a/__tests__/test-checkout.js
+++ b/__tests__/test-checkout.js
@@ -348,6 +348,22 @@ describe('checkout', () => {
     `)
   })
 
+  it('checkout filepaths stop at a path component boundary', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-checkout')
+    // 'src/model' is not a path in the tree. 'src/models' is, and it must not
+    // be dragged in just because its name starts the same way.
+    await checkout({
+      fs,
+      dir,
+      gitdir,
+      ref: 'test-branch',
+      filepaths: ['src/model'],
+    })
+    const index = await listFiles({ fs, dir, gitdir })
+    expect(index).toEqual([])
+  })
+
   it('checkout files using filepaths', async () => {
     // Setup
     const { fs, dir, gitdir } = await makeFixture('test-checkout')

--- a/__tests__/test-statusMatrix.js
+++ b/__tests__/test-statusMatrix.js
@@ -312,6 +312,22 @@ describe('statusMatrix', () => {
     ])
   })
 
+  it('statusMatrix with a trailing slash on the filepath', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-statusMatrix-filepath')
+
+    // Test
+    expect(await statusMatrix({ fs, dir, gitdir, filepaths: ['i/'] })).toEqual([
+      ['i/.gitignore', 0, 2, 0],
+      ['i/i.txt', 0, 2, 0],
+    ])
+
+    // './' names the repository root, the same as '.'
+    expect(await statusMatrix({ fs, dir, gitdir, filepaths: ['./'] })).toEqual(
+      await statusMatrix({ fs, dir, gitdir, filepaths: ['.'] })
+    )
+  })
+
   it('statusMatrix with filter', async () => {
     // Setup
     const { fs, dir, gitdir } = await makeFixture('test-statusMatrix-filepath')

--- a/__tests__/test-statusMatrix.js
+++ b/__tests__/test-statusMatrix.js
@@ -295,6 +295,23 @@ describe('statusMatrix', () => {
     ])
   })
 
+  it('statusMatrix with filepaths stops at a path component boundary', async () => {
+    // Setup
+    const { fs, dir, gitdir } = await makeFixture('test-statusMatrix-filepath')
+    // Siblings whose names start with the requested path, but which are
+    // neither the path itself nor anything under it.
+    await fs.write(path.join(dir, 'index.js'), 'sibling file')
+    await fs.mkdir(path.join(dir, 'i2'))
+    await fs.write(path.join(dir, 'i2', 'i2.txt'), 'sibling directory')
+
+    // Test
+    const matrix = await statusMatrix({ fs, dir, gitdir, filepaths: ['i'] })
+    expect(matrix).toEqual([
+      ['i/.gitignore', 0, 2, 0],
+      ['i/i.txt', 0, 2, 0],
+    ])
+  })
+
   it('statusMatrix with filter', async () => {
     // Setup
     const { fs, dir, gitdir } = await makeFixture('test-statusMatrix-filepath')

--- a/src/utils/worthWalking.js
+++ b/src/utils/worthWalking.js
@@ -5,6 +5,9 @@ export const worthWalking = (filepath, root) => {
   // A shared prefix only counts when it lands on a path component boundary,
   // otherwise the root 'src' would also pull in 'src2/a.js' and 'srcfoo.txt'.
   const base = root.endsWith('/') ? root.slice(0, -1) : root
+  if (base === '.') {
+    return true
+  }
   if (base.length >= filepath.length) {
     // Keep walking while filepath is still an ancestor of the wanted root.
     return base === filepath || base.startsWith(`${filepath}/`)

--- a/src/utils/worthWalking.js
+++ b/src/utils/worthWalking.js
@@ -2,9 +2,12 @@ export const worthWalking = (filepath, root) => {
   if (filepath === '.' || root == null || root.length === 0 || root === '.') {
     return true
   }
-  if (root.length >= filepath.length) {
-    return root.startsWith(filepath)
-  } else {
-    return filepath.startsWith(root)
+  // A shared prefix only counts when it lands on a path component boundary,
+  // otherwise the root 'src' would also pull in 'src2/a.js' and 'srcfoo.txt'.
+  const base = root.endsWith('/') ? root.slice(0, -1) : root
+  if (base.length >= filepath.length) {
+    // Keep walking while filepath is still an ancestor of the wanted root.
+    return base === filepath || base.startsWith(`${filepath}/`)
   }
+  return filepath.startsWith(`${base}/`)
 }


### PR DESCRIPTION
`filepaths` matches on a raw string prefix, so a path also selects its siblings whose names happen to start the same way.

```js
// repo containing i/i.txt, index.js and i2/i2.txt
await git.statusMatrix({ fs, dir, filepaths: ['i'] })
// [['i/.gitignore', 0, 2, 0], ['i/i.txt', 0, 2, 0], ['i2/i2.txt', 0, 2, 0], ['index.js', 0, 2, 0]]
```

`git status -- i` reports only what is under `i`. `worthWalking` returns true for `('index.js', 'i')`, `('src2/a.js', 'src')`, `('srcfoo.txt', 'src')` and `('a/bc', 'a/b')`.

The same filter drives `checkout`, and there it writes files:

```js
// test-checkout fixture, on test-branch. 'src/model' is not a path in the tree.
await git.checkout({ fs, dir, gitdir, ref: 'test-branch', filepaths: ['src/model'] })
await git.listFiles({ fs, dir, gitdir })
// ['src/models/GitBlob.js', 'src/models/GitCommit.js', 'src/models/GitConfig.js', 'src/models/GitTree.js']
```

A caller who asks for `docs` gets `docs2/` and `docs-old/` overwritten from the ref as well, and any uncommitted edits in those files are gone. Nothing warns, because the caller did name a path, just not those.

`src/utils/worthWalking.js` compares with `startsWith` and never checks for the `/` that ends a path component:

```js
if (root.length >= filepath.length) {
  return root.startsWith(filepath)
} else {
  return filepath.startsWith(root)
}
```

Requiring the separator is enough. Both directions still need to hold, because the walk has to descend through the ancestors of the wanted path before it reaches it: `a` and `a/b` are both worth walking when the root is `a/b/c`.

I kept a trailing slash working. `filepaths: ['src/']` matches today and would have stopped matching, and since nothing in the API normalises the input that looked like a regression waiting to happen rather than part of the fix.

Two tests, one per call site. The `statusMatrix` one adds a sibling file and a sibling directory to the existing fixture at runtime; the `checkout` one asks for a path that does not exist and expects nothing to be written. Both fail on main.

On the six suites that touch this code (`checkout`, `statusMatrix`, `status`, `add`, `walk`, `isIgnored`) the run goes from 10 failures to 8: the two new tests start passing and nothing else moves. The 8 that stay are three `checkout` cases that want the git http mock server on 127.0.0.1:9999 and five `walk` cases about symlinks and autocrlf, all of which fail the same way on a clean main here. `eslint` and `prettier --check` are clean on the touched files.

The whole suite is noisy on this machine, several hundred failures on a clean checkout too, so I did not lean on it. For what it is worth the failure list has no entry that is not already there on main.

---

Second commit: `filepaths: ['./']` was coming back empty. Stripping the trailing slash turns `'./'` into `'.'`, which then fell through to the prefix comparison instead of being treated as the repository root. `main` does the same thing, so it is not a regression from the first commit, but the trailing slash handling I added here is what makes it worth closing. One line, plus a test that `['./']` and `['.']` agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected file path matching so similarly prefixed paths are no longer included incorrectly.
  - Checkout and status operations now respect path-component boundaries, preventing matches such as `src/model` from affecting `src/models`.
  - Improved handling of paths with trailing slashes and equivalent root paths while preserving ancestor and descendant matching behavior.

- **Tests**
  - Added regression coverage for checkout and status path filtering, including boundary cases and trailing-slash paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->